### PR TITLE
Declaracion de guerra de 50 a 30

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -2,7 +2,7 @@
 #define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
 #define CHALLENGE_SCALE_BONUS 2 // How many TC per scaling bonus
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 30
 #define CHALLENGE_SHUTTLE_DELAY 18000 //30 minutes, so the ops have at least 10 minutes before the shuttle is callable. Gives the nuke ops at least 15 minutes before shuttle arrive.
 
 /obj/item/nuclear_challenge


### PR DESCRIPTION
Bajar la cantidad de players de 50 (Numero demasiado alto para nuestro pop) A un numero mas razonable que es nuestro horario pico

Actualmente nuke ops pide 15 readys.
La declaracion de guerra pediria que haya 30 online para poder declararla

:cl:
balance: players necesarios para declarar la guerra nuke de 50 a 30.
/:cl:

