### PR TITLE
La cryoxadona solo cura el daño de clonación y de oxigeno

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -118,11 +118,11 @@
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(M.bodytemperature < TCRYO)
-		update_flags |= M.adjustCloneLoss(-4, FALSE)
-		update_flags |= M.adjustOxyLoss(-10, FALSE)
-		update_flags |= M.adjustToxLoss(-3, FALSE)
-		update_flags |= M.adjustBruteLoss(-12, FALSE)
-		update_flags |= M.adjustFireLoss(-12, FALSE)
+		update_flags |= M.adjustCloneLoss(-10, FALSE)
+		update_flags |= M.adjustOxyLoss(0, FALSE)
+		update_flags |= M.adjustToxLoss(0, FALSE)
+		update_flags |= M.adjustBruteLoss(0, FALSE)
+		update_flags |= M.adjustFireLoss(0, FALSE)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head = H.get_organ("head")

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -119,7 +119,7 @@
 	var/update_flags = STATUS_UPDATE_NONE
 	if(M.bodytemperature < TCRYO)
 		update_flags |= M.adjustCloneLoss(-10, FALSE)
-		update_flags |= M.adjustOxyLoss(0, FALSE)
+		update_flags |= M.adjustOxyLoss(-15, FALSE)
 		update_flags |= M.adjustToxLoss(0, FALSE)
 		update_flags |= M.adjustBruteLoss(0, FALSE)
 		update_flags |= M.adjustFireLoss(0, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-La cryoxadon ahora solo cura el daño de clonación y de oxigeno aunque mucho más rapido.

## Why It's Good For The Game
Hay muchisimos quimicos en medbay con todo tipo de efectos y faciles de hacer. Esto le daria más importancia al rol de quimico y en realidad es un cambio que se puede superar facilmente. si quieren que el cryo cure otros daños, crear un poco de saline glucose y mezclarla con la cryoxadona en el cryomix ya curará el 3 de los cuatro tipos de daño que ha perdido la cryoxadona. Meterse en cryo debe ser un proceso lento, no algo que cure tan rapido como lo hace actualmente. 

También, la cryoxadona  opaca todos los otros quimicos ¿Por qué ponerse a hacer quimicos para curar  toxinas, oxygeno, daño bruto y quemaduras si puedo hacer una sola medicina magica? Igualmente, en los nanomeds se encuentran todos los medicamentos que hacen lo mismo que estoy retirando de cryo y hay parches que hacen lo mismo. De la misma forma, los nanomeds se pueden rellenar con una visita a cargo y los parches también.

Además, con el newcrit generando grandes daños de oxigeno a los pacientes, la cryoxadona tendria el rol de mantener estabale a un paciente  vivo mientras se buscan formas de curar otros daños (eso o hacer un buen criomix). 
## Changelog
:cl:Evankhell
balance: la cryoxadona  cura más rapido el daño de clonación y de oxigeno, ya no cura otros daños.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
