### PR TITLE
Los accesos del hop ahora se limitan a los de su trabajo en hispania

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -70,17 +70,17 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	minimal_player_age = 15
 	exp_requirements = 1440
 	exp_type = EXP_TYPE_CREW
-	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
+	access = list(access_sec_doors, access_court,
+			            access_change_ids, access_eva, access_heads,
+			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+			            access_theatre, access_chapel_office, access_library, access_mining, access_heads_vault, access_mining_station,
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_mineral_storeroom)
-	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
+	minimal_access = list(access_sec_doors, access_court,
+			            access_change_ids, access_eva, access_heads,
+			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+			            access_theatre, access_chapel_office, access_library, access_mining, access_heads_vault, access_mining_station,
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_mineral_storeroom)
 	outfit = /datum/outfit/job/hop
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -111,7 +111,7 @@
 /obj/item/encryptionkey/heads/hop
 	name = "Head of Personnel's Encryption Key"
 	icon_state = "hop_cypherkey"
-	channels = list("Supply" = 1, "Service" = 1, "Security" = 0, "Command" = 1)
+	channels = list("Supply" = 1, "Service" = 1, "Command" = 1)
 
 /obj/item/encryptionkey/heads/ntrep
 	name = "Nanotrasen Representative's Encryption Key"


### PR DESCRIPTION
**What does this PR do:**
Este pr le retira al hop accesos demás y también canal de sec de su radio.
¿Por qué?
La idea de que el hop tenga todos esos accesos es porque en Paradise el hop es el segundo al mando en la estación y es "el capitan en tiempos de paz" cuando no hay un capitan enviado por nt. En hispania el hop solo es el jefe de cargo y servicio a parte del encargado de reasignar trabajaos (y aun para esto requiere permiso del cmo si quiere contratar a alguien en medbay por ejemplo) y está al mismo nivel en rango que todos los otros heads, no sobre ellos. 

¿Qué pasa si es necesario que tenga esos accesos?
El trabajo del HoP le da la libertad de aumetar los acceso de una persona siempre que sea necesario (a parte de que puede reasignar empleos) por lo que si lo necesita, el sop avala que pueda aumentar sus acceso o los de cualquiera en caso de una emergencia (a menos que le de accesos de nivel de capitan, éstos solo puede darselos al capitan en funciones). 
_____
En resumen, el hop no está perdiendo nada que le sea necesario para su trabajo, los accesos que éste pr le retira puede reotorgarselos él mismo en caso de emergencia, siguiendo el sop, y ésto de la más coherencia al trabajo que realiza el HoP en hispania como también evita que el hop meta sus narices donde no lo llaman o se crea el jefe de la estación cuando no haya capitan. 


**Changelog:**
:cl: Evan
balance: El hop ya no tiene accesos a sec, ciencias, medicina e ingeneria.
balance: el hop ya no tiene el canal de sec en su radio. 
/:cl:

