### PR TITLE
Cambios a la creación de baterias

### DIFF
--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -13,6 +13,11 @@
 	self_recharge = 1 // Infused slime cores self-recharge, over time
 	chargerate = 600
 
+/obj/item/stock_parts/cell/xenoblue/empty/New()
+	..()
+	charge = 0
+	update_icon()
+
 /obj/item/xenobluecellmaker
 	icon = 'icons/hispania/obj/power.dmi'
 	icon_state = "xenobluecellmaker"
@@ -45,7 +50,14 @@
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the Xenobluespace power cell.</span>")
 				var/turf/T = get_turf(src)
-				new /obj/item/stock_parts/cell/xenoblue(T)
-				user.unEquip(src, 1)
+				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue(T))
 				qdel(src)
+
+
+
+//fin de la xenoblue cell
+/obj/item/stock_parts/cell/high/plus/empty/New()
+	..()
+	charge = 0
+	update_icon()
 

--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_GLASS = 800)
 	rating = 7
 	self_recharge = 1 // Infused slime cores self-recharge, over time
-	chargerate = 600
+	chargerate = 750
 
 /obj/item/stock_parts/cell/xenoblue/empty/New()
 	..()
@@ -50,12 +50,12 @@
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the Xenobluespace power cell.</span>")
 				var/turf/T = get_turf(src)
-				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue(T))
 				qdel(src)
-
-
+				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue/empty(T))
 
 //fin de la xenoblue cell
+
+
 /obj/item/stock_parts/cell/high/plus/empty/New()
 	..()
 	charge = 0

--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/cell/xenoblue
-	icon = 'icons/HISPANIA/obj/power.dmi'
+	icon = 'icons/hispania/obj/power.dmi'
 	icon_state = "xenobluecell"
 	item_state = "xenobluecell"
 	name = "xenobluespace power cell"
@@ -14,7 +14,7 @@
 	chargerate = 600
 
 /obj/item/xenobluecellmaker
-	icon = 'icons/HISPANIA/obj/power.dmi'
+	icon = 'icons/hispania/obj/power.dmi'
 	icon_state = "xenobluecellmaker"
 	item_state = "xenobluecellmaker"
 	lefthand_file = 'icons/hispania/mob/inhands/items_lefthand.dmi'

--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -20,7 +20,7 @@
 	lefthand_file = 'icons/hispania/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/hispania/mob/inhands/items_righthand.dmi'
 	name = "xenobluespace power cell maker"
-	desc = "High-tech power cell shell capable of creating a power cell that combines Bluespace and Xenobiology technology. Requiered a bluespace power cell and a charged slime core. Has inscribed: -en Honor a Blob Bob, Maestro de la Teleciencia, Sticky Gum, Maestra de la Xenobiologia y a Baldric Chapman, Maestro de la Robotica-"
+	desc = "High-tech power cell shell capable of creating a power cell that combines Bluespace and Xenobiology technology. Requiered a bluespace power cell and a charged slime core."
 	origin_tech = "powerstorage=6;biotech=4"
 	materials = list(MAT_GLASS = 1000)
 	var/build_step = 0

--- a/code/HISPANIA/modules/research/designs/power_designs.dm
+++ b/code/HISPANIA/modules/research/designs/power_designs.dm
@@ -3,10 +3,23 @@
 	desc = "High-tech porwer cell shell capable of creating a porwer cell that combines Bluespace and xenobiology technology."
 	id = "xenobluecell"
 	req_tech = list("powerstorage" = 7, "materials" = 6, "engineering" = 6, "bluespace" = 6)
-	build_type = PROTOLATHE | MECHFAB
+	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 2000, MAT_GOLD = 440, MAT_GLASS = 720, MAT_DIAMOND = 480, MAT_URANIUM = 100, MAT_TITANIUM = 600, MAT_BLUESPACE = 200)
-	construction_time=50
 	build_path = /obj/item/xenobluecellmaker
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
+
+/datum/design/high_cell_plus
+	name = "High-Capacity Power Cell+"
+	desc = "A power cell that holds 15 kW of power."
+	id = "high_cell_plus"
+	req_tech = list("powerstorage" = 3)
+	build_type = PROTOLATHE | MECHFAB | PODFAB
+	materials = list(MAT_METAL = 700, MAT_GLASS = 65)
+	build_path = /obj/item/stock_parts/cell/high/plus/empty
+	category = list("Misc","Power")
+	lathe_time_factor = 0.2
+
+
 
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -152,8 +152,8 @@
 		cell = C
 		return
 	cell = new(src)
-	cell.charge = 500
-	cell.maxcharge = 1000
+	cell.charge = 15000
+	cell.maxcharge = 15000
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -152,8 +152,8 @@
 		cell = C
 		return
 	cell = new(src)
-	cell.charge = 15000
-	cell.maxcharge = 15000
+	cell.charge = 500
+	cell.maxcharge = 1000
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -10,7 +10,7 @@
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell
+	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power","Machinery","initial")
 
 /datum/design/high_cell
@@ -21,7 +21,7 @@
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/high
+	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list("Misc","Power")
 
 /datum/design/hyper_cell
@@ -32,7 +32,7 @@
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/hyper
+	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list("Misc","Power")
 
 /datum/design/super_cell
@@ -43,7 +43,7 @@
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/super
+	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power")
 
 /datum/design/bluespace_cell
@@ -54,7 +54,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
 	construction_time=100
-	build_path = /obj/item/stock_parts/cell/bluespace
+	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list("Misc","Power")
 
 /datum/design/pacman

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -9,9 +9,9 @@
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
-	construction_time=100
 	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power","Machinery","initial")
+	lathe_time_factor = 0.2
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -20,9 +20,9 @@
 	req_tech = list("powerstorage" = 2)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
-	construction_time=100
 	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -31,20 +31,20 @@
 	req_tech = list("powerstorage" = 5, "materials" = 5, "engineering" = 5)
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
-	construction_time=100
 	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"
 	desc = "A power cell that holds 20 kW of power."
 	id = "super_cell"
-	req_tech = list("powerstorage" = 3, "materials" = 3)
+	req_tech = list("powerstorage" = 4, "materials" = 3)
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
-	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/bluespace_cell
 	name = "Bluespace Power Cell"
@@ -53,9 +53,9 @@
 	req_tech = list("powerstorage" = 6, "materials" = 5, "engineering" = 5, "bluespace" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
-	construction_time=100
 	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/pacman
 	name = "Machine Board (PACMAN-type Generator)"


### PR DESCRIPTION
**What does this PR do:**
-las baterias creadas en el autlathe o en el protolathe inician con cero de carga pero se crean más rapido (a la misma velocidad que los otros stocks parts).
-añade la high cell+ descargada al code
-añade la xenobluecell descargada al code
-la super celda requiere tecnologia 4
-añade el diseño de la high cell+ al protolathe por tecnologia 3
-elimina nombres de pj de terceros de la xenoblue cell
-al crear una xenobluecell esta aparece en tus manos en vez de en el suelo
-añade el diseño de la xenobluecellmaker al podfabricator


Como ya le he explicado a daniel, este pr solo afecta a las baterias creadas en el autolathe y los protolahtes por esto, no afectará a casi a ningun departamento que no sea ciencias y más especificamente a robotica. Los ingenieros por su parte tienen un reserva de baterias de alta capacidad (que ya están cargadas) desde el inicio y nunca en todo mi tiempo en ciencias he visto a un ingeniero yendo a pedir baterias en ciencias. En cambio los unicos que usan las baterias hechas por ciencias son los robotistas ya que los cientificos de rnd usan sus baterias para mejorar maquinas y estas no requieren que la bateria tenga carga. 

**¿Por qué es bueno este pr?**
Este pr está enfocado en mejorar la experiencia de ciencias mediante un nerfeo a ciencias. ¿como es posible esto?
1. Los cientificos de rnd suelen no mejorar los cargadores de borgs y los mechas y aun si los mejoran nadie los usa y es que, ¿por qué poner a cargar un mecha por un minuto cuando el robotista ya puede cambiarle la bateria por una igual de potente y que puede cambiar en un segundo? esto le dará utilidad a esos cargadores y al hecho de mejorar esos cargadores por lo que los buenos cientificos los mejorarán más a menudo y tendrán un efecto más visible.

2. Los robotistas podrán usar todas las mecanicas de siempre para cambiar baterias rapidamente pero se sentirán en un ambiente más realista donde si alguien llega a tu taller para que le repares el motor del carro, no le vas a cambiar el motor dañado por uno nuevo sino que vas a repararlo. En este caso es tener más frecuentemente un mecha cargando en tu taller. También, para quien quiera una mejora en la bateria de su mecha tendrá que pagar el costo de dejarlo cargando un rato. ¿quieres una mejora en tu bateria? pues debes decidir si pagas el precio de si estás dispuesto a que tu nueva y más potente bateria se cargue o si sigues con la vieja

**Changelog:**
:cl:Evankhell
add: añade la high cell+ descargada al codigo y al protolahte. 
teak: la super cell requiere más tecnologia.
add: añade la xenobluecell descargada al codigo.
balance: las baterias creadas en el protolathe/autolathe inician descargadas pero se crean más rapido.
fix: arregla la ruta de la xenobluespacepowercell.
balance: la xenobluecell inicia descargada al ser crafteada pero se carga más rapido.
del: elimina nombres de pj de terceros de la xenobluespacepowercellmaker.
tweak: la xenobluecellmaker se puede crear en la en el pod fabricator.
tweak: al crear la xenobluecell, ésta aparece en tu mano en vez de en el suelo.
/:cl:

