### PR TITLE
arregla la descripción del objetivo del CE

### DIFF
--- a/code/HISPANIA/game/jobs/job_objectives/engineering.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/engineering.dm
@@ -15,7 +15,6 @@
 
 /datum/job_objective/make_station_goal/get_description()
 	var/desc = "Complete the station goal."
-	desc += "([units_completed] completed.)"
 	return desc
 
 /datum/job_objective/make_station_goal/check_for_completion()


### PR DESCRIPTION
## What Does This PR Do
arregla la descripción del objetivo del CE. Ya no se muestra "x units completed". 

## Changelog
:cl:Evankhell
tweak: cambia la descripción del objetivo del CE.
/:cl:
