### PR TITLE
Arregla el bug de no poder abrir los airlocks con las manos

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -662,6 +662,8 @@ About the new airlock wires panel:
 			to_chat(user, "<span class='warning'>Wires are protected!</span>")
 			return
 		wires.Interact(user)
+	else
+		..()
 
 //Checks if the user can headbutt the airlock and does it if it can. Returns TRUE if it happened
 /obj/machinery/door/airlock/proc/headbutt_airlock(mob/user)


### PR DESCRIPTION
**What does this PR do:**
Arregla el pequeño error de no poder abrir ni cerrar airlocks con las manos.

**Changelog:** Ryzor
:cl:
fix: Los tripulantes ya pueden volver a abrir y cerrar los airlocks con las manos
/:cl:

