### PR TITLE
Buffea partes roboticas y a los IPCs.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,8 +15,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
-	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
+	brute_mod = 1.95 // 100% * 2.28 * 0.66 (robolimbs) ~= 150% ///Raze nerf:  100% * 1.95 * 0.59 = 116%///
+	burn_mod = 1.95  // So they take 50% extra damage from brute/burn overall /// Raze nerf: toman un 38% mas de dmg bruto/quemado
 	tox_mod = 0
 	clone_mod = 0
 	oxy_mod = 0

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -635,8 +635,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	..()
 	//robot limbs take reduced damage
 	if(!make_tough)
-		brute_mod = 0.66
-		burn_mod = 0.66
+		brute_mod = 0.59 ///antes estaba a 0.66
+		burn_mod = 0.59
 		dismember_at_max_damage = TRUE
 	else
 		tough = TRUE


### PR DESCRIPTION
Los IPC's su multiplicador de golpes antes  era del 100% * 2.28 * 0.66 = 150% dividido a 3 ... obviamente da 50% (quemaduras/golpes brutos/partes del cuerpo)

Ahora  con el buffeo 100% * 1.95 * 0.59 = 116% dividido a 3
Que es 38% en general (quemaduras/golpes brutos/partes del cuerpo)
-----------------------------------------

Ahora con las partes del cuerpo roboticas que su dmg anterior estaba al 0.66 se le arreglo para que fuera a 0.59 lo que los hace un poquito mas recistentes a un emp.



