### PR TITLE
[más que listo] Los tracking beacon son más utiles

### DIFF
--- a/code/HISPANIA/game/mecha/mecha_control_console.dm
+++ b/code/HISPANIA/game/mecha/mecha_control_console.dm
@@ -1,0 +1,2 @@
+/obj/item/mecha_parts/mecha_tracking/proc/recharge()
+	recharging = 0

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -144,12 +144,9 @@
 		return
 	var/obj/mecha/M = in_mecha()
 	if(M)
-		M.emp_act(2)
+		M.emp_act(1)
 		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		recharging = 1
-
-/obj/item/mecha_parts/mecha_tracking/proc/recharge()
-	recharging = 0
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -40,6 +40,7 @@
 /obj/machinery/computer/mecha/Topic(href, href_list)
 	if(..())
 		return 1
+
 	var/datum/topic_input/afilter = new /datum/topic_input(href,href_list)
 	if(href_list["send_message"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("send_message")

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -53,9 +53,9 @@
 	if(href_list["shock"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("shock")
 		if(MT.recharging)
-			to_chat(viewers(src), "<span class='notice'>Recharging EMP Pulse....</span>")
+			to_chat(usr, "<span class='notice'>Recharging EMP Pulse...</span>")
 		else
-			to_chat(viewers(src), "<span class='notice'>EMP Pulse sent</span>")
+			to_chat(usr, "<span class='notice'>EMP Pulse sent</span>")
 		MT.shock()
 
 	if(href_list["get_log"])

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -145,8 +145,10 @@
 	var/obj/mecha/M = in_mecha()
 	if(M)
 		M.emp_act(1)
-		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-		recharging = 1
+		M = in_mecha()
+		if(M)
+			addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+			recharging = 1
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -40,7 +40,6 @@
 /obj/machinery/computer/mecha/Topic(href, href_list)
 	if(..())
 		return 1
-
 	var/datum/topic_input/afilter = new /datum/topic_input(href,href_list)
 	if(href_list["send_message"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("send_message")
@@ -53,7 +52,11 @@
 
 	if(href_list["shock"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("shock")
+		if(MT.recharging)
+			to_chat(viewers(src), "<span class='notice'>Recharging EMP Pulse....</span>")
 		MT.shock()
+		if(!MT.recharging)
+			to_chat(viewers(src), "<span class='notice'>EMP Pulse sent</span>")
 
 	if(href_list["get_log"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("get_log")
@@ -74,6 +77,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "programming=2;magnets=2"
 	var/ai_beacon = FALSE //If this beacon allows for AI control. Exists to avoid using istype() on checking.
+	var/recharging = 0
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_info()
 	if(!in_mecha())
@@ -135,10 +139,16 @@
 	return FALSE
 
 /obj/item/mecha_parts/mecha_tracking/proc/shock()
+	if(recharging)
+		return
 	var/obj/mecha/M = in_mecha()
 	if(M)
 		M.emp_act(2)
-	qdel(src)
+		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		recharging = 1
+
+/obj/item/mecha_parts/mecha_tracking/proc/recharge()
+	recharging = 0
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -54,9 +54,9 @@
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("shock")
 		if(MT.recharging)
 			to_chat(viewers(src), "<span class='notice'>Recharging EMP Pulse....</span>")
-		MT.shock()
-		if(!MT.recharging)
+		else
 			to_chat(viewers(src), "<span class='notice'>EMP Pulse sent</span>")
+		MT.shock()
 
 	if(href_list["get_log"])
 		var/obj/item/mecha_parts/mecha_tracking/MT = afilter.getObj("get_log")

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -144,11 +144,9 @@
 		return
 	var/obj/mecha/M = in_mecha()
 	if(M)
+		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		recharging = 1
 		M.emp_act(1)
-		M = in_mecha()
-		if(M)
-			addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-			recharging = 1
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -146,7 +146,7 @@
 	if(M)
 		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		recharging = 1
-		M.emp_act(1)
+		M.emp_act(0.5)
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_log()
 	if(!in_mecha())

--- a/code/game/mecha/medical/medical.dm
+++ b/code/game/mecha/medical/medical.dm
@@ -1,7 +1,3 @@
 /obj/mecha/medical
 	turnsound = 'sound/mecha/mechmove01.ogg'
 	stepsound = 'sound/mecha/mechstep.ogg'
-
-/obj/mecha/medical/New()
-	..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/working/working.dm
+++ b/code/game/mecha/working/working.dm
@@ -1,7 +1,3 @@
 /obj/mecha/working
 	internal_damage_threshold = 60
 
-/obj/mecha/working/New()
-	..()
-	if(!ruin_mecha)
-		trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1155,6 +1155,7 @@
 #include "code\HISPANIA\game\jobs\job_objectives\science.dm"
 #include "code\HISPANIA\game\machinery\jukebox.dm"
 #include "code\HISPANIA\game\machinery\vending.dm"
+#include "code\HISPANIA\game\mecha\mecha_control_console.dm"
 #include "code\HISPANIA\game\mecha\equipament\tools\medical_tools.dm"
 #include "code\HISPANIA\game\objects\items\miscellaneous\bell.dm"
 #include "code\HISPANIA\game\objects\items\weapons\chronoeraser.dm"


### PR DESCRIPTION
## What Does This PR Do
-los mechas ya no se generan con un trackingbeacon
-los trackingbeacon ya no se destruyen al enviar un pulso electromagnetico
-agrega un tiempo de reutilización para enviar pulsos electromagneticos desde la consola de control de mechas.
-aumenta la severidad el emp enviado, ahora se puede destruir un mecha con 4 envios de emp.


## Why It's Good For The Game
A pesar de que encontramos una solución al abuso de los mechas antes y no creo que ese sea ya un problema éste cambio me resulta bastante interesante debido a que colocarle un  tranking beacon a los mechas es parte crucial del sop del robotista pero los mechas ya se generaban con uno y no tenia sentido, luego el  tracking beacon solo servia para rastraer y la funcion de "enviar un pem" era un boton trampa donde solo hacia una cantidad ridicula de daño y descargaba un poco la bateria al costo de que con eso el  tracking beacon se destruia y ya no eras capaz de rastrear el mecha. Ésto le da más utilidad al boton de EMP de la consola de control de mechas y ya no se siente mal usarlo (ya no es una trampa para bobos). También, esto le da más sentido al sop del robotista. 

## Changelog
:cl:Evankhell
del: los mechas ya no se generan con un tranking beacon.
balance: los tracking beacon ya no se destruyen al enviar un emp.
add: agrega un tiempo de reutilización para enviar pulsos electromagneticos desde la consola de control de mechas.
balance: aumenta el daño puede enviar la consola de control de mechas a los mechas.
/:cl:
