### PR TITLE
Hispania Icons Mob Refactorizado

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1,4 +1,3 @@
-
 /*
 	Global associative list for caching humanoid icons.
 	Index format m or f, followed by a string of 0 and 1 to represent bodyparts followed by husk fat hulk skeleton 1 or 0.
@@ -557,10 +556,10 @@ var/global/list/damage_icon_parts = list()
 		if(!t_color)
 			t_color = icon_state
 
-		var/mutable_appearance/standing = mutable_appearance('icons/mob/uniform.dmi', "[t_color]_s", layer = -UNIFORM_LAYER)
+		var/mutable_appearance/standing = hispania_icon(w_uniform, 'icons/hispania/mob/uniform.dmi', 'icons/mob/uniform.dmi', "[t_color]_s", -UNIFORM_LAYER)
 		if(FAT in mutations)
 			if(w_uniform.flags_size & ONESIZEFITSALL)
-				standing.icon	= icon_condition(w_uniform, null, null, null, TRUE, TRUE, -UNIFORM_LAYER)
+				standing.icon	= (w_uniform.hispania_icon ? 'icons/hispania/mob/uniform_fat.dmi' : 'icons/mob/uniform_fat.dmi')
 			else
 				to_chat(src, "<span class='warning'>You burst out of \the [w_uniform]!</span>")
 				unEquip(w_uniform)
@@ -586,7 +585,7 @@ var/global/list/damage_icon_parts = list()
 				else if(A.sprite_sheets && A.sprite_sheets[dna.species.name])
 					standing.overlays += image("icon" = A.sprite_sheets[dna.species.name], "icon_state" = "[A.icon_state]")
 				else
-					standing.overlays += icon_condition(A, 'icons/mob/ties.dmi', 'icons/hispania/mob/ties.dmi', "[tie_color]")
+					standing.overlays += image("icon" = (A.hispania_icon ? 'icons/hispania/mob/ties.dmi' : 'icons/mob/ties.dmi'), "icon_state" = "[tie_color]")
 		standing.alpha = w_uniform.alpha
 		standing.color = w_uniform.color
 		overlays_standing[UNIFORM_LAYER] = standing
@@ -643,7 +642,7 @@ var/global/list/damage_icon_parts = list()
 		else if(gloves.sprite_sheets && gloves.sprite_sheets[dna.species.name])
 			standing = mutable_appearance(gloves.sprite_sheets[dna.species.name], "[t_state]", layer = -GLOVES_LAYER)
 		else
-			standing = icon_condition(gloves, 'icons/mob/hands.dmi', 'icons/hispania/mob/hands.dmi', "[t_state]", null, null, -GLOVES_LAYER)
+			standing = hispania_icon(gloves, 'icons/hispania/mob/hands.dmi', 'icons/mob/hands.dmi', "[t_state]", -GLOVES_LAYER)
 
 		if(gloves.blood_DNA)
 			var/image/bloodsies	= image("icon" = dna.species.blood_mask, "icon_state" = "bloodyhands")
@@ -681,7 +680,7 @@ var/global/list/damage_icon_parts = list()
 		else if(glasses.sprite_sheets && glasses.sprite_sheets[head_organ.dna.species.name])
 			new_glasses = mutable_appearance(glasses.sprite_sheets[head_organ.dna.species.name], "[glasses.icon_state]", layer = -GLASSES_LAYER)
 		else
-			new_glasses = icon_condition(glasses, 'icons/mob/eyes.dmi', 'icons/hispania/mob/eyes.dmi', "[glasses.icon_state]", null, null, -GLASSES_LAYER)
+			new_glasses = hispania_icon(glasses, 'icons/hispania/mob/eyes.dmi', 'icons/mob/eyes.dmi', "[glasses.icon_state]", -GLASSES_LAYER)
 
 		var/datum/sprite_accessory/hair/hair_style = GLOB.hair_styles_full_list[head_organ.h_style]
 		var/obj/item/clothing/glasses/G = glasses
@@ -727,7 +726,8 @@ var/global/list/damage_icon_parts = list()
 			else if(l_ear.sprite_sheets && l_ear.sprite_sheets[dna.species.name])
 				overlays_standing[EARS_LAYER] = mutable_appearance(l_ear.sprite_sheets[dna.species.name], "[t_type]", layer = -EARS_LAYER)
 			else
-				overlays_standing[EARS_LAYER] = icon_condition(l_ear, 'icons/mob/ears.dmi', 'icons/hispania/mob/ears.dmi', "[t_type]", null, null, -EARS_LAYER)
+				overlays_standing[EARS_LAYER] = hispania_icon(l_ear, 'icons/hispania/mob/ears.dmi', 'icons/mob/ears.dmi', "[t_type]", -EARS_LAYER)
+
 
 		if(r_ear)
 			if(client && hud_used && hud_used.hud_shown)
@@ -744,7 +744,7 @@ var/global/list/damage_icon_parts = list()
 			else if(r_ear.sprite_sheets && r_ear.sprite_sheets[dna.species.name])
 				overlays_standing[EARS_LAYER] = mutable_appearance(r_ear.sprite_sheets[dna.species.name], "[t_type]", layer = -EARS_LAYER)
 			else
-				overlays_standing[EARS_LAYER] = icon_condition(r_ear, 'icons/mob/ears.dmi', 'icons/hispania/mob/ears.dmi', "[t_type]", null, null, -EARS_LAYER)
+				overlays_standing[EARS_LAYER] = hispania_icon(r_ear, 'icons/hispania/mob/ears.dmi', 'icons/mob/ears.dmi', "[t_type]", -EARS_LAYER)
 	apply_overlay(EARS_LAYER)
 
 /mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
@@ -766,7 +766,7 @@ var/global/list/damage_icon_parts = list()
 		else if(shoes.sprite_sheets && shoes.sprite_sheets[dna.species.name])
 			standing = mutable_appearance(shoes.sprite_sheets[dna.species.name], "[shoes.icon_state]", layer = -SHOES_LAYER)
 		else
-			standing = icon_condition(shoes, 'icons/mob/feet.dmi', 'icons/hispania/mob/feet.dmi', "[shoes.icon_state]", null, null, -SHOES_LAYER)
+			standing = hispania_icon(shoes, 'icons/hispania/mob/feet.dmi', 'icons/mob/feet.dmi', "[shoes.icon_state]", -SHOES_LAYER)
 
 
 		if(shoes.blood_DNA)
@@ -819,7 +819,7 @@ var/global/list/damage_icon_parts = list()
 		else if(head.sprite_sheets && head.sprite_sheets[dna.species.name])
 			standing = mutable_appearance(head.sprite_sheets[dna.species.name], "[head.icon_state]", layer = -HEAD_LAYER)
 		else
-			standing = icon_condition(head, 'icons/mob/head.dmi', 'icons/hispania/mob/head.dmi', "[head.icon_state]", null, null, -HEAD_LAYER)
+			standing = hispania_icon(head, 'icons/hispania/mob/head.dmi', 'icons/mob/head.dmi', "[head.icon_state]", -HEAD_LAYER)
 
 		if(head.blood_DNA)
 			var/image/bloodsies = image("icon" = dna.species.blood_mask, "icon_state" = "helmetblood")
@@ -852,7 +852,7 @@ var/global/list/damage_icon_parts = list()
 		else if(belt.sprite_sheets && belt.sprite_sheets[dna.species.name])
 			overlays_standing[BELT_LAYER] = mutable_appearance(belt.sprite_sheets[dna.species.name], "[t_state]", layer = -BELT_LAYER)
 		else
-			overlays_standing[BELT_LAYER] = icon_condition(belt, 'icons/mob/belt.dmi', 'icons/hispania/mob/belt.dmi', "[t_state]", null, null, -BELT_LAYER)
+			overlays_standing[BELT_LAYER] = hispania_icon(belt, 'icons/hispania/mob/belt.dmi', 'icons/mob/belt.dmi', "[t_state]", -BELT_LAYER)
 	apply_overlay(BELT_LAYER)
 
 
@@ -876,13 +876,13 @@ var/global/list/damage_icon_parts = list()
 			standing = mutable_appearance(wear_suit.sprite_sheets[dna.species.name], "[wear_suit.icon_state]", layer = -SUIT_LAYER)
 		else if(FAT in mutations)
 			if(wear_suit.flags_size & ONESIZEFITSALL)
-				standing = icon_condition(wear_suit, 'icons/mob/suit_fat.dmi', 'icons/hispania/mob/suit_fat.dmi', "[wear_suit.icon_state]", FALSE, TRUE, -SUIT_LAYER)
+				standing = hispania_icon(wear_suit, 'icons/hispania/mob/suit_fat.dmi', 'icons/mob/suit_fat.dmi', "[wear_suit.icon_state]", -SUIT_LAYER)
 			else
 				to_chat(src, "<span class='warning'>You burst out of \the [wear_suit]!</span>")
 				unEquip(wear_suit)
 				return
 		else
-			standing = icon_condition(wear_suit, 'icons/mob/suit.dmi', 'icons/hispania/mob/suit.dmi', "[wear_suit.icon_state]", FALSE, FALSE, -SUIT_LAYER)
+			standing = hispania_icon(wear_suit, 'icons/hispania/mob/suit.dmi', 'icons/mob/suit.dmi', "[wear_suit.icon_state]", -SUIT_LAYER)
 
 		if(wear_suit.breakouttime)
 			drop_l_hand()
@@ -984,7 +984,7 @@ var/global/list/damage_icon_parts = list()
 		else if(back.sprite_sheets && back.sprite_sheets[dna.species.name])
 			standing = mutable_appearance(back.sprite_sheets[dna.species.name], "[back.icon_state]", layer = -BACK_LAYER)
 		else
-			standing = icon_condition(back, 'icons/mob/back.dmi', 'icons/hispania/mob/back.dmi', "[back.icon_state]", null, null, -BACK_LAYER)
+			standing = hispania_icon(back, 'icons/hispania/mob/back.dmi', 'icons/mob/back.dmi', "[back.icon_state]", -BACK_LAYER)
 
 		//create the image
 		standing.alpha = back.alpha
@@ -1347,24 +1347,18 @@ var/global/list/damage_icon_parts = list()
 
 	. = "[.][!!husk][!!fat][!!hulk][!!skeleton]"
 
-/mob/living/carbon/human/proc/icon_condition(var/obj/item/A, var/icon_paradise, var/icon_hispania, var/i_state, var/uniform, var/fat, var/layer)
-    var/obj/item/I = new A.type
-    if(istype(I, /obj/item/))
-        if(I.hispania_icon)
-            if(uniform)
-                if(fat)
-                    return 'icons/hispania/mob/uniform_fat.dmi'
-                return 'icons/hispania/mob/uniform.dmi'
-            else
-                if(fat)
-                    return 'icons/hispania/mob/suit_fat.dmi'
-            return mutable_appearance(icon_hispania, i_state, layer)
-        else
-            if(uniform)
-                if(fat)
-                    return 'icons/mob/uniform_fat.dmi'
-                return 'icons/mob/uniform.dmi'
-            else
-                if(fat)
-                    return 'icons/mob/suit_fat.dmi'
-            return mutable_appearance(icon_paradise, i_state, layer)
+/mob/living/carbon/human/proc/hispania_icon(var/obj/item/A, var/icon_hispania, var/icon_paradise, var/i_state, var/layer)
+	var/obj/item/I = new A.type
+	var/result
+
+	if(istype(I, /obj/item/clothing/under) || istype(I, /obj/item/clothing/suit))
+		if(I.flags_size & ONESIZEFITSALL)
+			result = (I.hispania_icon ? icon_hispania : icon_paradise) // Si es gordo
+		else
+			result = (I.hispania_icon ? icon_hispania : icon_paradise) // Si no es gordo
+
+	return mutable_appearance((length(result) > 0 ? result : (I.hispania_icon ? icon_hispania : icon_paradise)), i_state, layer = layer)
+	/*	Si result NO es un string vacio entonces retornara un uniforme o traje, para gordos o para gente normal
+		Si esta vacio entonces hay otra condicion que pregunta si la ropa es un hispania_icon, si lo es usara icons/hispania/mob
+		y si no lo es usara icons/mob
+	*/


### PR DESCRIPTION
**What does this PR do:**
He refactorizado el código del Hispania Icons en los mobs haciéndolo más fácil de leer y entender, he arreglado también problemas al mostrar el sprite de los uniformes de hispania y el sprite de la ropa para gordos.

**Changelog:** Ryzor
:cl:
tweak: Hispania Icons Refactorizado
fix: Los uniformes de hispania ya se ven al ser equipados
/:cl:

