### PR TITLE
cambios a botanica

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1237,7 +1237,8 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/seeds/banana,
 					/obj/item/seeds/eggplant/eggy,
 					/obj/item/seeds/random,
-					/obj/item/seeds/random)
+					/obj/item/seeds/random,
+					/obj/item/seeds/glowshroom)
 	cost = 15
 	containername = "exotic seeds crate"
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1284,9 +1284,9 @@
 						/obj/item/seeds/lime = 3, /obj/item/seeds/onion = 3, /obj/item/seeds/orange = 3, /obj/item/seeds/peanuts = 3, /obj/item/seeds/pineapple = 3, /obj/item/seeds/potato = 3, /obj/item/seeds/poppy = 3,
 						/obj/item/seeds/pumpkin = 3, /obj/item/seeds/replicapod = 3, /obj/item/seeds/wheat/rice = 3, /obj/item/seeds/soya = 3, /obj/item/seeds/sunflower = 3, /obj/item/seeds/sugarcane = 3,
 						/obj/item/seeds/tea = 3, /obj/item/seeds/tobacco = 3, /obj/item/seeds/tomato = 3,
-						/obj/item/seeds/tower = 3, /obj/item/seeds/watermelon = 3, /obj/item/seeds/wheat = 3, /obj/item/seeds/whitebeet = 3)
+						/obj/item/seeds/tower = 3, /obj/item/seeds/watermelon = 3, /obj/item/seeds/wheat = 3, /obj/item/seeds/whitebeet = 3, /obj/item/seeds/fungus = 3)
 	contraband = list(/obj/item/seeds/amanita = 2, /obj/item/seeds/glowshroom = 2, /obj/item/seeds/liberty = 2, /obj/item/seeds/nettle = 2,
-						/obj/item/seeds/plump = 2, /obj/item/seeds/reishi = 2, /obj/item/seeds/cannabis = 3, /obj/item/seeds/starthistle = 2, /obj/item/seeds/fungus = 3, /obj/item/seeds/random = 2)
+						/obj/item/seeds/plump = 2, /obj/item/seeds/reishi = 2, /obj/item/seeds/cannabis = 3, /obj/item/seeds/starthistle = 2, /obj/item/seeds/random = 2)
 	premium = list(/obj/item/reagent_containers/spray/waterflower = 1)
 	refill_canister = /obj/item/vending_refill/hydroseeds
 


### PR DESCRIPTION
**What does this PR do:**
-las glowshroom ahora se pueden encontrar en el crate de las cajas exoticas
-los hongos espaciales se pueden encontrar regularmente en la maquina de semillas de botanica sin necesidad de hackear la maquina.

¿por qué es bueno este cambio?
Al colocar las glowshroom en el crate de semillas exóticas, nuestro querido investigador botanico no tendrá que depender de que un ingeniero se apiade de el para hacer su trabajo. Esta interacción también da poco rol, por lo genral el botanico llama a un ingeniero para que le hackee la maquina y el ingeniero por razones ooc lo hace sin rechistar (razon de que sin eso no puede trabajr) y ni pregunta por qué debe hackear la maquina. Al colocar las glowshroom  en el crate, el botanico aun tendrá que hacer algo para conseguirlas y cargo puede rolear poniendose estricto con el papelo


¿Por qué sacar los hongos espaciales de la categoria ilegal de la maquina de semillas?
Un poco por lo mismo, depender un poco menos del ingeniero que por razones ooc debe hacer lo que le dices para no joderte la partida como botanco además, los hongos espaciales no tienen efecto dañino directo por lo qué no son peligrosos y no hay razón para que no este desde el inicio en la maquina de semillas


**Changelog:**
:cl:
tweak: las glowshroom ahora se pueden encontrar en el crate de las semillas exoticas
tweak: los hongos espaciales se pueden encontrar regularmente en la maquina de semillas de botanica sin necesidad de hackear la maquina.
/:cl:

