### PR TITLE
Los mechas se crean con una carga de 10kW

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -926,8 +926,8 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/assembly/prox_sensor,
 					/obj/item/storage/toolbox/electrical,
 					/obj/item/storage/box/flashes,
-					/obj/item/stock_parts/cell/high,
-					/obj/item/stock_parts/cell/high)
+					/obj/item/stock_parts/cell/high/plus,
+					/obj/item/stock_parts/cell/high/plus)
 	cost = 10
 	containertype = /obj/structure/closet/crate/secure/scisec
 	containername = "robotics assembly crate"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -151,7 +151,7 @@
 		C.forceMove(src)
 		cell = C
 		return
-	cell = new/obj/item/stock_parts/cell/high/plus(src)
+	cell = new/obj/item/stock_parts/cell/high(src)
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new


### PR DESCRIPTION
## What Does This PR Do
lo mismo que aca #163  pero sin tantos cambios ficticios en el repositorio. 

Adicionalmente reemplaza las baterias high de los crates robotica (los que se piden en cargo) por baterias high+ para seguir impulsando la idea de que el robotista puede trabajar independientemente de si hay alguien en RnD y hacer su job más diferenciado del científico.


**Changelog:**
:cl:Evankhell
balance: Los mechas se crean con una carga de 10kW.
tweak: los crates de robotica contienen baterias high+ en vez de high
/:cl:

