### PR TITLE
Menos pull más grab

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -31,6 +31,8 @@
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
 	var/suicidal_hands = FALSE // Does it requires you to hold it to commit suicide with it?
 
+	var/drag_slowdown
+
 /obj/New()
 	..()
 	if(!armor)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -19,6 +19,7 @@
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
 	var/material_drop = /obj/item/stack/sheet/metal
 	var/material_drop_amount = 2
+	drag_slowdown = 1.5
 
 /obj/structure/closet/New()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -438,6 +438,7 @@
 	icon_opened = "bluespaceopen"
 	storage_capacity = 60
 	var/materials = list(MAT_METAL = 5000, MAT_PLASMA = 2500, MAT_TITANIUM = 500, MAT_BLUESPACE = 500)
+	drag_slowdown = 0
 
 /obj/structure/closet/bluespace/CheckExit(atom/movable/AM)
 	UpdateTransparency(AM, loc)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -268,6 +268,15 @@
 			. -= 1
 		if(H.status_flags & GOTTAGOFAST_METH)
 			. -= 1
+
+		if(H.pulling)
+			if(isobj(H.pulling))
+				var/obj/structure/S = H.pulling
+				if(S.drag_slowdown)
+					. = S.drag_slowdown
+			else
+				. = slowdown
+
 	return .
 
 /datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -528,15 +528,12 @@
 		stop_pulling()
 
 	var/turf/T = loc
-
 	. = ..()
 	if(.)
 		handle_footstep(loc)
 		step_count++
 
-
 		if(pulling && pulling == pullee) // we were pulling a thing and didn't lose it during our move.
-
 			if(pulling.anchored)
 				stop_pulling()
 				return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -209,7 +209,15 @@
 	set category = "Object"
 
 	if(istype(AM) && Adjacent(AM))
-		start_pulling(AM)
+		if(ishuman(usr))
+			var/mob/living/carbon/human/MM = AM
+			if(isobj(AM) || ismob(AM) && !MM.incapacitated(TRUE))
+				start_pulling(AM)
+			else
+				to_chat(usr, "<span class='warning'>You need a better grap to pull them!</span>")
+				return
+		else
+			start_pulling(AM)
 	else
 		stop_pulling()
 
@@ -520,12 +528,15 @@
 		stop_pulling()
 
 	var/turf/T = loc
+
 	. = ..()
 	if(.)
 		handle_footstep(loc)
 		step_count++
 
+
 		if(pulling && pulling == pullee) // we were pulling a thing and didn't lose it during our move.
+
 			if(pulling.anchored)
 				stop_pulling()
 				return


### PR DESCRIPTION
**What does this PR do:**
Este PR reduce la velocidad del jugador al arrastrar un locker. También sólo podrás hacer pull a jugadores que estén de pie o esposados, en cualquier otro caso será obligatorio usar grab para arrastrar sus cuerpos.

Esto último no afecta a las arañas y xenos, pero sí viceversa, para arrastrar a una araña muerta tendrán que hacer drag.

Este cambio es para dos cosas, la primera para los powergamers que les gusta arrastrar lockers mientras corren para que ningún disparo le haga daño y para los que les gusta arrastrar cuerpos muertos por toda la estación usen las camillas que para eso están, con suerte los médicos usarán más las camillas.

Este PR es una prueba, luego de ser mergeado y probado con muchos jugadores se hará una refactorización del código.

Excluyo los lockers bluespace del slowdown.

Parte de creditos a Asdfly por tirar la idea.

**Changelog:**
:cl: Ryzor
add: Lockers con slowdown
add: Limita el pull
/:cl:

