### PR TITLE
Unusable emote 'babea'

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -167,7 +167,7 @@
 				if(2)
 					say(pick(s2))
 				if(3)
-					emote("babea")
+					emote("drool")
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	for(var/datum/dna/gene/gene in dna_genes)


### PR DESCRIPTION
**What does this PR do:**
Arregla este pequeño error
![image](https://i.gyazo.com/thumb/1200/9b79db5e8233ca92fe3fb0fa7da2967e-png.jpg)

**Changelog:**
:cl:
fix: Emote traducido por accidente
/:cl:

