### PR TITLE
Agregar requerimientos mínimos de experiencia

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -17,8 +17,8 @@
 			            access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_minisat, access_mechanic, access_mineral_storeroom)
-	minimal_player_age = 25
-	exp_requirements = 2160
+	minimal_player_age = 15
+	exp_requirements = 2880
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chief_engineer
 
@@ -58,8 +58,8 @@
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_mineral_storeroom, access_mechanic)
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mineral_storeroom)
 	alt_titles = list("Atmospherics Specialist","Mechanic")
-	minimal_player_age = 7
-	exp_requirements = 300
+	minimal_player_age = 4
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/engineer
 
@@ -86,7 +86,7 @@
 	title = "Life Support Specialist"
 	flag = ATMOSTECH
 	department_flag = ENGSEC
-	total_positions = 3
+	total_positions = 1
 	spawn_positions = 2
 	is_engineering = 1
 	supervisors = "the chief engineer"
@@ -95,9 +95,9 @@
 	access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_atmospherics, access_mineral_storeroom, access_mechanic)
 	minimal_access = list(access_eva, access_atmospherics, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_construction, access_mineral_storeroom, access_tech_storage)
 	alt_titles = list("Atmospheric Technician")
-	minimal_player_age = 7
+	minimal_player_age = 4
 	exp_requirements = 300
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_ENGINEERING
 	outfit = /datum/outfit/job/atmos
 
 /datum/outfit/job/atmos

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -15,9 +15,9 @@
 	minimal_access = list(access_eva, access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels, access_paramedic, access_mineral_storeroom, access_maint_tunnels)
-	minimal_player_age = 25
-	exp_requirements = 2160
-	exp_type = EXP_TYPE_CREW
+	minimal_player_age = 15
+	exp_requirements = 2880
+	exp_type = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/cmo
 
 /datum/outfit/job/cmo
@@ -136,14 +136,14 @@
 					head = /obj/item/clothing/head/nursehat
 				else
 					uniform = /obj/item/clothing/under/rank/medical/purple
-			
+
 //Chemist is a medical job damnit	//YEAH FUCK YOU SCIENCE	-Pete	//Guys, behave -Erro
 
 /datum/job/chemist
 	title = "Chemist"
 	flag = CHEMIST
 	department_flag = MEDSCI
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
 	supervisors = "the chief medical officer"
@@ -177,7 +177,7 @@
 	title = "Geneticist"
 	flag = GENETICIST
 	department_flag = MEDSCI
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
 	supervisors = "the chief medical officer and the research director"
@@ -220,8 +220,8 @@
 	minimal_access = list(access_medical, access_virology, access_maint_tunnels, access_mineral_storeroom)
 	alt_titles = list("Pathologist","Microbiologist")
 	minimal_player_age = 7
-	exp_requirements = 300
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 600
+	exp_type = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/virologist
 
 /datum/outfit/job/virologist

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -17,8 +17,8 @@
 					access_tox_storage, access_tech_storage, access_teleporter, access_sec_doors,
 					access_research, access_robotics, access_xenobiology, access_ai_upload,
 					access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_minisat, access_maint_tunnels, access_mineral_storeroom, access_network)
-	minimal_player_age = 21
-	exp_requirements = 300
+	minimal_player_age = 15
+	exp_requirements = 1440
 	exp_type = EXP_TYPE_SCIENCE
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
@@ -51,7 +51,7 @@
 	title = "Scientist"
 	flag = SCIENTIST
 	department_flag = MEDSCI
-	total_positions = 6
+	total_positions = 4
 	spawn_positions = 6
 	is_science = 1
 	supervisors = "the research director"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -18,7 +18,7 @@
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_pilot, access_weapons)
 	minimal_player_age = 21
-	exp_requirements = 300
+	exp_requirements = 2880
 	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
@@ -62,8 +62,8 @@
 	selection_color = "#ffeeee"
 	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_weapons)
-	minimal_player_age = 21
-	exp_requirements = 600
+	minimal_player_age = 10
+	exp_requirements = 1440
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/warden
 
@@ -108,9 +108,9 @@
 	access = list(access_security, access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_weapons)
 	minimal_access = list(access_sec_doors, access_forensics_lockers, access_morgue, access_maint_tunnels, access_court, access_weapons)
 	alt_titles = list("Forensic Technician")
-	minimal_player_age = 14
+	minimal_player_age = 10
 	exp_requirements = 600
-	exp_type = EXP_TYPE_CREW
+	exp_type = EXP_TYPE_SECURITY
 	outfit = /datum/outfit/job/detective
 
 /datum/outfit/job/detective
@@ -157,16 +157,16 @@
 	title = "Security Officer"
 	flag = OFFICER
 	department_flag = ENGSEC
-	total_positions = 7
-	spawn_positions = 7
+	total_positions = 20
+	spawn_positions = 20
 	is_security = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_morgue, access_weapons)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_weapons)
-	minimal_player_age = 14
-	exp_requirements = 600
+	minimal_player_age = 7
+	exp_requirements = 1200
 	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/officer
 

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -9,7 +9,7 @@
 	department_head = list("Captain")
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 300
+	exp_requirements = 2880
 	exp_type = EXP_TYPE_SILICON
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
@@ -24,13 +24,13 @@
 	title = "Cyborg"
 	flag = CYBORG
 	department_flag = ENGSEC
-	total_positions = 1
+	total_positions = 2
 	spawn_positions = 1
 	supervisors = "your laws and the AI"	//Nodrak
 	department_head = list("AI")
 	selection_color = "#ddffdd"
-	minimal_player_age = 21
-	exp_requirements = 300
+	minimal_player_age = 15
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	alt_titles = list("Android", "Robot")
 

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -13,8 +13,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 30
-	exp_requirements = 2400
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 4320
+	exp_type = EXP_TYPE_COMMAND
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/captain
 
@@ -67,8 +67,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
-	minimal_player_age = 25
-	exp_requirements = 2160
+	minimal_player_age = 15
+	exp_requirements = 1440
 	exp_type = EXP_TYPE_CREW
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
@@ -113,8 +113,9 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
-	minimal_player_age = 25
-	exp_requirements = 2160
+	minimal_player_age = 21
+	exp_requirements = 2880
+	exp_type = EXP_TYPE_CREW
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
@@ -157,8 +158,9 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
-	minimal_player_age = 25
+	minimal_player_age = 21
 	exp_requirements = 2160
+	exp_type = EXP_TYPE_CREW
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_eva, access_heads, access_all_personal_lockers,
 						access_maint_tunnels, access_construction, access_lawyer, access_theatre, access_library,
@@ -201,7 +203,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	req_admin_notify = 1
 	is_legal = 1
 	minimal_player_age = 30
-	exp_requirements = 2400
+	exp_requirements = 2880
+	exp_type = EXP_TYPE_SECURITY
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_eva, access_heads,
 			            access_all_personal_lockers, access_morgue, access_lawyer, access_theatre, access_RC_announce, access_keycard_auth, access_gateway, access_magistrate)

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -75,7 +75,7 @@
 	title = "Botanist"
 	flag = BOTANIST
 	department_flag = SUPPORT
-	total_positions = 3
+	total_positions = 2
 	spawn_positions = 2
 	is_service = 1
 	supervisors = "the head of personnel"
@@ -115,6 +115,8 @@
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
+	exp_requirements = 600
+	exp_type = EXP_TYPE_CREW
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station, access_mineral_storeroom)
 	minimal_access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station, access_mineral_storeroom)
 	outfit = /datum/outfit/job/qm
@@ -163,8 +165,8 @@
 	title = "Shaft Miner"
 	flag = MINER
 	department_flag = SUPPORT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 5
+	spawn_positions = 5
 	is_supply = 1
 	supervisors = "the quartermaster"
 	department_head = list("Head of Personnel")


### PR DESCRIPTION
Reduce la mayoría de días mínimos requeridos para los trabajos, pero agrega experiencia mínima por horas totales (y no solo días a partir de una fecha) que un jugador requiere para acceder al puesto de supervisor de departamento. Al ser experiencia específica de un deptartamento en lugar de experiencia en general, un jugador puede tener los mínimos para CE por haber jugado el tiempo suficiente de ingeniero, pero no para CMO si no ha jugado de médico nunca, independientemente de cuanto tiempo lleva jugando en la comunidad

Chief Engineer: 15 días | 48 horas totales jugadas en el departamento de ingeniería
Chief Medical Officer: 15 días | 48 horas totales jugadas en el departamento de medicina
Research Director: 15 días | 24 horas totales jugadas en el departamento de ciencias
Head of Security: 21 días | 48 horas totales en seguridad
Warden: 10 días | 24 horas totales jugadas en el departamento de seguridad
AI: 10 días | 48 horas totales jugadas como silicon (cyborg)
Capitán: 30 días | 72 horas totales jugadas en el departamento de comando
Head of Personnel: 15 días | 24 horas totales jugadas en general
NT Rep: 21 días | 48 horas totales jugadas en el departamento de comando
Blueshit: 21 días | 36 horas totales jugadas en general
Magistrado: 30 días 48 horas totales jugadas en el departamento de seguridad

Algunos trabajos tienen requerimientos también. Trabajos como ingeniería/atmos requieren que el jugador haya jugado al menos 600 minutos en general. Considerando que las rondas suelen durar entre 2-4 horas, son aproximadamente 3-6 rondas.

🆑Helixis
tweak: Los trabajos tienen tiempo mínimo de experiencia requerida.
/🆑