### PR TITLE
Fix hot_coco v3

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -216,7 +216,7 @@
 	desc = "Made in Space South America."
 	icon_state = "hot_coco"
 	item_state = "coffee"
-	list_reagents = list("chocolate" = 30)
+	list_reagents = list("hot_coco" = 30)
 
 /obj/item/reagent_containers/food/drinks/chocolate
 	name = "hot chocolate"


### PR DESCRIPTION
## What Does This PR Do
-el Dutch hot coco ya no te alimenta

El pr #43  no funciono porque el ingrediente roto siempre fue el chocolate (que se encontraba dentro del chocolate caliente) y no el hot choco. Nicaragua nerfeo el hot choco (que no tenia mucho que ver en el asunto aunque igual estaba roto) y cuando se quiso dar cuenta intento arreglar su mierda.., lo que nos lleval pr #72  donde le paso el chocolate (el roto) a otra bebida y al hot choco (el vaso de la mquina) le dio como reactivo el hot_choco al que habia nerfeado. El argumento era que esta bebida llamada "Dutch hot coco" no aparecia en las maquinas vendedoras. cosa que no era cierto. Asi que el componente roto, el chocolate nunca dejo de venderse solo que estaba en otra bebida. 

## Why It's Good For The Game

Esto hace que el trabajo del cheff realmente sea importante. 


## Changelog
:cl:Evanakhell
balance: el Dutch hot coco vuelve a tener hot_choco en vez de chocolate.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
