### PR TITLE
El cinturon de botanico puede llevar más variedad de cosas

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -194,15 +194,17 @@
 		/obj/item/cultivator,
 		/obj/item/hatchet,
 		/obj/item/reagent_containers/glass/bottle,
-//		/obj/item/reagent_containers/syringe,
-//		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/glass/beaker,
 		/obj/item/lighter/zippo,
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/shovel/spade,
 		/obj/item/flashlight/pen,
 		/obj/item/seeds,
 		/obj/item/wirecutters,
-        /obj/item/wrench,
+		/obj/item/wrench,
+		/obj/item/reagent_containers/spray/pestspray,
+		/obj/item/reagent_containers/spray/plantbgone,
 	)
 
 /obj/item/storage/belt/security


### PR DESCRIPTION
**What does this PR do:**
Hace que el cinturon de botanico puede llevar beakers, jeringas, pest spray y  Plant-B-Gone. Todos estos items son usados comunmente por los botanicos e incluso se pueden encontrar en la maquina que le proporciona instrumentos por lo que es logico que su cinturon puedacargar con todo esto.

**Changelog:**
:cl:
Tweak: Ahora el cinturon de botanico puede llevar beakers, jeringas, pest spray y  Plant-B-Gone.
/:cl:

