### PR TITLE
Hot drinks machine nerf - ready si es aprobado

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -226,7 +226,7 @@
 	desc = "Made in Space South America."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("hot_coco" = 30, "sugar" = 5)
+	list_reagents = list("hot_coco" = 30)
 
 /obj/item/reagent_containers/food/drinks/chocolate
 	name = "hot chocolate"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -257,7 +257,7 @@
 	name = "Hot Chocolate"
 	id = "hot_coco"
 	description = "Made with love! And coco beans."
-	nutriment_factor = 1 * REAGENTS_METABOLISM
+	nutriment_factor = 0
 	color = "#403010" // rgb: 64, 48, 16
 	adj_temp_hot = 5
 	drink_icon = "hot_coco"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -257,7 +257,7 @@
 	name = "Hot Chocolate"
 	id = "hot_coco"
 	description = "Made with love! And coco beans."
-	nutriment_factor = 0
+	nutriment_factor = 0.1 * REAGENTS_METABOLISM
 	color = "#403010" // rgb: 64, 48, 16
 	adj_temp_hot = 5
 	drink_icon = "hot_coco"

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -257,7 +257,7 @@
 	name = "Hot Chocolate"
 	id = "hot_coco"
 	description = "Made with love! And coco beans."
-	nutriment_factor = 0.1 * REAGENTS_METABOLISM
+	nutriment_factor = 0
 	color = "#403010" // rgb: 64, 48, 16
 	adj_temp_hot = 5
 	drink_icon = "hot_coco"

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -584,6 +584,10 @@
 	nutriment_factor = 2
 	taste_message = "broth"
 
+/datum/reagent/consumable/chicken_soup/on_mob_life(mob/living/M)
+	if(prob(15))
+		M.reagents.add_reagent("cholesterol", rand(1,3))
+
 /datum/reagent/consumable/cheese
 	name = "Cheese"
 	id = "cheese"


### PR DESCRIPTION
Hablemos un poco de la historia del hot chocolate. 
El hot chocolate fue introducido como un trago navideño en SS13 como situacion especial para juntarse alrededor del arbol y tomar unos ricos chocolates con guantes y bufanda.
Mas tarde fue agregado a las maquinas expendedoras volviendolo de facil acceso en toda la estacion.

El hot chocolate se volvio una cosa de todos los dias. Se siente realmente como si estuvieras cheteando el sistema de nutricion. O eligiendo optar por no jugar con la mecanica de alimentos.

Esto ademas de quitarle funcionalidad al chef, disminuye las posibilidades de rolear, de ir al bar a comer algo. De pedir pizzas a cargo (no tienen sentido) Y incluso de tripulantes que quieran hacer meta y no consuman nada de toda la estacion a menos que sea de una maquina expendedora por peligro a que los envenenen.

Mi idea es que si quieres algo de las maquinas expendedoras que te de nutricion tiene que tener un efecto negativo como lo hacen todas las demas comidas chatarras. O almenos te implique hackearla. El hot chocolate ya fue nerfeado por Rafa antes pero es un nerf que no cambia demasiado la situacion. Te tomas 4 sorbos en ves de 2 y problema solucionado.

Ademas aumenta la brecha entre los que conocen este overpowered drink y los novatos que siguen pidiendo cajas de pizza o pasan hambre por no conocerlo.

![daaaSin título](https://user-images.githubusercontent.com/24284918/56082645-992ee680-5df1-11e9-9797-1c681bf6cc1b.png)
Empezar a usar las maquinas de comidas para saciar el hambre que para eso están. Y dejar de usar las maquinas de bebidas únicamente

:cl:
balance: el hot chocolate ya no alimenta, el chicken soup puede dar colesterol 
/:cl:


