### PR TITLE
Modifica las las cantidades de materiales de ciencias

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -49153,13 +49153,18 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/metal,
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
 /obj/item/multitool,
 /obj/item/multitool,
 /turf/simulated/floor/plasteel,
@@ -76104,7 +76109,7 @@
 	amount = 50
 	},
 /obj/item/stack/sheet/mineral/plasma{
-	amount = 1;
+	amount = 3;
 	layer = 2.9
 	},
 /obj/item/stack/sheet/glass{
@@ -87693,7 +87698,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"


### PR DESCRIPTION
**¿Qué hace este pr?**
1. Hace algunos cambios al mapa para corregir algunos errores de mapeado en ciencias. Los valores los saque de mi memoria por lo que puede que no sean los mismos de antes, sin embargo los veo como unos buenos valores.
mapa de ciencias:
*robotica:
-de un 1 de vidrio a 50 de vidrio
-de 6 de metal a 150 de metal
*quimica:
-de uno de plasma a 3 de plasma.
2. Arregla un errore de mapeo en medbay donde habia un botiquin que empezaba sin medicamentos. Éste error es el mismo que se habia intentado arreglar aca #101 

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:Evankhell
tweak: robotica inicia con 150 de metal y 50 de vidrio en vez de 6 y 1 respectivamente.
tweak: quimica de ciencias inicia con 3 de plasma en vez de 1.
fix: el botiquin blanco del deposito de medbay ahora inicia con medicamentos
/:cl:

