### PR TITLE
make shields great again

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -5,7 +5,7 @@
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
-		final_block_chance += 30
+		final_block_chance += 33
 	if(attack_type == LEAP_ATTACK)
 		final_block_chance = 100
 	return ..()


### PR DESCRIPTION
**What does this PR do:**
Los escudos son aparatosos, poca gente los usa o recuerda que estan ahi. Darle un poco de poder ayudara a que la gente los use un poco más y hara que se note un poco más la diferencia entre alguien bien armado y alguien que no tiene ningún equipo defensivo. 

**Changelog:**
los escudos tienen un +3% de bloquear poyectiles.
:cl:
Escudos 3% más opi
Evan gana el rango de developer.
/:cl:

