### PR TITLE
Aumenta el rango de la explosión objetivo del doppler array

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -29,7 +29,7 @@ var/list/doppler_arrays = list()
 /obj/machinery/doppler_array/New()
 	..()
 	doppler_arrays += src
-	explosion_target = rand(8, 50)
+	explosion_target = rand(10, 50)
 	toxins_tech = new /datum/tech/toxins(src)
 
 /obj/machinery/doppler_array/Destroy()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -29,7 +29,7 @@ var/list/doppler_arrays = list()
 /obj/machinery/doppler_array/New()
 	..()
 	doppler_arrays += src
-	explosion_target = rand(8, 20)
+	explosion_target = rand(8, 50)
 	toxins_tech = new /datum/tech/toxins(src)
 
 /obj/machinery/doppler_array/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-Aumenta el rango de la explosión objetivo del doppler array

## Why It's Good For The Game

La tecnologia de toxinas no es para nada necesaria para el trabajo de merjorar la estación y ahi no hay nada vital, lo que hace que subir esta tecnologia no sea importante sin embargo existen muchos que la suben solo por rol y para divertirse haciendo toxinas. El gran problema es que los valores objetivos actuales es que son tan pero tan bajos que casi caulquier bomba de toxinas la supera con creces esto está bien pero cuando puedes subir toxinas lanzando granadas de agua y potasio entonces hay un problema. Los valores actuales son un chiste.

Mantener la posibilidad de que salgan valores bajos para que los cientificos aprendan la precisión y subir el valor maximo para que aprendan a hacer las bombas más grandes del juego es una buena dinámica que fomenta a aprender todo sobre la creación de bombas de toxinas lo que se traduce en que los jugadores puedan aprender más cosas y al hacer la tecnologia de toxinas un reto mayor, la hará más interesante para los que aman trabajar en este laboratorio.

## Changelog
:cl:Evankhell
tweak: la explosión objetivo del doppler array puede ser más alto.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
