### PR TITLE
Global def MAX_PILL_SPRITE

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -374,3 +374,7 @@
 
 //Melting Temperatures for various specific objects
 #define GIRDER_MELTING_TEMP 5000
+
+
+
+#define MAX_PILL_SPRITE 20 //max icon state of the pill sprites

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -299,7 +299,7 @@ proc/getFilesSlow(var/client/client, var/list/files, var/register_asset = TRUE)
 	var/verify = FALSE
 
 /datum/asset/chem_master/register()
-	for(var/i = 1 to 20)
+	for(var/i = 1 to MAX_PILL_SPRITE)
 		assets["pill[i].png"] = icon('icons/obj/chemical.dmi', "pill[i]")
 	for(var/i in list("bottle", "small_bottle", "wide_bottle", "round_bottle"))
 		assets["[i].png"] = icon('icons/obj/chemical.dmi', "[i]")

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -272,7 +272,6 @@
 				var/obj/item/reagent_containers/food/condiment/P = new/obj/item/reagent_containers/food/condiment(loc)
 				reagents.trans_to(P,50)
 		else if(href_list["change_pill"])
-			#define MAX_PILL_SPRITE 20 //max icon state of the pill sprites
 			var/dat = "<table>"
 			var/j = 0
 			for(var/i = 1 to MAX_PILL_SPRITE)


### PR DESCRIPTION
Moví la variable MAX_PILL_SPRITE a la carpeta code/__DEFINES/.. para volverlo una variable global y poder utilizarlo en asset_cache.dm y chem_master.dm.

Este cambio lo hice luego de que Jaunt al intentar poner píldoras nuevas pero no se mostraran en el chem dispenser, luego de días me encontré de casualidad el archivo asset_cache.dm que crea una imagen .png de la píldora.

Para hacer funcionar todo, hacen uso de loops for con el valor máximo de las píldoras, me parecía estúpido tener que declarar y cambiar su valor en la carpeta asset_cache pudiendo crear una variable global y no tener que modificar nada mas que su valor.