### PR TITLE
Crea el exosuit medical beamgun

### DIFF
--- a/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
+++ b/code/HISPANIA/game/mecha/equipament/tools/medical_tools.dm
@@ -1,25 +1,25 @@
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam
-	name = "exosuit prototype beamgun"
-	desc = "Equipment for medical exosuits. Generates a focused beam of medical nanites. This prototype consumes excessive energy."
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam
+	name = "exosuit beamgun"
+	desc = "Equipment for medical exosuits. Generates a focused beam of medical nanites."
 	icon = 'icons/hispania/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_medigun"
-	energy_drain = 800
+	energy_drain = 500
 	range = MELEE|RANGED
 	equip_cooldown = 10
 	var/last_check = 0
 	var/mode = 0
 	origin_tech = "materials=6;biotech=6;magnets=5;engineering=6"
-	var/obj/item/gun/medbeamgun/mech/protomedbeamgun/medigun
+	var/obj/item/gun/medbeamgun/mech/medigun
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/Initialize()
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/Initialize()
 	. = ..()
 	medigun = new(src)
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/Destroy()
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/Destroy()
 	qdel(medigun)
 	return ..()
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/Topic(href,href_list)
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/Topic(href,href_list)
 	..()
 	if(href_list["mode"])
 		mode = text2num(href_list["mode"])
@@ -32,11 +32,11 @@
 				set_ready_state(1)
 
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/get_equip_info()
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/get_equip_info()
 	return "[..()] \[<a href='?src=[UID()];mode=0'>on</a>|<a href='?src=[UID()];mode=1'>off</a>\]"
 
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/process()
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/process()
 	if(..())
 		return
 	medigun.process()
@@ -57,7 +57,7 @@
 	else
 		set_ready_state(1)
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/action(atom/target)
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/action(atom/target)
 	switch(mode)
 		if(0)
 			if(chassis.has_charge(energy_drain))
@@ -71,10 +71,19 @@
 			if(istype(target, /mob/living))
 				occupant_message("Prototype Beamgun is off")
 
-/obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam/detach()
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/detach()
 	STOP_PROCESSING(SSobj, src)
 	medigun.LoseTarget()
 	return ..()
+
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/protomechmedbeam
+	name = "exosuit prototype beamgun"
+	desc = "Equipment for medical exosuits. Generates a focused beam of medical nanites. This prototype consumes excessive energy."
+	energy_drain = 1000
+
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/protomechmedbeam/Initialize()
+	. = ..()
+	medigun.proto = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/large
 	name = "exosuit large syringe gun"

--- a/code/HISPANIA/modules/projectiles/guns/medbeam.dm
+++ b/code/HISPANIA/modules/projectiles/guns/medbeam.dm
@@ -119,8 +119,8 @@
 	target.adjustFireLoss(-4)
 
 	if(!proto)
-		target.adjustToxLoss(-1)
-		target.adjustOxyLoss(-1)
+		target.adjustToxLoss(-4)
+		target.adjustOxyLoss(-4)
 
 
 /obj/item/gun/medbeamgun/proc/on_beam_release(var/mob/living/target)
@@ -131,6 +131,7 @@
 
 //////////////////////////////Mech Version///////////////////////////////
 /obj/item/gun/medbeamgun/mech
+	max_range = 7
 	mounted = TRUE
 
 /obj/item/gun/medbeamgun/mech/Initialize()
@@ -143,7 +144,3 @@
 	STOP_PROCESSING(SSobj, src)
 //fin
 
-//////////////////////////////Proto mech varsion (beangum mounted de hispania)///////////////////////////////
-/obj/item/gun/medbeamgun/mech/protomedbeamgun/
-	max_range = 7
-	proto = TRUE

--- a/code/HISPANIA/modules/research/designs/mechfabricator_designs.dm
+++ b/code/HISPANIA/modules/research/designs/mechfabricator_designs.dm
@@ -4,7 +4,7 @@
 	id = "protomechmedbeamgun"
 	build_type = MECHFAB
 	req_tech = list("magnets" = 6,"biotech" = 7, "materials" = 7, "engineering" = 7)
-	build_path = /obj/item/mecha_parts/mecha_equipment/medical/protomechmedbeam
+	build_path = /obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/protomechmedbeam
 	materials = list(MAT_METAL=15000, MAT_GLASS = 8000, MAT_PLASMA = 4000, MAT_GOLD = 8000, MAT_DIAMOND = 2500)
 	construction_time = 250
 	category = list("Exosuit Equipment")


### PR DESCRIPTION
**What does this PR do:**
-crea el exosuit medical beamgun, solo obtenible mediante admin bus
-medideamgun es más poderoso
-el proto exosuit medical beamgun gasta más energia.

Ésto es exactamente lo que yo queria hacer en #84 pero en ese entonces no sabia como. A términos practicos éste es un pequeño nerf al proto beamgun que se crea en ciencias, un buff al beangum de tg (recordemos que no se puede obtener por métodos normales) y crea la version del mecha del beangum de tg  que es identico pero para el ody (solo obtenible mediante aminbus también)

**Changelog:**
:cl:Evankhell
balance: el proto mechmedbeamgun gasta más energia.
balance: el medibeamgun cura más oxigeno y toxinas.
add: crea la version mounted del medibeamgun.
/:cl:

