### PR TITLE
No más creación de energía de la nada: Protolathe/autolathe 

### DIFF
--- a/code/HISPANIA/modules/research/designs/power_designs.dm
+++ b/code/HISPANIA/modules/research/designs/power_designs.dm
@@ -5,8 +5,8 @@
 	req_tech = list("powerstorage" = 7, "materials" = 6, "engineering" = 6, "bluespace" = 6)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 2000, MAT_GOLD = 440, MAT_GLASS = 720, MAT_DIAMOND = 480, MAT_URANIUM = 100, MAT_TITANIUM = 600, MAT_BLUESPACE = 200)
-	construction_time=50
 	build_path = /obj/item/xenobluecellmaker
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -9,9 +9,9 @@
 	req_tech = list("powerstorage" = 1)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
-	construction_time=100
-	build_path = /obj/item/stock_parts/cell
+	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power","Machinery","initial")
+	lathe_time_factor = 0.2
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"
@@ -20,9 +20,9 @@
 	req_tech = list("powerstorage" = 2)
 	build_type = PROTOLATHE | AUTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 60)
-	construction_time=100
-	build_path = /obj/item/stock_parts/cell/high
+	build_path = /obj/item/stock_parts/cell/high/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/hyper_cell
 	name = "Hyper-Capacity Power Cell"
@@ -31,20 +31,20 @@
 	req_tech = list("powerstorage" = 5, "materials" = 5, "engineering" = 5)
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
-	construction_time=100
-	build_path = /obj/item/stock_parts/cell/hyper
+	build_path = /obj/item/stock_parts/cell/hyper/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/super_cell
 	name = "Super-Capacity Power Cell"
 	desc = "A power cell that holds 20 kW of power."
 	id = "super_cell"
-	req_tech = list("powerstorage" = 3, "materials" = 3)
+	req_tech = list("powerstorage" = 4, "materials" = 3)
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
-	construction_time=100
-	build_path = /obj/item/stock_parts/cell/super
+	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/bluespace_cell
 	name = "Bluespace Power Cell"
@@ -53,9 +53,9 @@
 	req_tech = list("powerstorage" = 6, "materials" = 5, "engineering" = 5, "bluespace" = 5)
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 120, MAT_GLASS = 160, MAT_DIAMOND = 160, MAT_TITANIUM = 300, MAT_BLUESPACE = 100)
-	construction_time=100
-	build_path = /obj/item/stock_parts/cell/bluespace
+	build_path = /obj/item/stock_parts/cell/bluespace/empty
 	category = list("Misc","Power")
+	lathe_time_factor = 0.2
 
 /datum/design/pacman
 	name = "Machine Board (PACMAN-type Generator)"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -39,7 +39,7 @@
 	name = "Super-Capacity Power Cell"
 	desc = "A power cell that holds 20 kW of power."
 	id = "super_cell"
-	req_tech = list("powerstorage" = 4, "materials" = 3)
+	req_tech = list("powerstorage" = 3, "materials" = 3)
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	build_path = /obj/item/stock_parts/cell/super/empty


### PR DESCRIPTION
## What Does This PR Do
Ésto hace que las baterias creadas en el protolathe y el autolathe inicien descargadas pero se creen mucho más rapido (a la misma velocidad que los otros stoks parts)

Las razones de por qué es bueno éste cambio están expuestas aca #151 

## Changelog
:cl:Evankhell
balance: las baterias del protolathe/autolathe inician descargadas pero se fabrican más rápido
/:cl:

