### PR TITLE
Reemplaza las high cell con 15kW de carga por high cell+

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -5211,9 +5211,8 @@
 	pixel_x = 0;
 	pixel_y = 10
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /obj/effect/decal/warning_stripes/east,
 /obj/item/clothing/glasses/welding,
@@ -24526,13 +24525,11 @@
 "aRZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
@@ -49549,9 +49546,8 @@
 "bNN" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /obj/item/radio/intercom{
 	frequency = 1459;
@@ -50599,13 +50595,11 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
-/obj/item/stock_parts/cell/high{
+/obj/item/stock_parts/cell/high/plus{
 	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 5;
 	pixel_y = -5
 	},
@@ -53881,9 +53875,8 @@
 "bUQ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -70310,9 +70303,8 @@
 "cvA" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -74284,9 +74276,8 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -84245,13 +84236,11 @@
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /obj/item/clothing/glasses/meson{
 	pixel_y = 4
@@ -84966,9 +84955,8 @@
 	},
 /obj/item/airlock_electronics,
 /obj/item/airlock_electronics,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
@@ -88259,13 +88247,11 @@
 "dbO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/item/stock_parts/cell/high/plus{
+	charge = 100
 	},
 /obj/item/stack/cable_coil{
 	pixel_x = 3;


### PR DESCRIPTION
**What does this PR do:**
Reemplaza todas las high cell con 15kW de carga por high cell+ en el mapa. 

**¿por qué es bueno este pr?**
esto añade claridad dentro del juego, en el mejor de los casos con ver el sprite de la bateria deberias ser capaz de decir cuales es su carga maxima, en el peor con ver el nombre. La carga maxima de las high cell son 10kW y tener variaciones de ella con el mismo nombre pero con diferente carga es confuso para el jugador.

:cl:
tweak: reemplaza las high cell con 15kW de carga por high cell+ en el mapa. 
/:cl:

