### PR TITLE
NSS Hispania - Viales, pinturas para pod y consola de cuentas bancarias del hop

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -747,16 +747,10 @@
 	},
 /area/shuttle/syndicate)
 "abV" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/turf/simulated/shuttle/floor{
+	icon_state = "floor4"
 	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
-	},
-/area/shuttle/pod_3)
+/area/shuttle/syndicate)
 "abW" = (
 /obj/structure/table,
 /obj/machinery/door_control{
@@ -3727,16 +3721,8 @@
 	},
 /area/shuttle/vox)
 "aha" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/pod_3)
+/turf/simulated/shuttle/floor4/vox,
+/area/shuttle/vox)
 "ahb" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -3976,10 +3962,16 @@
 	},
 /area/shuttle/syndicate)
 "ahx" = (
-/turf/simulated/shuttle/floor{
-	icon_state = "floor4"
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/area/shuttle/syndicate)
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f6";
+	icon_state = "swall_f6";
+	dir = 2
+	},
+/area/shuttle/pod_3)
 "ahy" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -5224,10 +5216,7 @@
 	pixel_x = 0;
 	pixel_y = 10
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/warning_stripes/east,
 /obj/item/clothing/glasses/welding,
 /obj/item/radio/intercom/department/security{
@@ -5346,8 +5335,22 @@
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
 "ajI" = (
-/turf/simulated/shuttle/floor4/vox,
-/area/shuttle/vox)
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/department/security{
+	pixel_x = 28;
+	pixel_y = -7
+	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_x = 28;
+	pixel_y = 5
+	},
+/obj/item/book/manual/security_space_law,
+/obj/item/stamp/magistrate,
+/obj/item/pen/multi/gold,
+/turf/simulated/floor/carpet,
+/area/magistrateoffice)
 "ajJ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 0;
@@ -7606,6 +7609,9 @@
 /area/security/permabrig)
 "ans" = (
 /obj/structure/bed,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/security/permabrig)
 "ant" = (
@@ -7950,6 +7956,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -10154,6 +10163,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/processing)
 "arA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -13179,39 +13191,9 @@
 /turf/simulated/floor/plasteel,
 /area/security/lobby)
 "avU" = (
-/obj/structure/chair,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0;
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Prisoner Processing East";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "redcorner";
-	dir = 4
-	},
-/area/security/processing)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/carpet,
+/area/magistrateoffice)
 "avV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13608,13 +13590,42 @@
 /turf/simulated/wall/r_wall,
 /area/security/prisonershuttle)
 "awC" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+/obj/structure/chair,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
 	},
-/area/shuttle/pod_1)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Prisoner Processing East";
+	dir = 8;
+	network = list("SS13");
+	pixel_x = 0;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redcorner";
+	dir = 4
+	},
+/area/security/processing)
 "awD" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -14341,19 +14352,18 @@
 	},
 /area/security/prison/cell_block/A)
 "axN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 16;
+	req_access_txt = "74"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bcarpet05"
-	},
-/area/security/prison/cell_block/A)
+/turf/simulated/floor/carpet,
+/area/magistrateoffice)
 "axO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15004,13 +15014,22 @@
 	},
 /area/security/permabrig)
 "ayR" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/shuttle/pod_1)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bcarpet05"
+	},
+/area/security/prison/cell_block/A)
 "ayS" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16157,23 +16176,16 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "aAN" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder{
-	pixel_y = 0
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/obj/item/megaphone,
-/obj/item/radio/intercom/department/security{
-	pixel_x = 28;
-	pixel_y = -7
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f5";
+	icon_state = "swall_f5";
+	dir = 2
 	},
-/obj/item/radio/intercom{
-	frequency = 1459;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 5
-	},
-/turf/simulated/floor/carpet,
-/area/magistrateoffice)
+/area/shuttle/pod_3)
 "aAO" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start{
@@ -16445,19 +16457,22 @@
 	},
 /area/shuttle/syndicate_sit)
 "aBl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/cable,
+/obj/item/megaphone,
+/turf/simulated/floor/plasteel{
+	tag = "icon-cult";
+	icon_state = "cult";
+	dir = 2
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
+/area/magistrateoffice)
 "aBm" = (
 /obj/item/stack/rods,
 /turf/space,
@@ -16583,11 +16598,26 @@
 /turf/simulated/floor/plating,
 /area/security/prisonershuttle)
 "aBC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	id_tag = "magistrateofficedoor";
+	name = "Magistrate's Office";
+	req_access_txt = "74"
 	},
-/turf/simulated/floor/carpet/arcade,
-/area/crew_quarters/arcade)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-cult";
+	icon_state = "cult";
+	dir = 2
+	},
+/area/magistrateoffice)
 "aBD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor{
@@ -16891,20 +16921,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aCi" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/security_space_law,
-/obj/item/pen/multi/gold,
-/turf/simulated/floor/carpet,
-/area/magistrateoffice)
-"aCj" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
+	dir = 2
 	},
-/obj/item/stamp/magistrate,
-/turf/simulated/floor/carpet,
-/area/magistrateoffice)
+/area/shuttle/pod_1)
+"aCj" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f9";
+	dir = 2
+	},
+/area/shuttle/pod_1)
 "aCk" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -18451,21 +18482,13 @@
 	},
 /area/crew_quarters/courtroom)
 "aFm" = (
-/obj/structure/table,
-/obj/item/gavelblock,
-/obj/item/gavelhammer,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	tag = "icon-cult";
-	icon_state = "cult";
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
 	dir = 2
 	},
-/area/magistrateoffice)
+/area/shuttle/pod_2)
 "aFn" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -19002,7 +19025,7 @@
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/simulated/floor/plating,
 /turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
+	icon_state = "swall_f9";
 	dir = 2
 	},
 /area/shuttle/pod_2)
@@ -19671,13 +19694,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aHV" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f9";
-	dir = 2
+/turf/simulated/floor/plasteel{
+	icon = 'icons/hispania/turf/floors.dmi';
+	icon_state = "L1"
 	},
-/area/shuttle/pod_2)
+/area/hallway/primary/central/north)
 "aHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20725,7 +20746,7 @@
 "aKp" = (
 /turf/simulated/floor/plasteel{
 	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L1"
+	icon_state = "L3"
 	},
 /area/hallway/primary/central/north)
 "aKq" = (
@@ -20788,25 +20809,11 @@
 	},
 /area/lawoffice)
 "aKx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Magistrate's Office";
-	req_access_txt = "74"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-cult";
-	icon_state = "cult";
-	dir = 2
+	icon = 'icons/hispania/turf/floors.dmi';
+	icon_state = "L5"
 	},
-/area/magistrateoffice)
+/area/hallway/primary/central/north)
 "aKy" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -22039,11 +22046,14 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/courtroom)
 "aNe" = (
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L3"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/hallway/primary/central/north)
+/obj/machinery/hispaniabox{
+	anchored = 1
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "aNf" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -22290,29 +22300,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aNI" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "aNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -22472,29 +22468,22 @@
 	},
 /area/crew_quarters/dorms)
 "aNW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/mob/living/simple_animal/pig,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/area/hydroponics)
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
 "aNX" = (
 /obj/machinery/disposal,
 /obj/machinery/light_switch{
@@ -22540,9 +22529,11 @@
 	},
 /area/civilian/barber)
 "aOa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L5"
+	icon_state = "L7"
 	},
 /area/hallway/primary/central/north)
 "aOb" = (
@@ -22581,22 +22572,14 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aOe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
-	},
-/area/crew_quarters/dorms)
+/turf/simulated/floor/carpet/arcade,
+/area/crew_quarters/arcade)
 "aOf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23647,8 +23630,21 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 1
+	},
+/area/crew_quarters/dorms)
 "aQu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -24135,15 +24131,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aRm" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/book/manual/hispania_recipes,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+	icon = 'icons/hispania/turf/floors.dmi';
+	icon_state = "L9"
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/primary/central/north)
 "aRn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24295,20 +24287,23 @@
 	},
 /area/hallway/primary/starboard/west)
 "aRz" = (
-/obj/machinery/light{
-	icon_state = "tube1";
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Dormitory East";
-	dir = 8;
-	network = list("SS13")
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -5;
+	pixel_y = 30;
+	req_access_txt = "0"
 	},
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/bell/medbay,
 /turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 2
+	tag = "icon-whitebluefull";
+	icon_state = "whitebluefull"
 	},
-/area/crew_quarters/dorms)
+/area/space)
 "aRA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24527,13 +24522,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
 "aRV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L7"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = 0
 	},
-/area/hallway/primary/central/north)
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "aRW" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -24554,24 +24552,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aRY" = (
-/obj/machinery/r_n_d/circuit_imprinter{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/effect/decal/warning_stripes/southeast,
+/obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
-/area/toxins/lab)
+/area/assembly/robotics)
 "aRZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plating,
 /area/maintenance/electrical)
 "aSa" = (
@@ -25779,6 +25767,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
@@ -25901,11 +25892,14 @@
 	},
 /area/medical/reception)
 "aUP" = (
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L9"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/area/hallway/primary/central/north)
+/obj/machinery/vending/walldrobe/cap{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet,
+/area/crew_quarters/captain/bedroom)
 "aUQ" = (
 /turf/simulated/wall,
 /area/crew_quarters/toilet)
@@ -26192,9 +26186,17 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
 "aVw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Dormitory East";
+	dir = 8;
+	network = list("SS13")
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -27546,15 +27548,33 @@
 	},
 /area/security/nuke_storage)
 "aXS" = (
-/obj/machinery/lapvend,
+/obj/machinery/vending/modularpc,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "aXT" = (
-/obj/machinery/computer/cryopod/robot{
-	pixel_x = -32
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/mech_bay_recharge_floor,
-/area/assembly/chargebay)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/multitool,
+/obj/item/multitool,
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "aXU" = (
 /obj/item/flag/mime,
 /obj/machinery/power/apc{
@@ -28610,8 +28630,15 @@
 	},
 /area/crew_quarters/bar)
 "aZS" = (
-/turf/simulated/floor/bluegrid,
-/area/assembly/chargebay)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/obj/effect/landmark/start{
+	name = "Roboticist"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "aZT" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -28906,7 +28933,7 @@
 /area/chapel/office)
 "baA" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box/full,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 5
@@ -28940,6 +28967,9 @@
 	d2 = 2;
 	icon_state = "1-2";
 	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -29412,21 +29442,18 @@
 	},
 /area/crew_quarters/dorms)
 "bbx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
 	level = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
-	},
-/area/crew_quarters/dorms)
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "bby" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
@@ -31159,17 +31186,13 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
 "beB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/r_n_d/circuit_imprinter{
+	pixel_x = 3;
+	pixel_y = 5
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
+/obj/effect/decal/warning_stripes/southeast,
 /turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/toxins/lab)
 "beC" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape)
@@ -31210,13 +31233,12 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "beH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/chapel/office)
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "beI" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -31783,27 +31805,17 @@
 /area/crew_quarters/dorms)
 "bfz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "neutralcorner";
+	dir = 2
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/area/hydroponics)
+/area/crew_quarters/dorms)
 "bfA" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -32055,13 +32067,13 @@
 /area/chapel/office)
 "bfW" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box{
+/obj/item/storage/fancy/candle_box/full{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/fancy/candle_box{
-	pixel_x = 3;
+/obj/item/storage/fancy/candle_box/full,
+/obj/item/storage/fancy/candle_box/full{
+	pixel_x = -3;
 	pixel_y = -3
 	},
 /turf/simulated/floor/plating,
@@ -32604,26 +32616,53 @@
 	},
 /area/hallway/primary/central/north)
 "bhb" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion";
-	tag = "icon-propulsion (EAST)"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/space,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/area/shuttle/transport)
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/area/hydroponics)
 "bhc" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/hispaniabox{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/mob/living/simple_animal/pig,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/area/hydroponics)
 "bhd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33371,17 +33410,16 @@
 	},
 /area/chapel/office)
 "biy" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion";
-	tag = "icon-propulsion (EAST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/space,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/shuttle/transport)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/chapel/office)
 "biz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33473,12 +33511,28 @@
 	},
 /area/hallway/primary/central/nw)
 "biI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "chapel"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/chapel/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/area/hydroponics)
 "biJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35751,7 +35805,7 @@
 /area/chapel/main)
 "bmU" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box/full,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35907,21 +35961,29 @@
 	},
 /area/hallway/primary/central/north)
 "bnj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion";
+	tag = "icon-propulsion (EAST)"
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 1
+/turf/space,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f6";
+	dir = 2
 	},
-/area/hallway/secondary/entry)
+/area/shuttle/transport)
 "bnk" = (
-/obj/structure/table,
-/obj/item/crowbar/large,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion";
+	tag = "icon-propulsion (EAST)"
+	},
+/turf/space,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
+	dir = 2
+	},
+/area/shuttle/transport)
 "bnl" = (
 /obj/machinery/camera{
 	c_tag = "Bar East";
@@ -36337,23 +36399,22 @@
 	},
 /area/crew_quarters/kitchen)
 "bok" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -5;
-	pixel_y = 30;
-	req_access_txt = "0"
-	},
 /obj/structure/table,
-/obj/item/folder/white,
-/obj/item/bell/medbay,
-/turf/simulated/floor/plasteel{
-	tag = "icon-whitebluefull";
-	icon_state = "whitebluefull"
+/obj/item/stack/sheet/plasteel{
+	amount = 10
 	},
-/area/medical/reception)
+/obj/item/stack/cable_coil,
+/obj/item/flash,
+/obj/item/flash,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "bol" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -36723,9 +36784,11 @@
 /area/hallway/secondary/entry)
 "boX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "boY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -37084,12 +37147,18 @@
 	},
 /area/crew_quarters/bar)
 "bpD" = (
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHWEST)";
-	icon_state = "whiteblue";
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	name = "Cargo Desk";
+	req_access_txt = "50"
 	},
-/area/medical/genetics)
+/obj/structure/noticeboard{
+	pixel_y = 27
+	},
+/obj/item/bell/cargo,
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bpE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -37246,16 +37315,15 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "bpU" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
 	},
-/area/shuttle/pod_4)
+/area/chapel/main)
 "bpV" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -37308,12 +37376,14 @@
 	},
 /area/hydroponics)
 "bqb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bqc" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -37867,12 +37937,14 @@
 	},
 /area/hallway/secondary/entry)
 "brm" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTH)";
-	icon_state = "whiteblue";
-	dir = 1
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/medical/genetics)
+/area/crew_quarters/kitchen)
 "brn" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -37900,16 +37972,18 @@
 	},
 /area/crew_quarters/kitchen)
 "brp" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/shuttle/pod_4)
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "brq" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "stairs-r"
@@ -38128,33 +38202,9 @@
 	},
 /area/bridge)
 "brT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
-	name = "Research and Development Desk";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 2;
-	icon_state = "open";
-	id_tag = "rdlab";
-	name = "Research and Development Lab Shutters";
-	opacity = 0
-	},
-/obj/item/bell/science,
-/turf/simulated/floor/plating,
-/area/toxins/lab)
+/obj/structure/chair/stool,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "brU" = (
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -38176,11 +38226,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/carpet,
-/area/security/vacantoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "brY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38495,25 +38547,11 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bsI" = (
-/obj/structure/table,
-/obj/item/phone{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/turret_protected/ai_upload)
+/turf/simulated/floor/wood,
+/area/civilian/pet_store)
 "bsJ" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -38828,20 +38866,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bts" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+/obj/machinery/door/airlock/maintenance{
+	name = "Science Maintenance";
+	req_access_txt = "47"
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "white"
 	},
-/area/crew_quarters/locker/locker_toilet)
+/area/maintenance/asmaint2)
 "btt" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -40911,15 +40943,24 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxy" = (
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 1
+	},
+/area/crew_quarters/dorms)
 "bxz" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/grassybush,
@@ -42898,16 +42939,15 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bBl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit)
 "bBm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/warning_stripes/north,
@@ -43100,8 +43140,14 @@
 /turf/simulated/floor/carpet,
 /area/security/vacantoffice)
 "bBJ" = (
-/turf/simulated/wall,
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/security/vacantoffice)
 "bBK" = (
 /obj/effect/decal/warning_stripes/southeastcorner,
 /obj/effect/decal/warning_stripes/northeastcorner,
@@ -44192,16 +44238,28 @@
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai_upload)
 "bDW" = (
-/obj/machinery/door/airlock/research{
-	name = "Research Division Access";
-	req_access_txt = "47"
+/obj/structure/table,
+/obj/item/phone{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "dark"
 	},
-/area/medical/research)
+/area/turret_protected/ai_upload)
 "bDX" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -44418,9 +44476,23 @@
 /turf/simulated/wall,
 /area/medical/reception)
 "bEz" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall,
-/area/medical/research)
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "bEA" = (
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
@@ -44991,21 +45063,9 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bFJ" = (
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/machinery/camera{
-	c_tag = "Medbay Genetics";
-	network = list("SS13")
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25;
-	pixel_y = 0
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (NORTHEAST)";
-	icon_state = "whiteblue";
-	dir = 5
-	},
-/area/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "bFK" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/wood,
@@ -45427,7 +45487,6 @@
 /area/medical/chemistry)
 "bGw" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/obj/item/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -45620,17 +45679,32 @@
 /area/toxins/lab)
 "bGL" = (
 /obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Research and Development Desk";
+	req_access_txt = "47"
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	name = "Cargo Desk";
-	req_access_txt = "50"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
-/obj/structure/noticeboard{
-	pixel_y = 27
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "open";
+	id_tag = "rdlab";
+	name = "Research and Development Lab Shutters";
+	opacity = 0
 	},
-/obj/item/bell/cargo,
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
+/obj/item/bell/science,
+/turf/simulated/floor/plating,
+/area/toxins/lab)
 "bGM" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/beach/sand,
@@ -46256,18 +46330,18 @@
 /turf/simulated/wall,
 /area/assembly/robotics)
 "bIb" = (
-/obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/effect/decal/warning_stripes/northwest,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "bIc" = (
 /obj/structure/table,
 /obj/machinery/door_control{
@@ -46343,19 +46417,10 @@
 	},
 /area/medical/reception)
 "bIi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/wall,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bIj" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -46382,25 +46447,11 @@
 	},
 /area/medical/reception)
 "bIk" = (
-/obj/machinery/camera{
-	c_tag = "Research Access";
-	dir = 2;
-	network = list("Research","SS13")
-	},
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/obj/structure/sign/securearea,
+/turf/simulated/wall,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bIl" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -46629,7 +46680,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/piano,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bIJ" = (
@@ -46948,17 +46998,15 @@
 	},
 /area/engine/gravitygenerator)
 "bJo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office)
+/area/assembly/robotics)
 "bJp" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
@@ -47572,15 +47620,18 @@
 /turf/simulated/shuttle/plating,
 /area/shuttle/escape)
 "bKn" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light{
+/obj/machinery/shower{
+	tag = "icon-shower (WEST)";
+	icon_state = "shower";
 	dir = 8
 	},
-/obj/effect/decal/warning_stripes/west,
+/obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bKo" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -47727,12 +47778,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bKH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "bKI" = (
 /obj/machinery/light{
 	dir = 8
@@ -48023,16 +48081,11 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bLn" = (
-/obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
+/obj/machinery/computer/cryopod/robot{
+	pixel_x = -32
 	},
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/floor/mech_bay_recharge_floor,
+/area/assembly/chargebay)
 "bLo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -48351,13 +48404,12 @@
 	},
 /area/medical/chemistry)
 "bLR" = (
-/obj/machinery/light/small,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/disposal)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bLS" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute{
@@ -48379,23 +48431,20 @@
 	},
 /area/medical/biostorage)
 "bLT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
+/turf/simulated/floor/bluegrid,
+/area/assembly/chargebay)
+"bLU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
-"bLU" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "bLV" = (
 /obj/item/storage/firstaid/o2{
 	pixel_x = 5;
@@ -48630,9 +48679,11 @@
 /turf/simulated/wall,
 /area/maintenance/maintcentral)
 "bMt" = (
-/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/assembly/chargebay)
 "bMu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48672,30 +48723,20 @@
 	},
 /area/quartermaster/office)
 "bMz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/area/medical/genetics)
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/bonesetter,
+/obj/item/bonegel,
+/obj/item/surgicaldrill,
+/obj/item/FixOVein,
+/obj/item/stack/medical/bruise_pack/advanced,
+/turf/simulated/floor/plasteel,
+/area/assembly/robotics)
 "bMA" = (
 /obj/machinery/mineral/ore_redemption,
 /turf/simulated/floor/plasteel,
@@ -49157,28 +49198,10 @@
 	},
 /area/assembly/robotics)
 "bNi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitecorner"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/multitool,
-/obj/item/multitool,
-/turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "bNj" = (
 /obj/machinery/firealarm{
@@ -49213,16 +49236,20 @@
 	},
 /area/assembly/robotics)
 "bNk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
+/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northwest,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bNl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49230,27 +49257,43 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
 "bNm" = (
+/obj/machinery/camera{
+	c_tag = "Research Access";
+	dir = 2;
+	network = list("Research","SS13")
+	},
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
 	pixel_x = 11;
 	pixel_y = 0
 	},
-/obj/effect/decal/warning_stripes/southeast,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bNn" = (
-/turf/simulated/wall/r_wall,
-/area/medical/research)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bNo" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/stethoscope,
@@ -49428,6 +49471,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/piano,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bNC" = (
@@ -49458,15 +49502,14 @@
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bNE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start{
-	name = "Roboticist"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/assembly/chargebay)
 "bNF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49560,10 +49603,7 @@
 "bNN" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /obj/item/radio/intercom{
 	frequency = 1459;
 	name = "station intercom (General)";
@@ -49646,9 +49686,20 @@
 	},
 /area/toxins/lab)
 "bNV" = (
-/obj/structure/sign/securearea,
-/turf/simulated/wall/r_wall,
-/area/medical/research)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bNW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -49709,16 +49760,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bOa" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
+/obj/machinery/camera{
+	c_tag = "Research Hallway North";
+	dir = 1;
+	network = list("Research","SS13")
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/medical/research)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bOb" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/sign/securearea{
@@ -49959,10 +50011,10 @@
 	opacity = 0
 	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bOw" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50247,21 +50299,10 @@
 /area/medical/biostorage)
 "bOS" = (
 /obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/flash,
-/obj/item/flash,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/item/crowbar/large,
+/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/assembly/chargebay)
 "bOT" = (
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 5;
@@ -50356,21 +50397,17 @@
 /turf/simulated/floor/plasteel,
 /area/medical/paramedic)
 "bPd" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
+/obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Research Hallway Entrance";
-	dir = 2;
-	network = list("Research","SS13")
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/turf/simulated/floor/plasteel,
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bPe" = (
 /obj/vehicle/ambulance,
 /obj/effect/decal/warning_stripes/west,
@@ -50445,38 +50482,53 @@
 	},
 /area/medical/reception)
 "bPi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitecorner"
-	},
-/area/medical/research)
-"bPj" = (
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
-	dir = 2
+	icon_state = "white"
 	},
-/area/medical/research)
-"bPk" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
+/area/medical/research{
+	name = "Research Division"
+	})
+"bPj" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
 	dir = 8;
-	icon_state = "whitecorner"
+	location = "Research Division"
 	},
-/area/medical/research)
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bot"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"bPk" = (
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Research Division Delivery";
+	req_access_txt = "47"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "delivery"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bPl" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -50499,9 +50551,16 @@
 	},
 /area/medical/reception)
 "bPn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
 /turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/assembly/robotics)
 "bPo" = (
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
@@ -50532,11 +50591,10 @@
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
 "bPt" = (
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
+/turf/simulated/wall/r_wall,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bPu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50550,23 +50608,27 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bPv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = -4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/item/storage/box/masks,
+/obj/item/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/item/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "white"
+	icon_state = "whitehall";
+	dir = 4
 	},
-/area/medical/genetics)
+/area/assembly/robotics)
 "bPw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -50610,13 +50672,8 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus{
 	pixel_x = 5;
 	pixel_y = -5
 	},
@@ -50714,26 +50771,16 @@
 /turf/simulated/floor/plasteel,
 /area/medical/chemistry)
 "bPH" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/machinery/light/small,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/floor/plating,
+/area/maintenance/disposal)
 "bPI" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -50875,16 +50922,20 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "bPU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/power/apc{
 	dir = 8;
-	icon_state = "white"
+	name = "west bump";
+	pixel_x = -24;
+	shock_proof = 0
 	},
-/area/medical/genetics)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "bPV" = (
 /obj/effect/landmark/start{
 	name = "Cargo Technician"
@@ -50968,20 +51019,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+	pixel_x = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "bQf" = (
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -51265,14 +51306,13 @@
 	},
 /area/crew_quarters/captain/bedroom)
 "bQz" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/vending/walldrobe/cap{
-	pixel_y = 28
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/captain/bedroom)
+/turf/simulated/floor/plasteel,
+/area/assembly/chargebay)
 "bQA" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -51726,15 +51766,12 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bRk" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bRl" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/window/reinforced/tinted{
@@ -51776,26 +51813,19 @@
 	},
 /area/assembly/robotics)
 "bRn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "bot"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bRo" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -51902,18 +51932,10 @@
 	},
 /area/shuttle/administration)
 "bRy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bRz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52079,42 +52101,35 @@
 	},
 /area/assembly/robotics)
 "bRP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/structure/closet/firecloset,
+/obj/effect/decal/warning_stripes/southwest,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/area/medical/research{
+	name = "Research Division"
+	})
+"bRQ" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
-"bRQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitepurplecorner"
-	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bRR" = (
 /obj/machinery/conveyor/east{
 	id = "QMLoad2"
@@ -52129,27 +52144,18 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "bRT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = "90Curve"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurple"
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bRU" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -52507,17 +52513,18 @@
 /turf/simulated/floor/plating,
 /area/medical/chemistry)
 "bSz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/research{
+	name = "Research Division Access";
+	req_access_txt = "47"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitepurplecorner"
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bSA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposal Access";
@@ -52620,21 +52627,18 @@
 	},
 /area/medical/genetics)
 "bSI" = (
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
-	icon_state = "whiteblue";
-	dir = 4
-	},
-/area/medical/genetics)
-"bSJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
+/obj/machinery/recharge_station,
+/obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/area/medical/research{
+	name = "Research Division"
+	})
+"bSJ" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bSK" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -52786,22 +52790,17 @@
 	},
 /area/medical/medbay2)
 "bSW" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Research Hallway West";
+	network = list("Research","SS13")
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bSX" = (
 /obj/effect/decal/warning_stripes/blue/partial,
 /turf/simulated/floor/plasteel{
@@ -52821,12 +52820,17 @@
 	},
 /area/assembly/robotics)
 "bSZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/office)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitecorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bTa" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -53077,18 +53081,14 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bTw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bTx" = (
 /obj/machinery/light{
 	dir = 4;
@@ -53481,11 +53481,11 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
 "bUh" = (
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bUi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53783,25 +53783,35 @@
 /area/assembly/robotics)
 "bUI" = (
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
-"bUJ" = (
-/obj/machinery/camera{
-	c_tag = "Research Hallway North";
 	dir = 1;
-	network = list("Research","SS13")
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
+	},
+/area/medical/genetics)
+"bUJ" = (
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/machinery/camera{
+	c_tag = "Medbay Genetics";
+	network = list("SS13")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25;
+	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
-/area/medical/research)
+/area/medical/genetics)
 "bUK" = (
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bUL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53843,31 +53853,13 @@
 	},
 /area/medical/sleeper)
 "bUN" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/bonesetter,
-/obj/item/bonegel,
-/obj/item/surgicaldrill,
-/obj/item/FixOVein,
-/obj/item/stack/medical/bruise_pack/advanced,
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bUO" = (
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Research Division Delivery";
-	req_access_txt = "47"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -53875,30 +53867,35 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "delivery"
+/obj/machinery/camera{
+	c_tag = "Research Hallway Entrance";
+	dir = 2;
+	network = list("Research","SS13")
 	},
-/area/medical/research)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/turf/simulated/floor/plasteel,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bUP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	dir = 8;
-	location = "Research Division"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot"
-	},
-/area/medical/research)
+/obj/effect/decal/warning_stripes/yellow/hollow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bUQ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54302,11 +54299,11 @@
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
 "bVA" = (
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitecorner"
-	},
-/area/assembly/robotics)
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/medical/research{
+	name = "Research Division"
+	})
 "bVB" = (
 /obj/machinery/message_server,
 /obj/machinery/firealarm{
@@ -54316,16 +54313,11 @@
 /turf/simulated/floor/bluegrid,
 /area/server)
 "bVC" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/circular_saw,
+/obj/machinery/cryopod/robot,
 /turf/simulated/floor/plasteel,
-/area/assembly/robotics)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bVD" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
@@ -54344,14 +54336,32 @@
 	},
 /area/assembly/robotics)
 "bVE" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitecorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bVF" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/robotics)
+/obj/effect/landmark{
+	name = "lightsout"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitehall";
+	dir = 2
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bVG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -54520,15 +54530,30 @@
 	},
 /area/hallway/primary/central/se)
 "bVU" = (
-/obj/machinery/status_display{
-	layer = 4;
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
 	pixel_x = 0;
-	pixel_y = 32
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
-/area/medical/research)
+/area/medical/genetics)
 "bVV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -54557,68 +54582,79 @@
 	},
 /area/medical/genetics)
 "bVW" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/tank/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitehall";
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/area/assembly/robotics)
-"bVX" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/obj/machinery/disposal,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
+	dir = 1;
+	icon_state = "white"
+	},
+/area/medical/genetics)
+"bVX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10;
+	level = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "bVY" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/sign/poster/random{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
-	icon_state = "whiteblue";
-	dir = 4
+	icon_state = "white"
 	},
-/area/medical/genetics)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bVZ" = (
-/obj/structure/table/glass,
-/obj/item/hand_labeler,
-/obj/item/roller,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25;
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
 	pixel_y = 0
 	},
-/obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (WEST)";
-	icon_state = "whiteblue";
-	dir = 8
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "bWa" = (
@@ -54651,18 +54687,29 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bWc" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "station intercom (General)";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
-	icon_state = "whiteblue";
-	dir = 4
+	icon_state = "dark"
 	},
-/area/medical/genetics)
+/area/toxins/server)
 "bWd" = (
 /turf/simulated/wall,
 /area/medical/genetics_cloning)
@@ -54695,33 +54742,79 @@
 /turf/simulated/wall/r_wall,
 /area/medical/genetics)
 "bWj" = (
-/obj/machinery/dna_scannernew,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Research Server Room";
+	dir = 2;
+	network = list("Research","SS13");
+	pixel_x = 22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
+	icon_state = "dark"
 	},
-/area/medical/genetics)
+/area/toxins/server)
 "bWk" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bWl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bWm" = (
 /obj/structure/chair/comfy/teal{
 	dir = 1
@@ -54736,15 +54829,25 @@
 	},
 /area/medical/medbay2)
 "bWn" = (
-/obj/machinery/camera{
-	c_tag = "Research Hallway West";
-	network = list("Research","SS13")
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bWo" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 0;
@@ -54758,34 +54861,70 @@
 	},
 /area/medical/medbay2)
 "bWp" = (
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteredcorner"
-	},
-/area/medical/research)
-"bWq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitered"
-	},
-/area/medical/research)
-"bWr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Science Maintenance";
-	req_access_txt = "47"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/maintenance/asmaint2)
+/area/medical/research{
+	name = "Research Division"
+	})
+"bWq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"bWr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "bWs" = (
 /obj/structure/table,
 /obj/item/soap/nanotrasen,
@@ -55222,11 +55361,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "bXj" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whiteredcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/quartermaster/office)
 "bXk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55302,6 +55445,10 @@
 /turf/simulated/floor/bluegrid,
 /area/server)
 "bXs" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitebluecorner";
@@ -55339,14 +55486,17 @@
 	},
 /area/engine/gravitygenerator)
 "bXv" = (
-/obj/machinery/dna_scannernew,
-/obj/structure/window/reinforced{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (EAST)";
-	icon_state = "whiteblue";
-	dir = 4
+	dir = 1;
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "bXw" = (
@@ -55600,7 +55750,15 @@
 	},
 /area/medical/medbay2)
 "bXQ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel{
+	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/genetics)
@@ -55657,22 +55815,35 @@
 /turf/simulated/floor/plating,
 /area/medical/cmo)
 "bXV" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/structure/window/reinforced,
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitepurplefull";
-	tag = "icon-whitepurple (WEST)"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "bXW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/hand_labeler,
+/obj/item/roller,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	icon_state = "tube1";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "bXX" = (
@@ -55857,15 +56028,14 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/hor)
 "bYk" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Geneticist"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	dir = 1;
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -55889,17 +56059,14 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "bYn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -56634,18 +56801,14 @@
 	},
 /area/medical/cmo)
 "bZB" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/dna_scannernew,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	dir = 8;
+	icon_state = "whitepurplefull";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/genetics)
 "bZC" = (
@@ -57162,17 +57325,26 @@
 	},
 /area/medical/genetics_cloning)
 "cab" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/obj/effect/landmark/start{
-	name = "Geneticist"
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen{
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+	icon_state = "dark"
 	},
-/area/medical/genetics)
+/area/toxins/server)
 "cac" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57183,14 +57355,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cad" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cae" = (
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -57223,20 +57396,18 @@
 	},
 /area/shuttle/administration)
 "caj" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/server)
 "cak" = (
 /obj/machinery/computer/communications,
 /turf/simulated/shuttle/floor{
@@ -57244,13 +57415,16 @@
 	},
 /area/shuttle/administration)
 "cal" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cam" = (
 /turf/simulated/wall,
 /area/quartermaster/miningdock)
@@ -57331,14 +57505,21 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cau" = (
-/obj/effect/decal/warning_stripes/yellow/hollow,
-/obj/structure/reagent_dispensers/oil,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteredcorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cav" = (
-/obj/machinery/light,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whiteredcorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "caw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
@@ -57353,12 +57534,27 @@
 	},
 /area/hallway/primary/central/sw)
 "cax" = (
-/obj/machinery/cryopod/robot,
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitered"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cay" = (
-/turf/simulated/wall,
-/area/medical/robotics)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "caz" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32;
@@ -57378,25 +57574,25 @@
 /turf/simulated/wall,
 /area/medical/sleeper)
 "caB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6;
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11;
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "caC" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -57579,6 +57775,12 @@
 	},
 /area/medical/cryo)
 "caM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -57586,17 +57788,13 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	icon_state = "freezerfloor"
 	},
-/area/medical/research)
+/area/medical/cryo)
 "caN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57660,25 +57858,16 @@
 	},
 /area/medical/cmo)
 "caS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	initialize_directions = 11;
-	level = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "caT" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start{
@@ -57723,56 +57912,44 @@
 	},
 /area/medical/cmo)
 "caW" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue (SOUTHEAST)";
-	icon_state = "whiteblue";
-	dir = 6
+	dir = 1;
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "caX" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 2;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
+/obj/machinery/computer/scan_consolenew,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkblue"
+	dir = 8;
+	icon_state = "whitepurplefull";
+	tag = "icon-whitepurple (WEST)"
 	},
-/area/medical/cmo)
+/area/medical/genetics)
 "caY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
-/area/medical/research)
+/area/medical/genetics)
 "caZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+/obj/machinery/dna_scannernew,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
+	},
+/area/medical/genetics)
 "cba" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57891,26 +58068,13 @@
 /turf/simulated/wall/r_wall,
 /area/toxins/storage)
 "cbk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cbl" = (
 /obj/machinery/computer/teleporter,
 /turf/simulated/floor/plating,
@@ -57934,27 +58098,13 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cbn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 9;
 	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cbo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58456,100 +58606,125 @@
 	},
 /area/medical/genetics_cloning)
 "cce" = (
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/server)
+"ccf" = (
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8";
+	icon_state = "4-8";
+	pixel_x = 0;
 	tag = ""
 	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"ccg" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8";
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"cch" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
 	tag = ""
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"cci" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/landmark/start{
-	name = "Scientist"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
-"ccf" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
-"ccg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
-"cch" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
-"cci" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "ccj" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cck" = (
 /obj/structure/table/glass,
 /obj/item/hemostat{
@@ -58595,16 +58770,40 @@
 /area/hallway/primary/central/se)
 "ccp" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/area/medical/research)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "ccq" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
@@ -58681,6 +58880,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/bodyscanner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteblue";
@@ -58688,12 +58888,24 @@
 	},
 /area/medical/sleeper)
 "ccw" = (
-/obj/machinery/bodyscanner,
-/turf/simulated/floor/plasteel{
-	tag = "icon-whiteblue";
-	icon_state = "whiteblue"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/area/medical/sleeper)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/toxins/server)
 "ccx" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -58966,29 +59178,18 @@
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "ccQ" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "station intercom (General)";
-	pixel_y = 25
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/effect/landmark/start{
+	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
-/area/toxins/server)
+/area/medical/genetics)
 "ccR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -59066,30 +59267,15 @@
 	},
 /area/toxins/server_coldroom)
 "ccW" = (
-/obj/machinery/camera{
-	c_tag = "Research Server Room";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 22
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_y = -22
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/cold_sink/freezer{
+	current_temperature = 73;
+	dir = 1;
+	on = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -59159,26 +59345,34 @@
 	},
 /area/engine/gravitygenerator)
 "cdb" = (
-/obj/machinery/power/apc{
+/obj/item/cartridge/signal/toxins,
+/obj/item/cartridge/signal/toxins{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/cartridge/signal/toxins{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
 	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+	network = list("Research","SS13")
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/item/clothing/glasses/welding/superior,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen{
-	anchored = 1
+/obj/structure/table/glass,
+/obj/machinery/vending/walldrobe/rd{
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/toxins/server)
+/area/crew_quarters/hor)
 "cdc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -59195,16 +59389,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cdd" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=HOP";
-	location = "CHE"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/turf/simulated/floor/plasteel{
 	dir = 9;
-	pixel_y = 0
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/se)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cde" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -59266,15 +59463,19 @@
 	},
 /area/crew_quarters/hor)
 "cdj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/disks,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "cdk" = (
@@ -59302,16 +59503,16 @@
 	},
 /area/shuttle/administration)
 "cdn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/landmark/start{
+	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "cdo" = (
@@ -59515,16 +59716,20 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/qm)
 "cdF" = (
-/obj/machinery/alarm{
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cdG" = (
 /obj/structure/table,
 /obj/machinery/status_display{
@@ -59556,36 +59761,23 @@
 "cdL" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	icon_state = "pipe-j1s";
-	name = "Sci RD Office 2";
-	sortType = 13
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
+	dir = 4;
 	initialize_directions = 11;
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cdM" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -60050,19 +60242,14 @@
 	},
 /area/toxins/server_coldroom)
 "ceJ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
+/obj/machinery/computer/scan_consolenew,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
+/area/medical/genetics)
 "ceK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60076,51 +60263,33 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "ceM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 5;
 	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "ceN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
+	icon_state = "white"
 	},
-/area/medical/cryo)
+/area/medical/research{
+	name = "Research Division"
+	})
 "ceO" = (
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -60140,6 +60309,11 @@
 	icon_state = "white"
 	},
 /area/crew_quarters/hor)
+"ceR" = (
+/turf/simulated/shuttle/floor{
+	icon_state = "floor3"
+	},
+/area/shuttle/administration)
 "ceS" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -60843,16 +61017,30 @@
 	},
 /area/medical/cmo)
 "cfV" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
-/turf/simulated/floor/plasteel,
-/area/quartermaster/qm)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbluecorners"
+	},
+/area/medical/cmo)
 "cfW" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -61106,10 +61294,30 @@
 	},
 /area/shuttle/administration)
 "cgx" = (
-/turf/simulated/shuttle/floor{
-	icon_state = "floor3"
+/obj/machinery/door_control{
+	id = "mechpod";
+	name = "Mechanic's Inner Door Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "70"
 	},
-/area/shuttle/administration)
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/pod_paint_bucket,
+/obj/item/pod_paint_bucket,
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "cgy" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
@@ -61196,15 +61404,19 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cgJ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=HOP";
+	location = "CHE"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitehall"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
-/area/medical/research)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/se)
 "cgK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61476,18 +61688,33 @@
 /turf/simulated/wall,
 /area/maintenance/asmaint)
 "chg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "viro_lab_airlock_control";
+	name = "Virology Lab Access Console";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access_txt = "39";
+	tag_exterior_door = "viro_lab_airlock_exterior";
+	tag_interior_door = "viro_lab_airlock_interior"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/item/storage/fancy/vials{
+	contents = newlist()
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 2;
+	icon_state = "whitegreen";
+	tag = "icon-whitehall (WEST)"
 	},
-/area/toxins/server)
+/area/medical/virology)
 "chh" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -61648,34 +61875,27 @@
 	},
 /area/medical/surgery1)
 "chv" = (
-/obj/structure/chair/office/light,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f6";
+	icon_state = "swall_f6";
+	dir = 2
 	},
-/area/toxins/server)
+/area/shuttle/pod_4)
 "chw" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f5";
+	icon_state = "swall_f5";
+	dir = 2
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/server)
+/area/shuttle/pod_4)
 "chx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -61848,46 +62068,83 @@
 	},
 /area/medical/surgery1)
 "chM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/alarm{
+	dir = 4;
+	icon_state = "alarm0";
+	pixel_x = -22
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"chN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"chO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	icon_state = "pipe-j1s";
+	name = "Sci RD Office 2";
+	sortType = 13
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
-"chN" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
-"chO" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24;
-	shock_proof = 0
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "whitehall"
-	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "chP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61986,19 +62243,15 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "chV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/medical/research)
+/area/crew_quarters/hor)
 "chW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63073,21 +63326,6 @@
 	temperature = 0
 	},
 /area/toxins/server_coldroom)
-"cjK" = (
-/obj/machinery/alarm{
-	dir = 1;
-	icon_state = "alarm0";
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/unary/cold_sink/freezer{
-	current_temperature = 73;
-	dir = 1;
-	on = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/toxins/server)
 "cjL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -63125,35 +63363,6 @@
 	name = "west bump";
 	pixel_x = -24;
 	shock_proof = 0
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/hor)
-"cjP" = (
-/obj/item/cartridge/signal/toxins,
-/obj/item/cartridge/signal/toxins{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/cartridge/signal/toxins{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("Research","SS13")
-	},
-/obj/item/clothing/glasses/welding/superior,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/machinery/vending/walldrobe/rd{
-	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -63201,14 +63410,10 @@
 /area/crew_quarters/hor)
 "cjT" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
 	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -63438,17 +63643,15 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "darkbluecorners"
+	icon_state = "whiteblue";
+	tag = "icon-whitehall (WEST)"
 	},
-/area/medical/cmo)
+/area/medical/surgery2)
 "cks" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -63604,13 +63807,19 @@
 	},
 /area/medical/medbreak)
 "ckG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/medical/research)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/quartermaster/qm)
 "ckH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63819,13 +64028,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "clb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 2;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkblue"
+	},
+/area/medical/cmo)
 "clc" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/firealarm{
@@ -63929,14 +64145,17 @@
 	},
 /area/medical/medbreak)
 "clj" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "clk" = (
 /obj/machinery/washing_machine,
 /obj/machinery/alarm{
@@ -63967,8 +64186,12 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
 "cln" = (
-/obj/effect/landmark/start{
-	name = "Scientist"
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63976,7 +64199,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "clo" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -64291,16 +64516,26 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "clY" = (
-/obj/item/radio/intercom{
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/power/apc{
 	dir = 8;
-	name = "station intercom (General)";
-	pixel_x = -28
+	name = "west bump";
+	pixel_x = -24;
+	shock_proof = 0
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "clZ" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -64384,21 +64619,21 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "cmi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cmj" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
@@ -64583,17 +64818,25 @@
 	},
 /area/medical/medbreak)
 "cmv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/medical/research)
+/area/medical/medbreak)
 "cmw" = (
 /obj/machinery/computer/crew,
 /obj/machinery/light{
@@ -64673,22 +64916,21 @@
 /turf/simulated/floor/plasteel/airless,
 /area/toxins/test_area)
 "cmF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
+	icon_state = "1-8";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whiteblue";
-	tag = "icon-whitehall (WEST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/medical/surgery2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cmG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -64703,18 +64945,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
-"cmI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	initialize_directions = 11;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
 "cmJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65112,18 +65342,15 @@
 	name = "\improper Virology Lobby"
 	})
 "cny" = (
-/obj/structure/sign/fire{
-	pixel_x = 32;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cnz" = (
 /obj/structure/sign/biohazard{
 	pixel_y = 32
@@ -65794,24 +66021,29 @@
 /turf/simulated/floor/plasteel,
 /area/toxins/storage)
 "coC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor/plasteel,
-/area/toxins/launch{
-	name = "Toxins Launch Room"
+/area/medical/research{
+	name = "Research Division"
 	})
 "coD" = (
-/obj/machinery/vending/snack,
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "coE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -66368,50 +66600,54 @@
 /turf/simulated/floor/engine,
 /area/toxins/explab_chamber)
 "cpr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "station intercom (General)";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cps" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cpt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"cpu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
+	dir = 8;
 	initialize_directions = 11;
 	level = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
-"cpu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/medical/medbreak)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cpv" = (
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
@@ -67660,38 +67896,34 @@
 	},
 /area/medical/virology)
 "crn" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0;
-	tag = ""
+/obj/structure/sign/fire{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 9;
+	icon_state = "whitehall"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cro" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11;
+	level = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "crp" = (
 /obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/light_switch{
@@ -67976,33 +68208,29 @@
 	},
 /area/toxins/explab)
 "crQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/research)
+/turf/simulated/floor/plasteel,
+/area/toxins/launch{
+	name = "Toxins Launch Room"
+	})
 "crR" = (
-/obj/machinery/camera{
-	c_tag = "Research Hallway South";
-	dir = 1;
-	network = list("Research","SS13");
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "crS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -68466,12 +68694,26 @@
 /turf/simulated/floor/wood,
 /area/ntrep)
 "csF" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
-	initialize_directions = 11;
-	level = 1
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"csG" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
+"csH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
 	initialize_directions = 11;
@@ -68480,24 +68722,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
-"csG" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plasteel,
-/area/engine/controlroom)
-"csH" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "whitegreencorner"
-	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "csI" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
@@ -68901,20 +69128,22 @@
 	},
 /area/medical/virology)
 "cth" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/virology)
 "cti" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69045,19 +69274,13 @@
 /turf/simulated/floor/plating,
 /area/toxins/explab)
 "ctv" = (
-/obj/machinery/light,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id_tag = "Biohazard";
-	name = "Biohazard Shutter";
-	opacity = 0
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitegreencorner"
+	icon_state = "white"
 	},
-/area/medical/research)
+/area/medical/research{
+	name = "Research Division"
+	})
 "ctw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69145,34 +69368,17 @@
 	},
 /area/toxins/explab)
 "ctC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
+/obj/machinery/status_display{
+	layer = 4;
 	pixel_x = 0;
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint2)
-"ctD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/medical/virology)
+/area/medical/research{
+	name = "Research Division"
+	})
 "ctE" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
@@ -69254,10 +69460,6 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/engine/controlroom)
-"ctK" = (
-/obj/machinery/drone_fabricator,
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "ctL" = (
@@ -69573,31 +69775,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
-	},
-/area/medical/virology)
-"cun" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "viro_lab_airlock_control";
-	name = "Virology Lab Access Console";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_one_access_txt = "39";
-	tag_exterior_door = "viro_lab_airlock_exterior";
-	tag_interior_door = "viro_lab_airlock_interior"
-	},
-/obj/effect/decal/warning_stripes/northeastcorner,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
 	},
 /area/medical/virology)
 "cuo" = (
@@ -70009,16 +70186,18 @@
 "cuV" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+	d2 = 8;
+	icon_state = "1-8";
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
+/area/medical/research{
+	name = "Research Division"
+	})
 "cuW" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -70029,17 +70208,27 @@
 	},
 /area/toxins/mixing)
 "cuX" = (
+/obj/machinery/light,
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8";
+	icon_state = "4-8";
+	pixel_x = 0;
 	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cuY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70318,10 +70507,7 @@
 "cvA" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cvB" = (
@@ -70351,16 +70537,55 @@
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cvF" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/turbine)
-"cvG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/assembly/chargebay)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"cvG" = (
+/obj/machinery/camera{
+	c_tag = "Research Hallway South";
+	dir = 1;
+	network = list("Research","SS13");
+	pixel_x = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
+"cvH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cvI" = (
 /turf/simulated/wall,
 /area/construction)
@@ -70743,17 +70968,36 @@
 	},
 /area/medical/cmostore)
 "cwo" = (
-/obj/machinery/bluespace_beacon,
-/obj/effect/decal/warning_stripes/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "dark";
-	tag = "icon-vault (NORTHEAST)"
+	dir = 8;
+	icon_state = "whitegreencorner"
 	},
-/area/turret_protected/aisat_interior)
+/area/medical/research{
+	name = "Research Division"
+	})
+"cwp" = (
+/obj/machinery/light,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitegreencorner"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cwq" = (
 /obj/machinery/camera{
 	c_tag = "Research E.X.P.E.R.I-MENTOR Lab";
@@ -70805,6 +71049,23 @@
 	dir = 4
 	},
 /area/medical/cmostore)
+"cwt" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id_tag = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/medical/research{
+	name = "Research Division"
+	})
 "cwu" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
@@ -72036,6 +72297,24 @@
 	icon_state = "dark"
 	},
 /area/construction)
+"cyI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4;
+	initialize_directions = 11;
+	level = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint2)
 "cyJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -74269,10 +74548,7 @@
 	pixel_y = 3
 	},
 /obj/item/stack/cable_coil,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cCP" = (
@@ -74286,6 +74562,14 @@
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/construction)
+"cCQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -74709,6 +74993,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/engine/controlroom)
+"cDA" = (
+/obj/machinery/drone_fabricator,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/controlroom)
 "cDB" = (
@@ -76094,7 +76385,7 @@
 	amount = 50
 	},
 /obj/item/stack/sheet/mineral/plasma{
-	amount = 3;
+	amount = 1;
 	layer = 2.9
 	},
 /obj/item/stack/sheet/glass{
@@ -78781,7 +79072,7 @@
 "cKD" = (
 /obj/structure/table,
 /obj/structure/window/reinforced,
-/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box/full,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cKE" = (
@@ -79163,29 +79454,6 @@
 	icon_state = "white"
 	},
 /area/assembly/assembly_line)
-"cLr" = (
-/obj/machinery/door_control{
-	id = "mechpod";
-	name = "Mechanic's Inner Door Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "70"
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
 "cLs" = (
 /obj/machinery/light_switch{
 	name = "light switch ";
@@ -79855,6 +80123,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/control)
+"cMO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/asmaint)
 "cMP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80957,7 +81241,7 @@
 	},
 /area/toxins/xenobiology)
 "cOS" = (
-/obj/machinery/optable,
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -81724,10 +82008,8 @@
 /area/toxins/xenobiology)
 "cQt" = (
 /obj/structure/table/reinforced,
-/obj/item/circular_saw{
-	pixel_y = 0
-	},
 /obj/item/scalpel,
+/obj/item/hemostat,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -82300,6 +82582,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/atmos/distribution)
+"cRl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos/distribution)
@@ -84230,14 +84527,8 @@
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
 /obj/item/clothing/glasses/meson{
 	pixel_y = 4
 	},
@@ -84951,10 +85242,7 @@
 	},
 /obj/item/airlock_electronics,
 /obj/item/airlock_electronics,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating,
 /area/storage/secure)
@@ -87683,7 +87971,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "blue"
@@ -88244,14 +88532,8 @@
 "dbO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
@@ -89590,6 +89872,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
+"dey" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/turbine)
 "dez" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -91652,6 +91942,21 @@
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
+"diQ" = (
+/obj/machinery/bluespace_beacon,
+/obj/effect/decal/warning_stripes/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "dark";
+	tag = "icon-vault (NORTHEAST)"
+	},
+/area/turret_protected/aisat_interior)
 "diR" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating/airless,
@@ -105022,9 +105327,9 @@ aaa
 aaa
 aaa
 aaa
-bhb
+bnj
 bvi
-biy
+bnk
 aaa
 aaa
 aaa
@@ -105278,11 +105583,11 @@ aab
 aaa
 aaa
 aaa
-bhb
+bnj
 btv
 bvj
 bwE
-biy
+bnk
 aaa
 bAQ
 bCa
@@ -105302,8 +105607,8 @@ bRA
 caf
 bPI
 cdl
-cgx
-cgx
+ceR
+ceR
 cig
 bPI
 cae
@@ -105559,9 +105864,9 @@ bRA
 cag
 bPI
 cdm
-cgx
-cgx
-cgx
+ceR
+ceR
+ceR
 ckd
 bPI
 cae
@@ -105771,7 +106076,7 @@ aaa
 aJP
 aLa
 aLa
-awC
+aCi
 aOP
 aMs
 aVf
@@ -105816,10 +106121,10 @@ bRA
 cah
 bPI
 cdp
-cgx
-cgx
-cgx
-cgx
+ceR
+ceR
+ceR
+ceR
 clC
 bPI
 aaa
@@ -106073,10 +106378,10 @@ bRA
 cai
 bPI
 cdl
-cgx
+ceR
 cgw
 cih
-cgx
+ceR
 clD
 bPI
 aaa
@@ -106285,7 +106590,7 @@ aaa
 aJQ
 aLa
 aLa
-ayR
+aCj
 aOR
 aQa
 aMd
@@ -106330,8 +106635,8 @@ bRA
 bRA
 bPI
 cdo
-cgx
-cgx
+ceR
+ceR
 cii
 ckf
 clE
@@ -106753,10 +107058,10 @@ abQ
 abQ
 abI
 afz
-ahx
+abV
 agf
 agE
-ahx
+abV
 ahw
 ahy
 ahN
@@ -106799,7 +107104,7 @@ aaa
 aJR
 aLe
 aLe
-aGv
+aFm
 aOP
 aMs
 aPJ
@@ -107010,10 +107315,10 @@ ade
 ade
 abI
 afz
-ahx
-ahx
-ahx
-ahx
+abV
+abV
+abV
+abV
 dcZ
 ahy
 ahO
@@ -107260,18 +107565,18 @@ aaa
 aaa
 aaa
 abI
-ahx
-ahx
-ahx
-ahx
-ahx
+abV
+abV
+abV
+abV
+abV
 abI
 afA
-ahx
-ahx
+abV
+abV
 agF
 ahg
-ahx
+abV
 ahy
 ahP
 aaa
@@ -107313,7 +107618,7 @@ aaa
 aJT
 aLe
 aLe
-aHV
+aGv
 aOR
 aQa
 aPQ
@@ -107517,15 +107822,15 @@ acq
 aaa
 aaa
 abI
-ahx
+abV
 ady
-ahx
-ahx
-ahx
+abV
+abV
+abV
 abI
 afB
 ady
-ahx
+abV
 ahv
 abQ
 abQ
@@ -107777,12 +108082,12 @@ abI
 adf
 adz
 adT
-ahx
-ahx
+abV
+abV
 abI
 afC
-ahx
-ahx
+abV
+abV
 agG
 abI
 aaa
@@ -108024,8 +108329,8 @@ aaa
 aaa
 aaa
 abJ
-ahx
-ahx
+abV
+abV
 acl
 abI
 abQ
@@ -108282,8 +108587,8 @@ aaa
 aaa
 abH
 aaw
-ahx
-ahx
+abV
+abV
 abI
 acz
 acI
@@ -108291,14 +108596,14 @@ acI
 acI
 acI
 adU
-ahx
-ahx
+abV
+abV
 afg
 afD
-ahx
-ahx
+abV
+abV
 agH
-ahx
+abV
 ahy
 ahN
 aaa
@@ -108540,20 +108845,20 @@ aaa
 abH
 abX
 ace
-ahx
+abV
 acr
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
-ahx
+abV
+abV
+abV
+abV
+abV
+abV
+abV
+abV
+abV
+abV
+abV
+abV
 agI
 ahh
 ahy
@@ -108796,7 +109101,7 @@ aaa
 aaa
 abH
 abW
-ahx
+abV
 acm
 abI
 acA
@@ -108806,11 +109111,11 @@ acJ
 acJ
 acf
 aet
-ahx
-ahx
-ahx
-ahx
-ahx
+abV
+abV
+abV
+abV
+abV
 agH
 ahi
 ahy
@@ -109053,8 +109358,8 @@ aaa
 aaa
 abK
 abZ
-ahx
-ahx
+abV
+abV
 abI
 abQ
 abQ
@@ -109140,7 +109445,7 @@ bBs
 bDu
 bEm
 bFM
-bxy
+bIb
 bJs
 bKd
 bKU
@@ -109323,8 +109628,8 @@ acQ
 dox
 abI
 afE
-ahx
-ahx
+abV
+abV
 agJ
 abI
 aaa
@@ -109581,7 +109886,7 @@ dox
 abI
 afF
 ady
-ahx
+abV
 agK
 abQ
 abQ
@@ -109627,7 +109932,7 @@ aGn
 aGn
 aLg
 aMh
-aQt
+aNI
 aHS
 aHS
 aHS
@@ -109837,10 +110142,10 @@ dov
 doA
 abI
 afG
-ahx
-ahx
-ahx
-ahx
+abV
+abV
+abV
+abV
 ahz
 ahy
 ahN
@@ -110095,9 +110400,9 @@ abQ
 abI
 afH
 ady
-ahx
-ahx
-ahx
+abV
+abV
+abV
 ahA
 ahy
 ahO
@@ -110353,8 +110658,8 @@ abI
 afI
 afR
 agi
-ahx
-ahx
+abV
+abV
 ahB
 ahy
 ahP
@@ -110678,7 +110983,7 @@ bqr
 btF
 btB
 bzP
-brX
+bBJ
 byh
 bqr
 bFY
@@ -110688,7 +110993,7 @@ bFc
 bHf
 bLJ
 bNF
-bLR
+bPH
 bCf
 aaa
 aaa
@@ -111443,7 +111748,7 @@ biA
 blh
 biA
 biA
-bnj
+brp
 bsx
 bqr
 btF
@@ -113764,7 +114069,7 @@ bvT
 bzQ
 bBP
 bDv
-bts
+bEz
 byo
 bIs
 bJx
@@ -116595,7 +116900,7 @@ bCs
 bGR
 bxa
 bJB
-bBl
+bKH
 bxb
 bIX
 bKz
@@ -117917,7 +118222,7 @@ cEL
 cFP
 cGF
 cJV
-cLr
+cgx
 cEY
 cLm
 cLi
@@ -118640,7 +118945,7 @@ bmf
 bkr
 blV
 brC
-bqE
+bsI
 bqE
 bsn
 blT
@@ -119428,7 +119733,7 @@ bKZ
 bNW
 bzJ
 bzJ
-bGL
+bpD
 bDX
 bDX
 cbz
@@ -119682,7 +119987,7 @@ bzF
 bFt
 bBn
 bMk
-bJo
+bNV
 bzJ
 bOt
 bHi
@@ -120202,14 +120507,14 @@ bFA
 bUo
 bUV
 bVL
-bSZ
+bXj
 bBn
 bYL
 caq
 cdR
 cfe
 civ
-cfV
+ckG
 cix
 bYM
 cnX
@@ -123239,7 +123544,7 @@ aIl
 aCd
 aDh
 aDR
-aFm
+aBl
 aIl
 aHB
 aJb
@@ -124007,7 +124312,7 @@ aAW
 ayN
 azF
 aAO
-aCj
+avU
 aDj
 aEd
 aFs
@@ -124263,12 +124568,12 @@ axZ
 axz
 ayN
 azF
-aAN
-aCi
+ajI
+axN
 aCf
 aCn
 aFr
-aKx
+aBC
 aHG
 aHG
 aKv
@@ -124546,7 +124851,7 @@ bor
 cRN
 aRw
 dix
-aKp
+aHV
 biK
 bpv
 blY
@@ -124803,7 +125108,7 @@ aRw
 aRw
 aRw
 diw
-aNe
+aKp
 biO
 bkz
 blU
@@ -125060,7 +125365,7 @@ aZx
 bbr
 dcb
 bdv
-aOa
+aKx
 bnd
 bkz
 bma
@@ -125317,7 +125622,7 @@ baE
 beu
 bhd
 bhd
-aRV
+aOa
 bne
 bkB
 bma
@@ -125328,7 +125633,7 @@ bsz
 bxC
 bAD
 bCy
-bsI
+bDW
 bzW
 bBz
 bCJ
@@ -125574,7 +125879,7 @@ baF
 bev
 bhh
 bhV
-aUP
+aRm
 bnf
 bkz
 bma
@@ -126319,7 +126624,7 @@ avX
 awJ
 ayT
 azK
-axN
+ayR
 aCp
 aHE
 axe
@@ -126907,7 +127212,7 @@ ctY
 cvB
 cAR
 cBJ
-ctK
+cDA
 csD
 cHQ
 cHt
@@ -127626,7 +127931,7 @@ aRx
 bea
 bgX
 biW
-bbx
+bxy
 aQH
 dhs
 djg
@@ -127650,7 +127955,7 @@ bFK
 bHw
 bMP
 bLd
-bQz
+aUP
 bOJ
 bQw
 bSi
@@ -128705,7 +129010,7 @@ cyD
 cyD
 cAp
 cAW
-cyD
+cCQ
 cFn
 cGK
 cGv
@@ -128750,9 +129055,9 @@ dfR
 dcq
 dcq
 dcq
-bpU
+chv
 doL
-brp
+chw
 dcq
 aaa
 aaa
@@ -128899,7 +129204,7 @@ aId
 aJp
 aJp
 aJp
-aBl
+aNW
 aPP
 aQm
 aSm
@@ -129459,7 +129764,7 @@ bZr
 cbm
 bKN
 bKN
-cdd
+cgJ
 bFO
 chf
 ceb
@@ -129656,7 +129961,7 @@ axt
 arF
 atn
 auX
-avU
+awC
 axU
 azc
 azZ
@@ -130204,7 +130509,7 @@ bhr
 bja
 bkM
 bcU
-bhc
+aNe
 bmq
 brf
 bmq
@@ -130443,7 +130748,7 @@ aKG
 aMw
 aNY
 aPe
-aOe
+aQt
 aSE
 aUd
 aWG
@@ -130461,7 +130766,7 @@ dkE
 aZR
 bkM
 bmr
-bmq
+brT
 btf
 btf
 bmq
@@ -130968,7 +131273,7 @@ bfb
 aUS
 bjc
 baJ
-aZV
+beH
 bwl
 bft
 aYd
@@ -131289,7 +131594,7 @@ cDl
 cOJ
 cPE
 cPW
-cuX
+cRl
 cVQ
 cXb
 cXT
@@ -131758,7 +132063,7 @@ bAk
 bHy
 bDb
 bEy
-bok
+aRz
 bDf
 bGe
 bJA
@@ -132260,7 +132565,7 @@ dkN
 boM
 dkN
 bqy
-boX
+brX
 btx
 buq
 buq
@@ -132497,7 +132802,7 @@ aIs
 aJy
 aIa
 aMI
-aBC
+aOe
 aPf
 aQv
 aSM
@@ -132802,7 +133107,7 @@ bXG
 bZi
 cgM
 caI
-ccw
+ccu
 ceg
 cfI
 cho
@@ -133073,7 +133378,7 @@ cpy
 cpN
 cru
 ctc
-cun
+chg
 cQn
 cwe
 cxu
@@ -133321,7 +133626,7 @@ cDf
 cfK
 chq
 cpo
-cmF
+ckr
 cld
 cDf
 cuB
@@ -133791,7 +134096,7 @@ aWY
 aZI
 bbw
 bdm
-aVw
+bfz
 aOI
 aMo
 bbh
@@ -133829,7 +134134,7 @@ cuv
 bWa
 bXM
 cgO
-ceN
+caM
 ccz
 cDf
 cfM
@@ -133843,7 +134148,7 @@ cpa
 cpB
 cpP
 cte
-ctD
+cth
 cvd
 cQk
 cwi
@@ -134149,7 +134454,7 @@ aaa
 dol
 dnZ
 diJ
-cwo
+diQ
 djI
 dpf
 dpq
@@ -134826,8 +135131,8 @@ bbC
 aGY
 beb
 djw
-aNI
-bpH
+bhb
+boX
 bpH
 bqH
 bro
@@ -135071,7 +135376,7 @@ aFK
 aPn
 aRt
 aNL
-aRz
+aVw
 aXf
 aZJ
 aIc
@@ -135083,13 +135388,13 @@ bbh
 aGY
 beb
 dju
-aNW
+bhc
 bjv
 dnD
 bmy
 boo
 btM
-aRm
+brm
 bsU
 bof
 bof
@@ -135162,7 +135467,7 @@ dcw
 dcG
 dcQ
 deu
-cvF
+dey
 ddj
 ddv
 dln
@@ -135340,7 +135645,7 @@ bbh
 aGY
 beb
 djx
-bfz
+biI
 bjv
 dnE
 bmy
@@ -135570,9 +135875,9 @@ atG
 auA
 axg
 axh
-abV
+ahx
 avt
-aha
+aAN
 atG
 aaa
 aFK
@@ -135597,7 +135902,7 @@ bbI
 aGY
 beb
 bfH
-bfz
+biI
 bjx
 bfH
 bmy
@@ -135854,7 +136159,7 @@ bbV
 aGY
 beb
 bfJ
-bfz
+biI
 bjy
 bkY
 bmy
@@ -136400,14 +136705,14 @@ bWD
 bXU
 bZy
 caT
-caX
+clb
 cel
-ckr
+cfV
 chB
 ciX
 ckD
 csb
-cpu
+cmv
 cnP
 ciY
 cwY
@@ -137426,8 +137731,8 @@ bXN
 bVV
 bXN
 bWi
-bWj
-bXV
+bZB
+caX
 bWi
 cep
 cep
@@ -137679,12 +137984,12 @@ bNd
 bEu
 bSF
 bUd
-bpD
-bMz
-bVX
-bVZ
+bUI
+bVU
 bXs
-bYk
+bXW
+bUI
+ccQ
 bWg
 ceo
 cfY
@@ -137936,12 +138241,12 @@ bQJ
 bEu
 bSH
 bUf
-brm
-bPv
-cdn
-bXW
-bXW
-bZB
+bUI
+bVW
+bXv
+bYk
+bYk
+cdj
 bWg
 cer
 cga
@@ -137965,7 +138270,7 @@ ctr
 ctr
 cJd
 cKo
-cuV
+cMO
 cNn
 ciY
 ciY
@@ -138193,12 +138498,12 @@ bNd
 bEu
 bSG
 bUd
-brm
-bPU
-cdj
+bUI
+bVX
 bXQ
-bXQ
-cab
+caW
+caW
+cdn
 bWg
 ceq
 cfZ
@@ -138448,14 +138753,14 @@ bGr
 bGr
 bQL
 bGr
+bGr
 bWi
-bWi
-bFJ
-bSI
-bVY
-bWc
-bXv
-caW
+bUJ
+bVZ
+bXV
+caY
+caZ
+ceJ
 bWi
 clp
 clp
@@ -138704,9 +139009,9 @@ bLN
 bNg
 bOZ
 bQK
-aXT
+bLn
 bLE
-bGr
+bWi
 bWi
 bWi
 cbd
@@ -138961,11 +139266,11 @@ bLE
 bHX
 bLE
 bQK
-aZS
-aZS
-caj
-bVE
-cau
+bLT
+bLT
+bPU
+bRk
+bUN
 cbd
 ccT
 cez
@@ -139220,9 +139525,9 @@ bLP
 bQK
 bVz
 bHX
-caZ
-bHX
-cav
+bQe
+bRy
+bVA
 cbd
 ceI
 cgT
@@ -139475,11 +139780,11 @@ bLm
 bRr
 bUl
 bQN
-beB
-bSJ
-clb
-bHX
-bHX
+bLU
+bNE
+bQz
+bRy
+bRy
 cbd
 ccV
 chb
@@ -139728,15 +140033,15 @@ bux
 bwL
 bBm
 bMW
-bLT
+aRV
 bRj
 bTW
-bPn
-cvG
-bnk
+bFJ
+bMt
+bOS
 bRU
-bRU
-cax
+bSI
+bVC
 cbf
 ccU
 cha
@@ -139986,18 +140291,18 @@ bEA
 bIa
 bNf
 bIa
-bNi
-bOS
-bRk
-bUN
-bVC
+aXT
+bok
+bJo
+bMz
+bPn
 bIa
-bVF
-cay
+bSJ
+bIi
 cbf
-ccQ
-chg
-cjK
+bWc
+caj
+ccW
 cbf
 cjG
 cjG
@@ -140242,18 +140547,18 @@ bEA
 bGu
 bGc
 bNc
-bMt
-bNE
+aRY
+aZS
 bPo
 bPo
-bVA
-bVW
+bNi
+bPv
 bIa
-bVU
-caB
+ctC
+bVY
 cdB
-ccW
-chv
+bWj
+cce
 cgf
 cbf
 cjG
@@ -140500,17 +140805,17 @@ bGA
 bId
 bNh
 bPa
-bRy
+bbx
 bPo
 bPo
 bId
 crH
 bIa
-bWk
-caM
+cad
+ccf
 cbf
-cdb
-chw
+cab
+ccw
 cgg
 cbf
 clp
@@ -140763,8 +141068,8 @@ bPo
 bId
 bUF
 bIa
-bWl
-bRP
+cal
+bWn
 cbf
 cbf
 cbf
@@ -141020,8 +141325,8 @@ bRl
 bVD
 bIa
 bIa
+bSW
 bWn
-bRP
 cbj
 ceL
 chI
@@ -141033,9 +141338,9 @@ coB
 chI
 crj
 cbj
-bUK
-crn
-bBJ
+ctv
+cuX
+bIi
 cpI
 cxO
 cep
@@ -141277,8 +141582,8 @@ bId
 bId
 bWe
 bLI
-bWp
-caS
+cau
+ccg
 cdC
 ceK
 ceK
@@ -141290,9 +141595,9 @@ coA
 ceK
 cri
 csB
-bTw
-cro
-bBJ
+bYm
+cuV
+bIi
 cxi
 cxT
 cBQ
@@ -141534,8 +141839,8 @@ bUe
 bUe
 bUe
 bYl
-bWq
-caY
+cax
+cci
 cbj
 chT
 cjN
@@ -141547,9 +141852,9 @@ cmV
 cmV
 chT
 cbj
-bUI
-crQ
-bBJ
+bLR
+cvF
+bIi
 cxU
 cxT
 cBQ
@@ -141791,8 +142096,8 @@ bRm
 bSY
 bUH
 bLI
-bXj
-cbk
+cav
+cch
 cbj
 cbj
 cjN
@@ -141804,9 +142109,9 @@ cmV
 cmV
 cbj
 cbj
-bVU
-crQ
-bBJ
+ctC
+cvF
+bIi
 cxM
 cxT
 cBP
@@ -142048,9 +142353,9 @@ bEA
 bTa
 bIa
 bIa
-bUI
+bLR
+cch
 cbk
-ccf
 cbj
 cbj
 cbj
@@ -142060,10 +142365,10 @@ cbj
 cbj
 cbj
 cbj
-coD
-bUI
 crR
-bBJ
+bLR
+cvG
+bIi
 cxN
 czx
 cBR
@@ -142296,31 +142601,31 @@ bHI
 bwv
 bDq
 bGF
-bBJ
-bIb
-bKn
-bLU
-bNn
-bOa
-bPi
+bIi
+bNk
+bPd
+bRP
 bPt
-bPt
-bPt
-cbn
-ccg
-cci
+bOv
+bSZ
+bUK
+bUK
+bUK
+ccj
 cdF
-bPt
-cgJ
-chO
-bPt
+ceM
+chM
+bUK
 clj
 clY
-cci
+bUK
+coC
 cpr
-bUI
-crQ
-csH
+ceM
+csF
+bLR
+cvF
+cwo
 cxN
 cxW
 cAf
@@ -142553,31 +142858,31 @@ bHQ
 bJq
 bJq
 bKT
-bDW
-bIi
-bKH
-bNk
-bDW
-bOv
-bPj
-bPH
-bTw
+bSz
+bNn
+bPi
+bRT
+bSz
+bUP
+bVF
+bWl
 bYm
-cce
-cch
-ccj
+caB
+ccp
 cdL
-ccj
-chM
-chV
-ckG
+ceN
+chO
+ceN
 cln
 cmi
-cmI
-cpt
-ckG
-csF
-cth
+cny
+coD
+cpu
+cro
+csH
+cny
+cvH
+cwt
 cyT
 cyC
 cAi
@@ -142810,31 +143115,31 @@ bHI
 bwv
 bDq
 bEM
-bEz
 bIk
-bLn
 bNm
-bNV
-bPd
-bPk
-bQe
+bKn
+bRQ
 bUh
-cad
-bUh
-bUh
-ccp
-ceM
-bUh
+bUO
+bVE
+bWk
+cbn
+cay
+cbn
+cbn
+cdd
 chN
-bUh
-bUh
-bUh
-cmv
-cny
-bUI
-bUI
-bUI
-ctv
+cbn
+bTw
+cbn
+cbn
+cbn
+cpt
+crn
+bLR
+bLR
+bLR
+cwp
 cxN
 cyB
 cAf
@@ -143049,7 +143354,7 @@ baz
 bcO
 bfV
 bhB
-beH
+biy
 bgg
 bcD
 bpK
@@ -143074,8 +143379,8 @@ bED
 bED
 bED
 bTb
-bRn
-bUI
+bWp
+bLR
 bYi
 bZU
 bZU
@@ -143083,15 +143388,15 @@ cdf
 chQ
 bYj
 bYj
-bNn
-bNn
-bNn
+bPt
+bPt
+bPt
 cpD
-bNn
-bNn
-bBJ
-bBJ
-bBJ
+bPt
+bPt
+bIi
+bIi
+bIi
 cxN
 cAG
 cAP
@@ -143331,8 +143636,8 @@ bMj
 bPz
 bRp
 bTg
-bRP
-bUI
+bWn
+bLR
 bYh
 bZT
 cbp
@@ -143580,7 +143885,7 @@ aSI
 bHI
 bwv
 bDq
-brT
+bGL
 bPD
 bKi
 bPl
@@ -143588,8 +143893,8 @@ bRX
 bUj
 bUQ
 bTe
-bRP
-bUI
+bWn
+bLR
 caC
 ccr
 cdM
@@ -143607,7 +143912,7 @@ ctH
 cAS
 cAS
 cAS
-ctC
+cyI
 cAQ
 cCf
 cDw
@@ -143841,18 +144146,18 @@ bGK
 bIv
 bKi
 bKx
-aRY
+beB
 bUi
 bRq
 bTe
-bRQ
-bUJ
+bWq
+bOa
 bYj
 bZV
 cbq
 cdg
 chR
-cjP
+cdb
 bYj
 cmk
 cgs
@@ -144102,8 +144407,8 @@ bRY
 bUk
 bUR
 bVG
-bRT
-bUI
+bWr
+bLR
 bYj
 bVo
 bYA
@@ -144359,13 +144664,13 @@ bIp
 bPB
 bIp
 bTe
-bSz
-bUK
+bqb
+ctv
 bYj
 bZW
 cdO
 ceQ
-ceO
+chV
 cgq
 bYj
 cmB
@@ -144594,7 +144899,7 @@ bhD
 aUX
 bla
 aUX
-biI
+bpU
 bqW
 bsb
 bqg
@@ -144616,8 +144921,8 @@ bNU
 bPJ
 bRE
 bED
-bSW
-bUO
+bRn
+bPk
 bYj
 bYz
 bYB
@@ -144873,8 +145178,8 @@ bED
 bED
 bED
 bED
-bWr
-bUP
+bts
+bPj
 bYj
 bYj
 bYj
@@ -145130,7 +145435,7 @@ cZp
 cZp
 cZT
 bEG
-ceJ
+cjT
 cac
 cba
 ccM
@@ -145139,7 +145444,7 @@ dsm
 cFc
 dso
 cFc
-cjT
+cmF
 cgs
 cnb
 cqd
@@ -145389,7 +145694,7 @@ bUS
 bXi
 bWv
 bYn
-cal
+caS
 ccI
 bGG
 dfc
@@ -147942,7 +148247,7 @@ bue
 buD
 bvP
 bzx
-bqb
+bBl
 bmm
 bmm
 bmm
@@ -148484,7 +148789,7 @@ uDK
 afO
 iNz
 cqp
-coC
+crQ
 csn
 ctO
 cvj
@@ -150707,8 +151012,8 @@ adV
 ail
 ail
 ail
-ajI
-ajI
+aha
+aha
 ajz
 ajY
 akp
@@ -150965,7 +151270,7 @@ agZ
 agZ
 ail
 aiE
-ajI
+aha
 ajA
 ajY
 akp
@@ -151222,7 +151527,7 @@ aaa
 agZ
 ail
 aiF
-ajI
+aha
 ajB
 agZ
 ahn
@@ -151479,7 +151784,7 @@ aaa
 agZ
 ail
 aiG
-ajI
+aha
 ajC
 agZ
 aaa
@@ -152244,13 +152549,13 @@ aaa
 aaa
 afZ
 agw
-ajI
-ajI
-ajI
+aha
+aha
+aha
 agZ
 ail
 ahZ
-ajI
+aha
 ajE
 ajZ
 akq
@@ -152502,16 +152807,16 @@ aaa
 aaa
 agz
 abT
-ajI
+aha
 ahK
 agZ
 agw
 agZ
-ajI
-ajI
-ajI
-ajI
-ajI
+aha
+aha
+aha
+aha
+aha
 akP
 aly
 amj
@@ -152764,14 +153069,14 @@ ahL
 ahZ
 aim
 ahZ
-ajI
-ajI
-ajI
-ajI
-ajI
+aha
+aha
+aha
+aha
+aha
 ahZ
-ajI
-ajI
+aha
+aha
 amZ
 agZ
 aaa
@@ -153016,16 +153321,16 @@ aaa
 aaa
 agA
 ahd
-ajI
-ajI
+aha
+aha
 agZ
 agw
 agZ
-ajI
-ajI
-ajI
-ajI
-ajI
+aha
+aha
+aha
+aha
+aha
 akR
 alz
 amk
@@ -153272,13 +153577,13 @@ aaa
 aaa
 agc
 agw
-ajI
-ajI
-ajI
+aha
+aha
+aha
 agZ
 ail
 ahZ
-ajI
+aha
 ajF
 aka
 akr
@@ -153792,7 +154097,7 @@ ahM
 agZ
 ail
 aiI
-ajI
+aha
 ajG
 agZ
 aaa
@@ -154049,8 +154354,8 @@ aaa
 agZ
 ail
 aiJ
-ajI
-ajI
+aha
+aha
 agZ
 aaa
 aaa
@@ -154563,8 +154868,8 @@ agZ
 agZ
 ail
 aiL
-ajI
-ajI
+aha
+aha
 ajY
 akp
 aaa
@@ -154819,8 +155124,8 @@ aen
 ail
 ail
 ail
-ajI
-ajI
+aha
+aha
 ajz
 ajY
 akp

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -19694,11 +19694,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aHV" = (
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L1"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/hallway/primary/central/north)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/area/hydroponics)
 "aHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20752,8 +20770,9 @@
 	},
 /mob/living/simple_animal/pig,
 /turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L3"
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
 	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-siding1 (NORTH)";
@@ -20826,11 +20845,28 @@
 	},
 /area/lawoffice)
 "aKx" = (
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L5"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/hallway/primary/central/north)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/area/hydroponics)
 "aKy" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -22546,11 +22582,10 @@
 	},
 /area/civilian/barber)
 "aOa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L7"
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion";
+	tag = "icon-propulsion (EAST)"
 	},
 /turf/space,
 /turf/simulated/shuttle/wall{
@@ -24153,11 +24188,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aRm" = (
-/turf/simulated/floor/plasteel{
-	icon = 'icons/hispania/turf/floors.dmi';
-	icon_state = "L9"
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8;
+	icon_state = "propulsion";
+	tag = "icon-propulsion (EAST)"
 	},
-/area/hallway/primary/central/north)
+/turf/space,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
+	dir = 2
+	},
+/area/shuttle/transport)
 "aRn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32634,53 +32675,15 @@
 	},
 /area/hallway/primary/central/north)
 "bhb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "L3"
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/area/hydroponics)
+/area/hallway/primary/central/north)
 "bhc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/mob/living/simple_animal/pig,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "L5"
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/area/hydroponics)
+/area/hallway/primary/central/north)
 "bhd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33529,28 +33532,12 @@
 	},
 /area/hallway/primary/central/nw)
 "biI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
+	icon_state = "L7"
 	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/area/hydroponics)
+/area/hallway/primary/central/north)
 "biJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35983,30 +35970,6 @@
 	icon_state = "L14"
 	},
 /area/hallway/primary/central/north)
-"bnj" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion";
-	tag = "icon-propulsion (EAST)"
-	},
-/turf/space,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f6";
-	dir = 2
-	},
-/area/shuttle/transport)
-"bnk" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion";
-	tag = "icon-propulsion (EAST)"
-	},
-/turf/space,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/transport)
 "bnl" = (
 /obj/machinery/camera{
 	c_tag = "Bar East";
@@ -37400,6 +37363,13 @@
 /area/hydroponics)
 "bqb" = (
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -38892,6 +38862,13 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance";
 	req_access_txt = "47"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -44941,10 +44918,6 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bFu" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -44953,6 +44926,17 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -45010,6 +44994,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
@@ -46250,6 +46239,12 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bHR" = (
@@ -47044,12 +47039,29 @@
 "bJq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
 "bJr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bJs" = (
@@ -47939,6 +47951,12 @@
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "purple"
@@ -48120,6 +48138,12 @@
 	dir = 8;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -48767,7 +48791,7 @@
 "bMB" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
+/area/bridge/meeting_room)
 "bMC" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -48783,10 +48807,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bMD" = (
-/obj/machinery/computer/account_database{
-	anchored = 1
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plating,
 /area/bridge/meeting_room)
 "bME" = (
 /turf/simulated/wall,
@@ -49149,6 +49171,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -49215,6 +49244,13 @@
 	dir = 10;
 	initialize_directions = 10;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -49311,6 +49347,12 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -49407,6 +49449,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bNu" = (
@@ -49494,7 +49542,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/structure/piano,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bNC" = (
@@ -49917,9 +49964,12 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "bOl" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/plating,
-/area/maintenance/maintcentral)
+/obj/machinery/computer/account_database,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "blue"
+	},
+/area/crew_quarters/heads)
 "bOm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -49972,12 +50022,31 @@
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "bOq" = (
-/obj/item/radio/intercom{
-	name = "station intercom (General)";
-	pixel_y = -28
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/turf/simulated/floor/plasteel,
-/area/bridge/meeting_room)
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "viro_lab_airlock_control";
+	name = "Virology Lab Access Console";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access_txt = "39";
+	tag_exterior_door = "viro_lab_airlock_exterior";
+	tag_interior_door = "viro_lab_airlock_interior"
+	},
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/item/storage/fancy/vials,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitegreen";
+	tag = "icon-whitehall (WEST)"
+	},
+/area/medical/virology)
 "bOr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -50093,35 +50162,16 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "bOA" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/flasher_button{
-	id = "hopflash";
-	pixel_x = 6;
-	pixel_y = 36
+/obj/structure/table,
+/obj/item/pod_parts/core,
+/obj/item/circuitboard/mecha/pod,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 12
 	},
-/obj/machinery/door_control{
-	id = "hopqueue";
-	name = "Queue Privacy Shutters Control";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "28"
-	},
-/obj/machinery/door_control{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "28"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 36
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "blue"
-	},
-/area/crew_quarters/heads)
+/obj/item/gps,
+/obj/item/pod_paint_bucket,
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "bOB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8;
@@ -50507,6 +50557,12 @@
 "bPi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -50594,6 +50650,12 @@
 "bPq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bPr" = (
@@ -51843,6 +51905,13 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "bot"
 	},
@@ -51968,6 +52037,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52172,6 +52247,12 @@
 	dir = 8;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -52542,6 +52623,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53018,13 +53105,27 @@
 	},
 /area/shuttle/administration)
 "bTm" = (
-/obj/structure/table,
-/obj/item/pod_parts/core,
-/obj/item/circuitboard/mecha/pod,
-/obj/item/clothing/glasses/welding{
-	pixel_y = 12
+/obj/machinery/door_control{
+	id = "mechpod";
+	name = "Mechanic's Inner Door Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "70"
 	},
-/obj/item/gps,
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/pod_paint_bucket,
 /turf/simulated/floor/plasteel,
 /area/engine/mechanic_workshop)
 "bTn" = (
@@ -53482,6 +53583,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -53806,9 +53912,8 @@
 /area/assembly/robotics)
 "bUI" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	dir = 2;
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bUJ" = (
@@ -53823,8 +53928,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bUK" = (
@@ -53911,6 +54015,12 @@
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/medical/research{
 	name = "Research Division"
@@ -53945,6 +54055,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bUT" = (
@@ -54378,6 +54494,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall";
 	dir = 2
@@ -54573,8 +54695,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bVV" = (
@@ -54606,6 +54727,23 @@
 /area/medical/genetics)
 "bVW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10;
+	level = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/genetics)
+"bVX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -54624,23 +54762,8 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "white"
-	},
-/area/medical/genetics)
-"bVX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10;
-	initialize_directions = 10;
-	level = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bVY" = (
@@ -54673,9 +54796,8 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/medical/genetics)
 "bWa" = (
@@ -54830,6 +54952,12 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -54938,6 +55066,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -55514,9 +55649,15 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
+	tag = "icon-whitepurple (EAST)";
+	icon_state = "whitepurple";
+	dir = 4
+	},
+/area/medical/genetics)
 "bXw" = (
 /obj/structure/cable{
 	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8";
 	pixel_x = 0;
 	tag = ""
@@ -55834,9 +55975,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitepurple (WEST)";
+	icon_state = "whitepurple";
+	dir = 8
 	},
 /area/medical/genetics)
 "bXW" = (
@@ -56038,9 +56179,9 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitepurple (EAST)";
+	icon_state = "whitepurple";
+	dir = 4
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -56053,6 +56194,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -57542,6 +57689,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitered"
@@ -57917,14 +58070,16 @@
 	},
 /area/medical/cmo)
 "caW" = (
-/obj/machinery/dna_scannernew,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitepurple (SOUTHWEST)";
+	icon_state = "whitepurple";
+	dir = 10
 	},
 /area/medical/genetics)
 "caX" = (
@@ -57938,15 +58093,15 @@
 /area/medical/genetics)
 "caY" = (
 /obj/structure/chair/office/light{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitepurple (SOUTHEAST)";
+	icon_state = "whitepurple";
+	dir = 6
 	},
 /area/medical/genetics)
 "caZ" = (
@@ -57960,9 +58115,9 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	dir = 8;
+	icon_state = "whitepurplefull";
+	tag = "icon-whitepurple (WEST)"
 	},
 /area/medical/genetics)
 "cba" = (
@@ -58193,6 +58348,12 @@
 	tag = ""
 	},
 /obj/effect/decal/warning_stripes/east,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/se)
 "cbt" = (
@@ -58217,6 +58378,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	tag = "icon-whiteblue (WEST)";
@@ -58710,6 +58877,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -59193,16 +59366,10 @@
 /turf/simulated/floor/plasteel,
 /area/escapepodbay)
 "ccQ" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Geneticist"
-	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	tag = "icon-whitepurple (WEST)";
+	icon_state = "whitepurple";
+	dir = 8
 	},
 /area/medical/genetics)
 "ccR" = (
@@ -60253,14 +60420,16 @@
 	},
 /area/toxins/server_coldroom)
 "ceJ" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/area/medical/genetics)
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f6";
+	icon_state = "swall_f6";
+	dir = 2
+	},
+/area/shuttle/pod_4)
 "ceK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -61305,31 +61474,16 @@
 	},
 /area/shuttle/administration)
 "cgx" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
 	},
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "viro_lab_airlock_control";
-	name = "Virology Lab Access Console";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_one_access_txt = "39";
-	tag_exterior_door = "viro_lab_airlock_exterior";
-	tag_interior_door = "viro_lab_airlock_interior"
+/turf/simulated/floor/plating,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f5";
+	icon_state = "swall_f5";
+	dir = 2
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/item/storage/fancy/vials,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
-	},
-/area/medical/virology)
+/area/shuttle/pod_4)
 "cgy" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
@@ -61699,31 +61853,6 @@
 "chf" = (
 /turf/simulated/wall,
 /area/maintenance/asmaint)
-"chg" = (
-/obj/machinery/door_control{
-	id = "mechpod";
-	name = "Mechanic's Inner Door Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "70"
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/pod_paint_bucket,
-/obj/item/pod_paint_bucket,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
 "chh" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -61883,28 +62012,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/medical/surgery1)
-"chv" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
-	},
-/area/shuttle/pod_4)
-"chw" = (
-/obj/structure/shuttle/engine/propulsion/burst{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/pod_4)
 "chx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -63424,6 +63531,13 @@
 	icon_state = "2-4";
 	tag = ""
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "cjU" = (
@@ -64637,6 +64751,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -65354,6 +65474,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -66047,6 +66173,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -66632,6 +66764,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitehall"
@@ -66651,6 +66790,17 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -66665,6 +66815,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -66786,6 +66943,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
 	},
 /turf/simulated/floor/plasteel,
 /area/toxins/mixing)
@@ -66974,6 +67138,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -67927,6 +68096,12 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -68727,6 +68902,12 @@
 	dir = 4;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -70201,6 +70382,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70552,6 +70740,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70571,6 +70766,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -70588,6 +70790,18 @@
 	dir = 4;
 	initialize_directions = 11;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -71069,6 +71283,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -72256,6 +72476,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -72407,6 +72633,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -86070,12 +86302,26 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "purple"
 	},
 /area/hallway/secondary/exit)
 "cXh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "ramptop";
@@ -86101,6 +86347,13 @@
 /turf/simulated/floor/plasteel,
 /area/engine/engineering)
 "cXj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -96422,6 +96675,16 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"fpP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "gMZ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -96536,6 +96799,20 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"leC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -96550,12 +96827,35 @@
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"neF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/starboard/east)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
 /turf/space,
 /area/space/nearstation)
+"oXt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/exit)
 "oZV" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -96584,6 +96884,17 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"qey" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "qgG" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -96595,6 +96906,19 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"qth" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "purple"
+	},
+/area/hallway/primary/starboard/east)
 "qUv" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
@@ -96682,6 +97006,19 @@
 /obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"wQz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "wVD" = (
 /obj/effect/landmark/start{
 	name = "Shaft Miner"
@@ -96691,6 +97028,35 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/miningdock)
+"xjj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
+"xpU" = (
+/obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0;
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "purple"
+	},
+/area/hallway/primary/starboard/east)
 "xAw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -96721,6 +97087,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"ygr" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/assembly/robotics)
 "ylx" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -105336,9 +105713,9 @@ aaa
 aaa
 aaa
 aaa
-bnj
+aOa
 bvi
-bnk
+aRm
 aaa
 aaa
 aaa
@@ -105592,11 +105969,11 @@ aab
 aaa
 aaa
 aaa
-bnj
+aOa
 btv
 bvj
 bwE
-bnk
+aRm
 aaa
 bAQ
 bCa
@@ -117974,7 +118351,7 @@ cEJ
 cFM
 cGD
 cJV
-bTm
+bOA
 cEY
 cLm
 cLi
@@ -118231,7 +118608,7 @@ cEL
 cFP
 cGF
 cJV
-chg
+bTm
 cEY
 cLm
 cLi
@@ -122825,7 +123202,7 @@ bxl
 bMC
 bOo
 bMG
-bOA
+bOl
 bQk
 bSd
 bTE
@@ -123079,8 +123456,8 @@ bCG
 bJH
 bFF
 bxl
-bMB
-bOl
+bMv
+bMv
 bMG
 bTc
 bUq
@@ -123336,8 +123713,8 @@ bCC
 bJH
 bFI
 bxl
-bxl
-bxl
+bMB
+bMD
 bMG
 bOC
 bQl
@@ -123593,8 +123970,8 @@ bBw
 bJH
 bKJ
 bxm
-bMD
-bOq
+bxl
+bxl
 bQo
 bTd
 bUr
@@ -124860,8 +125237,8 @@ bor
 cRN
 aRw
 dix
-aHV
-biK
+bha
+bne
 bpv
 blY
 bnW
@@ -125117,8 +125494,8 @@ aRw
 aRw
 aRw
 diw
-aKp
-biO
+bhb
+bnd
 bkz
 blU
 bnV
@@ -125374,8 +125751,8 @@ aZx
 bbr
 dcb
 bdv
-aKx
-bnd
+bhc
+bnh
 bkz
 bma
 bnY
@@ -125631,8 +126008,8 @@ baE
 beu
 bhd
 bhd
-aOa
-bne
+biI
+bnf
 bkB
 bma
 bnX
@@ -125888,8 +126265,8 @@ baF
 bev
 bhh
 bhV
-aRm
-bnf
+biK
+bnj
 bkz
 bma
 boa
@@ -129064,9 +129441,9 @@ dfR
 dcq
 dcq
 dcq
-chv
+ceJ
 doL
-chw
+cgx
 dcq
 aaa
 aaa
@@ -133387,7 +133764,7 @@ cpy
 cpN
 cru
 ctc
-cgx
+bOq
 cQn
 cwe
 cxu
@@ -135140,7 +135517,7 @@ bbC
 aGY
 beb
 djw
-bhb
+aHV
 boX
 bpH
 bqH
@@ -135397,7 +135774,7 @@ bbh
 aGY
 beb
 dju
-bhc
+aKp
 bjv
 dnD
 bmy
@@ -135654,7 +136031,7 @@ bbh
 aGY
 beb
 djx
-biI
+aKx
 bjv
 dnE
 bmy
@@ -135911,7 +136288,7 @@ bbI
 aGY
 beb
 bfH
-biI
+aKx
 bjx
 bfH
 bmy
@@ -136168,7 +136545,7 @@ bbV
 aGY
 beb
 bfJ
-biI
+aKx
 bjy
 bkY
 bmy
@@ -137997,8 +138374,8 @@ bUI
 bVU
 bXs
 bXV
-bUI
-caY
+ccQ
+caW
 bWg
 ceo
 cfY
@@ -138251,7 +138628,7 @@ bEu
 bSH
 bUf
 bUI
-bVW
+bVX
 cdn
 bXW
 bXW
@@ -138508,11 +138885,11 @@ bEu
 bSG
 bUd
 bUI
-bVX
+bVW
 cdj
 bXQ
 bXQ
-ccQ
+caY
 bWg
 ceq
 cfZ
@@ -138768,8 +139145,8 @@ bUJ
 bVZ
 bXv
 bYk
-caW
-ceJ
+bZB
+caX
 bWi
 clp
 clp
@@ -141069,7 +141446,7 @@ cXf
 bEA
 bGw
 bId
-bNJ
+xjj
 bLL
 bRs
 bTX
@@ -141326,7 +141703,7 @@ bJp
 bEA
 bEA
 bIm
-bNJ
+xjj
 bLM
 bRF
 bPp
@@ -141583,10 +141960,10 @@ bwv
 bEJ
 bGB
 bIc
-bNJ
-bId
+wQz
+qey
 bRz
-bId
+ygr
 bId
 bId
 bWe
@@ -141844,9 +142221,9 @@ bNJ
 bPb
 bRO
 bUe
-bUe
-bUe
-bUe
+leC
+leC
+leC
 bYl
 cax
 cci
@@ -142865,7 +143242,7 @@ aYP
 bFz
 bHQ
 bJq
-bJq
+neF
 bKT
 bSz
 bNn
@@ -143121,7 +143498,7 @@ bjD
 aYP
 bFw
 bHI
-bwv
+fpP
 bDq
 bEM
 bIk
@@ -143378,7 +143755,7 @@ byZ
 aYP
 aSI
 bHI
-bwv
+fpP
 bDq
 bED
 bED
@@ -143635,7 +144012,7 @@ bya
 aYQ
 aSI
 bHI
-bwv
+fpP
 bDq
 bGK
 bIt
@@ -143892,7 +144269,7 @@ boJ
 bEl
 aSI
 bHI
-bwv
+fpP
 bDq
 bGL
 bPD
@@ -144149,7 +144526,7 @@ boJ
 aYQ
 aSI
 bHI
-bwv
+fpP
 bEM
 bGK
 bIv
@@ -144406,7 +144783,7 @@ boJ
 bEl
 aSI
 bHI
-bDr
+xpU
 bED
 bED
 bIo
@@ -144663,7 +145040,7 @@ bya
 aYQ
 aSI
 bHR
-bDq
+qth
 bED
 bGC
 bIp
@@ -145692,8 +146069,8 @@ bAI
 bFH
 bHU
 bJr
-bJr
-bJr
+oXt
+oXt
 bLo
 bNt
 bPq

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -54601,7 +54601,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/genetics)
@@ -54618,7 +54617,6 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/genetics)
@@ -55486,17 +55484,16 @@
 	},
 /area/engine/gravitygenerator)
 "bXv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "bXw" = (
@@ -55750,15 +55747,7 @@
 	},
 /area/medical/medbay2)
 "bXQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 1;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
 	icon_state = "white"
 	},
 /area/medical/genetics)
@@ -55816,19 +55805,6 @@
 /area/medical/cmo)
 "bXV" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
-	},
-/area/medical/genetics)
-"bXW" = (
-/obj/structure/table/glass,
 /obj/item/hand_labeler,
 /obj/item/roller,
 /obj/machinery/alarm{
@@ -55844,6 +55820,16 @@
 	dir = 1;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
+	},
+/area/medical/genetics)
+"bXW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "bXX" = (
@@ -56028,14 +56014,16 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/hor)
 "bYk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "bYl" = (
@@ -57912,9 +57900,14 @@
 	},
 /area/medical/cmo)
 "caW" = (
+/obj/machinery/dna_scannernew,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitebluecorner";
+	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "caX" = (
@@ -57927,23 +57920,28 @@
 	},
 /area/medical/genetics)
 "caY" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
+	dir = 1;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
 /area/medical/genetics)
 "caZ" = (
-/obj/machinery/dna_scannernew,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/disks,
+/obj/machinery/power/apc{
+	dir = 2;
+	name = "south bump";
+	pixel_y = -24
 	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitebluecorner";
@@ -59179,13 +59177,13 @@
 /area/escapepodbay)
 "ccQ" = (
 /obj/structure/chair/office/light{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "Geneticist"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 2;
 	icon_state = "whitebluecorner";
 	tag = "icon-whitebluecorner"
 	},
@@ -59463,19 +59461,15 @@
 	},
 /area/crew_quarters/hor)
 "cdj" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "cdk" = (
@@ -59503,16 +59497,16 @@
 	},
 /area/shuttle/administration)
 "cdn" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start{
-	name = "Geneticist"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitebluecorner";
-	tag = "icon-whitebluecorner"
+	icon_state = "white"
 	},
 /area/medical/genetics)
 "cdo" = (
@@ -61294,30 +61288,31 @@
 	},
 /area/shuttle/administration)
 "cgx" = (
-/obj/machinery/door_control{
-	id = "mechpod";
-	name = "Mechanic's Inner Door Control";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "70"
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "viro_lab_airlock_control";
+	name = "Virology Lab Access Console";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_one_access_txt = "39";
+	tag_exterior_door = "viro_lab_airlock_exterior";
+	tag_interior_door = "viro_lab_airlock_interior"
 	},
-/obj/item/stack/sheet/glass{
-	amount = 50
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/item/storage/fancy/vials,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitegreen";
+	tag = "icon-whitehall (WEST)"
 	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/pod_paint_bucket,
-/obj/item/pod_paint_bucket,
-/turf/simulated/floor/plasteel,
-/area/engine/mechanic_workshop)
+/area/medical/virology)
 "cgy" = (
 /obj/machinery/door/poddoor{
 	id_tag = "ToxinsVenting";
@@ -61688,33 +61683,30 @@
 /turf/simulated/wall,
 /area/maintenance/asmaint)
 "chg" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/door_control{
+	id = "mechpod";
+	name = "Mechanic's Inner Door Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "70"
 	},
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "viro_lab_airlock_control";
-	name = "Virology Lab Access Console";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_one_access_txt = "39";
-	tag_exterior_door = "viro_lab_airlock_exterior";
-	tag_interior_door = "viro_lab_airlock_interior"
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/item/storage/fancy/vials{
-	contents = newlist()
+/obj/item/stack/sheet/glass{
+	amount = 50
 	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whitegreen";
-	tag = "icon-whitehall (WEST)"
+/obj/item/stack/rods{
+	amount = 50
 	},
-/area/medical/virology)
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/pod_paint_bucket,
+/obj/item/pod_paint_bucket,
+/turf/simulated/floor/plasteel,
+/area/engine/mechanic_workshop)
 "chh" = (
 /turf/simulated/wall,
 /area/medical/paramedic)
@@ -118222,7 +118214,7 @@ cEL
 cFP
 cGF
 cJV
-cgx
+chg
 cEY
 cLm
 cLi
@@ -133378,7 +133370,7 @@ cpy
 cpN
 cru
 ctc
-chg
+cgx
 cQn
 cwe
 cxu
@@ -137987,9 +137979,9 @@ bUd
 bUI
 bVU
 bXs
-bXW
+bXV
 bUI
-ccQ
+caY
 bWg
 ceo
 cfY
@@ -138243,10 +138235,10 @@ bSH
 bUf
 bUI
 bVW
-bXv
-bYk
-bYk
-cdj
+cdn
+bXW
+bXW
+caZ
 bWg
 cer
 cga
@@ -138500,10 +138492,10 @@ bSG
 bUd
 bUI
 bVX
+cdj
 bXQ
-caW
-caW
-cdn
+bXQ
+ccQ
 bWg
 ceq
 cfZ
@@ -138757,9 +138749,9 @@ bGr
 bWi
 bUJ
 bVZ
-bXV
-caY
-caZ
+bXv
+bYk
+caW
 ceJ
 bWi
 clp


### PR DESCRIPTION
## What Does This PR Do
Agrego los viales y pinturas para pods que antes estaban pero se perdieron entre las muchas updates al mapa.

## Images of changes
![image](https://user-images.githubusercontent.com/8194839/66087006-fa837700-e543-11e9-86fd-aeecb746c350.png)
![image](https://user-images.githubusercontent.com/8194839/66087016-02431b80-e544-11e9-9e70-594f677f028e.png)

## Changelog
:cl: Ryzor
add: Viales y pinturas al mapa.
del: Consola de seguridad en departamento del hop.
tweak: La consola de cuentas bancarias ahora esta donde antes estaba la de records de seguridad.
/:cl:
