### PR TITLE
Los paramedicos pueden entrar a cirugía pero no a virología

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -289,8 +289,8 @@
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
-	access = list(access_psychiatrist, access_medical, access_morgue, access_chemistry, access_virology, access_genetics, access_mineral_storeroom, access_paramedic, access_maint_tunnels, access_external_airlocks)
-	minimal_access=list(access_paramedic, access_medical, access_maint_tunnels, access_external_airlocks, access_morgue)
+	access = list(access_psychiatrist, access_medical, access_morgue, access_chemistry, access_surgery, access_genetics, access_mineral_storeroom, access_paramedic, access_maint_tunnels, access_external_airlocks)
+	minimal_access=list(access_paramedic, access_medical, access_maint_tunnels, access_external_airlocks, access_morgue, access_surgery)
 	minimal_player_age = 3
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW


### PR DESCRIPTION
**What does this PR do:**
Los paramédicos tienen acceso a cigrugía pero no a virología. 
¿darle acceso a cirugía?
A los paramedicos en hispania les permitimos operar en sus conocimientos, sin embargo esto no tienen acceso a cirugía. Esto se hace por forzar al paramédico a no meterse en asuntos del cirujano pero no es nada que no se pueda resolver roleando, en cambio cuando solo hay un paramédico en med o solo hay dos personas y muchos heridos o a veces el mismo cirujano necesita ayuda con pacientes dificile, en esos casos, esto termina siendo una molestia más que otra cosa.

¿por qué quitarle el acceso a virologia?
pues bien, es más logico que un paramedico sepa operar (hacer suturas, desinfectar heridas, retirar un objeto extraño del cuerpo del paciente) que dedicarse a la experimentacion y desarrollo de virus super potentes. Ésto le daria más coherencia al juego de la que tiene actualmente. 
**Changelog:**
:cl:Evankhell
tweak: Los paramedicos pueden entrar a cirugía ya no pueden entrar a virología
/:cl:

