### PR TITLE
exosuit large syringe gun

### DIFF
--- a/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
+++ b/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
@@ -81,8 +81,8 @@
 	desc = "Equipment for medical exosuits. A upgraded exosuit syringe gun"
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "rapidsyringegun"
-	max_syringes = 60
-	max_volume = 450
+	max_syringes = 20
+	max_volume = 150
 	energy_drain = 100
 
 	origin_tech = "materials=4;biotech=5;magnets=4,engineering=4"

--- a/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
+++ b/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
@@ -75,3 +75,14 @@
 	STOP_PROCESSING(SSobj, src)
 	medigun.LoseTarget()
 	return ..()
+
+/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/large
+	name = "exosuit large syringe gun"
+	desc = "Equipment for medical exosuits. A upgraded exosuit syringe gun"
+	icon = 'icons/obj/guns/projectile.dmi'
+	icon_state = "rapidsyringegun"
+	max_syringes = 60
+	max_volume = 450
+	energy_drain = 100
+
+	origin_tech = "materials=4;biotech=5;magnets=4,engineering=4"

--- a/code/HISPANIA/modules/research/designs/mechfabricator_designs.dm
+++ b/code/HISPANIA/modules/research/designs/mechfabricator_designs.dm
@@ -9,4 +9,15 @@
 	construction_time = 250
 	category = list("Exosuit Equipment")
 
+/datum/design/mech_syringe_gun/large
+	name = "Exosuit Medical Equipment (Large Syringe Gun)"
+	id = "mech_large_syringe_gun"
+	build_type = MECHFAB
+	req_tech = list("magnets" = 5,"biotech" = 5, "combat" = 4, "materials" = 5, "engineering" = 4)
+	build_path = /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/large
+	materials = list(MAT_METAL=3000,MAT_GLASS=2000,MAT_TITANIUM=1000)
+	construction_time = 200
+	category = list("Exosuit Equipment")
+
+
 


### PR DESCRIPTION
**What does this PR do:**
Crea el exosuit large syringe gun. Es una pistola de jergigas para mechas con mayor capacidad que su versión antigua. 

Las pistolas de jeringas del ody son marivillosas, y tienen multiples usos.  El unico negativo que tiene son la cantidad de jeringas que puede cargar. Asi como en ciencias se puede construir una pistola de jeringas que carga seis veces más de lo normal, pensé aplicar eso a la versión del mecha. 

**Changelog:**
:cl:
add: exosuit large syringe gun
/:cl:

