### PR TITLE
fix coco

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -216,14 +216,14 @@
 	desc = "Made in Space South America."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("hot_coco" = 30)
+	list_reagents = list("chocolate" = 30)
 
 /obj/item/reagent_containers/food/drinks/chocolate
 	name = "hot chocolate"
 	desc = "Made in Space Switzerland."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("chocolate" = 30)
+	list_reagents = list("hot_coco" = 30)
 
 /obj/item/reagent_containers/food/drinks/weightloss
 	name = "weight-loss shake"


### PR DESCRIPTION
https://github.com/Helixis/Paradise/pull/43

El drink era incorrecto, seguia dando alta nutricion y esque era un problema de nombres y al igual que rafa estabamos modificando el Hot_coco creyendo que ese era el trago pero enrealidad el hot_coco no posee el reagent hot_coco, sino que posee chocolate (really)

El que posee el reagent hot_coco era otro trago que no sale de las vending machines.
Por ende se modifico y ahora el hot_choco posee el reagent hot_coco como debe ser

Fue un gran error mio

:cl:
fix: Corrige el nerf del hot choco
/:cl:

