### PR TITLE
Regresa los circuitos de teleciencias a RnD

### DIFF
--- a/code/HISPANIA/modules/research/designs/comp_board_designs.dm
+++ b/code/HISPANIA/modules/research/designs/comp_board_designs.dm
@@ -1,0 +1,9 @@
+/datum/design/telesci_console
+	name = "Console Board (Telepad Control Console)"
+	desc = "Allows for the construction of circuit boards used to build a telescience console."
+	id = "telesci_console"
+	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/telesci_console
+	category = list("Computer Boards")

--- a/code/HISPANIA/modules/research/designs/comp_board_designs.dm
+++ b/code/HISPANIA/modules/research/designs/comp_board_designs.dm
@@ -2,7 +2,7 @@
 	name = "Console Board (Telepad Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a telescience console."
 	id = "telesci_console"
-	req_tech = list("programming" = 3, "bluespace" = 8, "plasmatech" = 4)
+	req_tech = list("programming" = 5, "bluespace" = 8, "plasmatech" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/telesci_console

--- a/code/HISPANIA/modules/research/designs/comp_board_designs.dm
+++ b/code/HISPANIA/modules/research/designs/comp_board_designs.dm
@@ -2,7 +2,7 @@
 	name = "Console Board (Telepad Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a telescience console."
 	id = "telesci_console"
-	req_tech = list("programming" = 3, "bluespace" = 3, "plasmatech" = 4)
+	req_tech = list("programming" = 3, "bluespace" = 8, "plasmatech" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/telesci_console

--- a/code/HISPANIA/modules/research/designs/machine_designs.dm
+++ b/code/HISPANIA/modules/research/designs/machine_designs.dm
@@ -1,0 +1,9 @@
+/datum/design/telepad
+	name = "Machine Board (Telepad Board)"
+	desc = "Allows for the construction of circuit boards used to build a Telepad."
+	id = "telepad"
+	req_tech = list("programming" = 4, "bluespace" = 5, "plasmatech" = 4, "engineering" = 4)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/telesci_pad
+	category = list ("Teleportation Machinery")

--- a/code/HISPANIA/modules/research/designs/machine_designs.dm
+++ b/code/HISPANIA/modules/research/designs/machine_designs.dm
@@ -2,7 +2,7 @@
 	name = "Machine Board (Telepad Board)"
 	desc = "Allows for the construction of circuit boards used to build a Telepad."
 	id = "telepad"
-	req_tech = list("programming" = 4, "bluespace" = 5, "plasmatech" = 4, "engineering" = 4)
+	req_tech = list("programming" = 4, "bluespace" = 8, "plasmatech" = 4, "engineering" = 4)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/telesci_pad

--- a/code/HISPANIA/modules/research/designs/machine_designs.dm
+++ b/code/HISPANIA/modules/research/designs/machine_designs.dm
@@ -2,7 +2,7 @@
 	name = "Machine Board (Telepad Board)"
 	desc = "Allows for the construction of circuit boards used to build a Telepad."
 	id = "telepad"
-	req_tech = list("programming" = 4, "bluespace" = 8, "plasmatech" = 4, "engineering" = 4)
+	req_tech = list("programming" = 6, "bluespace" = 8, "plasmatech" = 6, "engineering" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000)
 	build_path = /obj/item/circuitboard/telesci_pad

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -362,7 +362,7 @@
 /obj/item/circuitboard/telesci_console
 	name = "Circuit board (Telepad Control Console)"
 	build_path = /obj/machinery/computer/telescience
-	origin_tech = "programming=3;bluespace=7;plasmatech=4"
+	origin_tech = "programming=5;bluespace=7;plasmatech=6"
 
 /obj/item/circuitboard/atmos_automation
 	name = "Circuit board (Atmospherics Automation)"

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -362,7 +362,7 @@
 /obj/item/circuitboard/telesci_console
 	name = "Circuit board (Telepad Control Console)"
 	build_path = /obj/machinery/computer/telescience
-	origin_tech = "programming=3;bluespace=3;plasmatech=4"
+	origin_tech = "programming=3;bluespace=7;plasmatech=4"
 
 /obj/item/circuitboard/atmos_automation
 	name = "Circuit board (Atmospherics Automation)"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -817,7 +817,7 @@ to destroy them and players will be able to make replacements.
 	name = "Circuit board (Telepad)"
 	build_path = /obj/machinery/telepad
 	board_type = "machine"
-	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=7"
+	origin_tech = "programming=6;engineering=5;plasmatech=6;bluespace=7"
 	frame_desc = "Requires 2 Bluespace Crystals, 1 Capacitor, 1 piece of cable and 1 Console Screen."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -817,7 +817,7 @@ to destroy them and players will be able to make replacements.
 	name = "Circuit board (Telepad)"
 	build_path = /obj/machinery/telepad
 	board_type = "machine"
-	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=4"
+	origin_tech = "programming=4;engineering=3;plasmatech=4;bluespace=7"
 	frame_desc = "Requires 2 Bluespace Crystals, 1 Capacitor, 1 piece of cable and 1 Console Screen."
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,

--- a/paradise.dme
+++ b/paradise.dme
@@ -1187,6 +1187,8 @@
 #include "code\HISPANIA\modules\reagents\chemistry\reagents\alcohol.dm"
 #include "code\HISPANIA\modules\reagents\chemistry\reagents\drinks.dm"
 #include "code\HISPANIA\modules\reagents\chemistry\recipes\drinks.dm"
+#include "code\HISPANIA\modules\research\designs\comp_board_designs.dm"
+#include "code\HISPANIA\modules\research\designs\machine_designs.dm"
 #include "code\HISPANIA\modules\research\designs\mechfabricator_designs.dm"
 #include "code\HISPANIA\modules\research\designs\misc_designs.dm"
 #include "code\HISPANIA\modules\research\designs\power_designs.dm"


### PR DESCRIPTION
**What does this PR do:**

Existen niveles tecnologicos más allá del siete pero estàn completamente vacios. Cosa parecida que pasa con la tecnogía ilegal (que es super decepcionante subirla y luego no encontrar nada interesante). Lograr subir tan arriba del siete las tecnogías merece un tipo de recomensa, así sea como algo anecdótico siempre deja un buen sabor de boca el desbloquear algo nuevo.  

Regresa los circuitos de teleciencias a RnD pero requieren tecnología 8 en bluespace. 
Esto hará a los circuitos de teleciencias algo sumamente exótico y casi imposible de obtener por métodos normales pero al menos con esto existe un método que so sea solo via admin. 


**Changelog:**
:cl:Evankhell
add: Los circuitos de teleciencias se pueden fabricar en ciencias, de nuevo, requiere tecnología 8 en bluespace. 
balance: los circuitos de la teleciencia tienen un origen tecnologico más elevado.
/:cl: