### PR TITLE
[listo] Cambios a la consola de RnD

### DIFF
--- a/code/HISPANIA/modules/research/rdconsole.dm
+++ b/code/HISPANIA/modules/research/rdconsole.dm
@@ -1,0 +1,7 @@
+/obj/machinery/computer/rdconsole/auto_use_power()
+	..()
+	if(!powered(power_channel))
+		qdel(files)
+		files = new /datum/research(src)
+
+

--- a/code/HISPANIA/modules/research/rdconsole.dm
+++ b/code/HISPANIA/modules/research/rdconsole.dm
@@ -1,4 +1,4 @@
-/obj/machinery/computer/rdconsole/auto_use_power()
+/obj/machinery/computer/rdconsole/power_change()
 	..()
 	if(!powered(power_channel))
 		qdel(files)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -335,7 +335,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(choice == "Cancel" || !linked_destroy)
 					return
 			linked_destroy.busy = 1
-			add_wait_message("Processing and Updating Database...", DECONSTRUCT_DELAY/2)
+			add_wait_message("Processing and Updating Database...", DECONSTRUCT_DELAY)
 			SSnanoui.update_uis(src)
 			flick("d_analyzer_process", linked_destroy)
 			spawn(DECONSTRUCT_DELAY)
@@ -433,7 +433,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * new_coeff * amount ** 0.8
 					var/enough_materials = 1
 
-					add_wait_message("Constructing Prototype. Please Wait...", time_to_construct/2)
+					add_wait_message("Constructing Prototype. Please Wait...", time_to_construct)
 					linked_lathe.busy = 1
 					flick("protolathe_n",linked_lathe)
 					use_power(power)
@@ -507,7 +507,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(g2g) //Again, if input is wrong, do nothing
 					var/new_coeff = (coeff * (1-(7.6/7))) + (7.6/7)
 					var/time_to_construct = IMPRINTER_DELAY * new_coeff * being_built.lathe_time_factor
-					add_wait_message("Imprinting Circuit. Please Wait...", time_to_construct/2)
+					add_wait_message("Imprinting Circuit. Please Wait...", time_to_construct)
 					linked_imprinter.busy = 1
 					flick("circuit_imprinter_ani",linked_imprinter)
 					use_power(power)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -505,9 +505,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					message_admins("Circuit imprinter exploit attempted by [key_name(usr, TRUE)]!")
 
 				if(g2g) //Again, if input is wrong, do nothing
-					var/new_coeff = (coeff * (1-(7.6/7))) + (7.6/7)
-					var/time_to_construct = IMPRINTER_DELAY * new_coeff * being_built.lathe_time_factor
-					add_wait_message("Imprinting Circuit. Please Wait...", time_to_construct)
+					add_wait_message("Imprinting Circuit. Please Wait...", IMPRINTER_DELAY)
 					linked_imprinter.busy = 1
 					flick("circuit_imprinter_ani",linked_imprinter)
 					use_power(power)
@@ -533,7 +531,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							linked_imprinter.reagents.remove_reagent(R, being_built.reagents_list[R]/coeff)
 
 					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
-					spawn(time_to_construct)
+					spawn(IMPRINTER_DELAY)
 						if(g2g)
 							var/obj/item/new_item = new P(src)
 							new_item.loc = linked_imprinter.loc

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -32,13 +32,13 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 // Who likes #defines?
 // I don't!
 // but I gotta add 'em anyways because we have a bias against /const statements for some reason
-#define TECH_UPDATE_DELAY 20
-#define DESIGN_UPDATE_DELAY 20
+#define TECH_UPDATE_DELAY 50
+#define DESIGN_UPDATE_DELAY 50
 #define PROTOLATHE_CONSTRUCT_DELAY 32
-#define SYNC_RESEARCH_DELAY 10
-#define DECONSTRUCT_DELAY 18
-#define SYNC_DEVICE_DELAY 10
-#define RESET_RESEARCH_DELAY 10
+#define SYNC_RESEARCH_DELAY 30
+#define DECONSTRUCT_DELAY 24
+#define SYNC_DEVICE_DELAY 20
+#define RESET_RESEARCH_DELAY 20
 #define IMPRINTER_DELAY 16
 
 /obj/machinery/computer/rdconsole

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -32,14 +32,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 // Who likes #defines?
 // I don't!
 // but I gotta add 'em anyways because we have a bias against /const statements for some reason
-#define TECH_UPDATE_DELAY 25
-#define DESIGN_UPDATE_DELAY 25
+#define TECH_UPDATE_DELAY 20
+#define DESIGN_UPDATE_DELAY 20
 #define PROTOLATHE_CONSTRUCT_DELAY 32
-#define SYNC_RESEARCH_DELAY 15
-#define DECONSTRUCT_DELAY 12
+#define SYNC_RESEARCH_DELAY 10
+#define DECONSTRUCT_DELAY 18
 #define SYNC_DEVICE_DELAY 10
 #define RESET_RESEARCH_DELAY 10
-#define IMPRINTER_DELAY 10
+#define IMPRINTER_DELAY 16
 
 /obj/machinery/computer/rdconsole
 	name = "\improper R&D console"
@@ -335,7 +335,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(choice == "Cancel" || !linked_destroy)
 					return
 			linked_destroy.busy = 1
-			add_wait_message("Processing and Updating Database...", DECONSTRUCT_DELAY)
+			add_wait_message("Processing and Updating Database...", DECONSTRUCT_DELAY/2)
 			SSnanoui.update_uis(src)
 			flick("d_analyzer_process", linked_destroy)
 			spawn(DECONSTRUCT_DELAY)
@@ -433,7 +433,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * new_coeff * amount ** 0.8
 					var/enough_materials = 1
 
-					add_wait_message("Constructing Prototype. Please Wait...", time_to_construct)
+					add_wait_message("Constructing Prototype. Please Wait...", time_to_construct/2)
 					linked_lathe.busy = 1
 					flick("protolathe_n",linked_lathe)
 					use_power(power)
@@ -505,7 +505,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					message_admins("Circuit imprinter exploit attempted by [key_name(usr, TRUE)]!")
 
 				if(g2g) //Again, if input is wrong, do nothing
-					add_wait_message("Imprinting Circuit. Please Wait...", IMPRINTER_DELAY)
+					var/new_coeff = (coeff * (1-(7.6/7))) + (7.6/7)
+					var/time_to_construct = IMPRINTER_DELAY * new_coeff * being_built.lathe_time_factor
+					add_wait_message("Imprinting Circuit. Please Wait...", time_to_construct/2)
 					linked_imprinter.busy = 1
 					flick("circuit_imprinter_ani",linked_imprinter)
 					use_power(power)
@@ -531,7 +533,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							linked_imprinter.reagents.remove_reagent(R, being_built.reagents_list[R]/coeff)
 
 					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
-					spawn(IMPRINTER_DELAY)
+					spawn(time_to_construct)
 						if(g2g)
 							var/obj/item/new_item = new P(src)
 							new_item.loc = linked_imprinter.loc

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -32,14 +32,14 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 // Who likes #defines?
 // I don't!
 // but I gotta add 'em anyways because we have a bias against /const statements for some reason
-#define TECH_UPDATE_DELAY 50
-#define DESIGN_UPDATE_DELAY 50
+#define TECH_UPDATE_DELAY 25
+#define DESIGN_UPDATE_DELAY 25
 #define PROTOLATHE_CONSTRUCT_DELAY 32
-#define SYNC_RESEARCH_DELAY 30
-#define DECONSTRUCT_DELAY 24
-#define SYNC_DEVICE_DELAY 20
-#define RESET_RESEARCH_DELAY 20
-#define IMPRINTER_DELAY 16
+#define SYNC_RESEARCH_DELAY 15
+#define DECONSTRUCT_DELAY 12
+#define SYNC_DEVICE_DELAY 10
+#define RESET_RESEARCH_DELAY 10
+#define IMPRINTER_DELAY 10
 
 /obj/machinery/computer/rdconsole
 	name = "\improper R&D console"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1197,6 +1197,7 @@
 #include "code\HISPANIA\modules\reagents\chemistry\reagents\alcohol.dm"
 #include "code\HISPANIA\modules\reagents\chemistry\reagents\drinks.dm"
 #include "code\HISPANIA\modules\reagents\chemistry\recipes\drinks.dm"
+#include "code\HISPANIA\modules\research\rdconsole.dm"
 #include "code\HISPANIA\modules\research\designs\comp_board_designs.dm"
 #include "code\HISPANIA\modules\research\designs\equipment_designs.dm"
 #include "code\HISPANIA\modules\research\designs\machine_designs.dm"


### PR DESCRIPTION
## What Does This PR Do

si se va la luz o la consola pierde energía por algun motivo, se pierde toda la investigación no guardada en el servidor.

## Why It's Good For The Game

Esto  trae consistencia a lo que es la computadora de rnd, cuando la desarmas tempralmente (asi sea dandole con el destornillador) ésta pierde toda la investigación hasta ese momento por lo que se da a entender que esta consola no puede apagarse ni por un momento para que no pierda sus archivos por lo que si se va la luz tampoco deberia conservar sus datos. Esto se puede evitar manteniendo sincronizado la consola al servidor.

## Changelog
:cl:Evankhell
add: Si se va la consola de rnd se queda sin energía, se perderá toda la investigación no subida al servidor (sincronizada).
/:cl: