### PR TITLE
Pequeño cambio al calentar Aceite -> Ash

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -209,10 +209,11 @@
 	if(exposed_temperature > T0C + 600)
 		var/turf/T = get_turf(holder.my_atom)
 		holder.my_atom.visible_message("<b>The oil burns!</b>")
-		fireflash(T, min(max(0, volume / 40), 8))
-		var/datum/effect_system/smoke_spread/bad/BS = new
-		BS.set_up(1, 0, T)
-		BS.start()
+		if(volume > (holder.maximum_volume / 2))
+			fireflash(T, min(max(0, volume / 40), 8))
+			var/datum/effect_system/smoke_spread/bad/BS = new
+			BS.set_up(1, 0, T)
+			BS.start()
 		if(holder)
 			holder.add_reagent("ash", round(volume * 0.5))
 			holder.del_reagent(id)

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -211,9 +211,9 @@
 		holder.my_atom.visible_message("<b>The oil burns!</b>")
 		if(volume > (holder.maximum_volume / 2))
 			fireflash(T, min(max(0, volume / 40), 8))
-			var/datum/effect_system/smoke_spread/bad/BS = new
-			BS.set_up(1, 0, T)
-			BS.start()
+		var/datum/effect_system/smoke_spread/bad/BS = new
+		BS.set_up(1, 0, T)
+		BS.start()
 		if(holder)
 			holder.add_reagent("ash", round(volume * 0.5))
 			holder.del_reagent(id)


### PR DESCRIPTION
**What does this PR do:**
Esto viene a raíz del PR #88 y Luego de hablarlo en el discord, se me ocurrió esto. La idea de que al crear ciertos químicos haya un peligro real si no se tiene cuidado me gusta, pero creo que para este en especifico era necesario este pequeño cambio. Ahora si la cantidad de aceite a calentar es mayor a la capacidad de la mitad del beaker, creará un area de fuego.

![image](https://user-images.githubusercontent.com/8194839/58054235-fcfeaa80-7b27-11e9-82e4-539c90f1b693.png)

**Changelog:**
:cl:
tweak: Al calentar mas aceite que la mitad de la capacidad de un beaker creará un area de fuego.
/:cl:

