### PR TITLE
Cambios a la creación de baterias, toma 2. 

### DIFF
--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/cell/xenoblue
-	icon = 'icons/HISPANIA/obj/power.dmi'
+	icon = 'icons/hispania/obj/power.dmi'
 	icon_state = "xenobluecell"
 	item_state = "xenobluecell"
 	name = "xenobluespace power cell"
@@ -14,13 +14,13 @@
 	chargerate = 600
 
 /obj/item/xenobluecellmaker
-	icon = 'icons/HISPANIA/obj/power.dmi'
+	icon = 'icons/hispania/obj/power.dmi'
 	icon_state = "xenobluecellmaker"
 	item_state = "xenobluecellmaker"
 	lefthand_file = 'icons/hispania/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/hispania/mob/inhands/items_righthand.dmi'
 	name = "xenobluespace power cell maker"
-	desc = "High-tech power cell shell capable of creating a power cell that combines Bluespace and Xenobiology technology. Requiered a bluespace power cell and a charged slime core. Has inscribed: -en Honor a Blob Bob, Maestro de la Teleciencia, Sticky Gum, Maestra de la Xenobiologia y a Baldric Chapman, Maestro de la Robotica-"
+	desc = "High-tech power cell shell capable of creating a power cell that combines Bluespace and Xenobiology technology. Requiered a bluespace power cell and a charged slime core."
 	origin_tech = "powerstorage=6;biotech=4"
 	materials = list(MAT_GLASS = 1000)
 	var/build_step = 0
@@ -45,7 +45,5 @@
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the Xenobluespace power cell.</span>")
 				var/turf/T = get_turf(src)
-				new /obj/item/stock_parts/cell/xenoblue(T)
-				user.unEquip(src, 1)
 				qdel(src)
-
+				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue(T))

--- a/code/HISPANIA/modules/power/cell.dm
+++ b/code/HISPANIA/modules/power/cell.dm
@@ -44,6 +44,5 @@
 				qdel(I)
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the Xenobluespace power cell.</span>")
-				var/turf/T = get_turf(src)
 				qdel(src)
-				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue(T))
+				usr.put_in_hands(new /obj/item/stock_parts/cell/xenoblue)


### PR DESCRIPTION
## What Does This PR Do
-elimina nombres de pj de terceros de la xenoblue cellmaker
-al crear una xenobluecell, ésta aparece en tus manos en vez de en el suelo
-corrige las rutas de los iconos de la xenoblue cell. 

Éstos cambios fueron presentados originalemnte en #151  y se ha divido para que sea más claro.

## Changelog
:cl:Evankhell
tweak: al crear la xenobluecell, ésta aparece en tu mano en vez de en el suelo.
del: elimina nombres de pj de terceros de la xenobluespacepowercellmaker.
fix: corrige la ruta de los iconos de la xenoblue cell.
/:cl: