### PR TITLE
Lets ripleys go fast in mining again.

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -174,7 +174,7 @@
 	var/datum/gas_mixture/environment = T.return_air()
 	var/pressure = environment.return_pressure()
 
-	if(pressure < 20)
+	if(pressure < 40)
 		step_in = 3
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown)/2


### PR DESCRIPTION
**What does this PR do:**
hace que los ripleys se muevan rapidamente en lavaland, con la misma velocidad que se movian en la mina. 

Este pr está basado en otro PR hecho en paradise que fue cerrado por porque habia otro pr que hacia lo mismo. Acá el link de referencia y los creditos al autor: 
https://github.com/ParadiseSS13/Paradise/pull/11694

**Changelog:**
:cl:
balance: aumenta la velocidad de los ripleys en lavaland.
/:cl:

