### PR TITLE
los robotistas ya no tienen el objetivo de hacer bots

### DIFF
--- a/code/HISPANIA/game/jobs/job_objectives/science.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/science.dm
@@ -7,13 +7,3 @@
 	var/desc = "Make a Odysseus."
 	desc += "([units_completed] created.)"
 	return desc
-
-//BOT
-/datum/job_objective/make_bot
-	completion_payment = 20
-	per_unit = 1
-
-/datum/job_objective/make_bot/get_description()
-	var/desc = "Make a Bot."
-	desc += "([units_completed] created.)"
-	return desc

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -106,8 +106,7 @@
 	required_objectives = list(
 		/datum/job_objective/make_cyborg,
 		/datum/job_objective/make_ripley,
-		/datum/job_objective/make_odysseus,
-		/datum/job_objective/make_bot
+		/datum/job_objective/make_odysseus
 	)
 
 	outfit = /datum/outfit/job/roboticist

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -27,9 +27,6 @@ var/robot_arm = /obj/item/robot_parts/l_arm
 		to_chat(user, "<span class='notice'>You add the robot arm to the bucket and sensor assembly. Beep boop!</span>")
 		user.unEquip(src, 1)
 		qdel(src)
-		var/datum/job_objective/make_bot/task = user.mind.findJobTask(/datum/job_objective/make_bot)
-		if(istype(task))
-			task.unit_completed()
 
 	else if(istype(W, /obj/item/pen))
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
@@ -301,9 +298,7 @@ var/robot_arm = /obj/item/robot_parts/l_arm
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly. Boop beep!</span>")
 		user.unEquip(src, 1)
 		qdel(src)
-		var/datum/job_objective/make_bot/task = user.mind.findJobTask(/datum/job_objective/make_bot)
-		if(istype(task))
-			task.unit_completed()
+
 	else if(istype(W, /obj/item/pen))
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
@@ -402,9 +397,6 @@ var/robot_arm = /obj/item/robot_parts/l_arm
 					qdel(I)
 					build_step++
 					to_chat(user, "<span class='notice'>You complete the Medibot. Beep boop!</span>")
-					var/datum/job_objective/make_bot/task = user.mind.findJobTask(/datum/job_objective/make_bot)
-					if(istype(task))
-						task.unit_completed()
 					var/turf/T = get_turf(src)
 					if(!syndicate_aligned)
 						var/mob/living/simple_animal/bot/medbot/S = new /mob/living/simple_animal/bot/medbot(T, skin)
@@ -487,9 +479,6 @@ var/robot_arm = /obj/item/robot_parts/l_arm
 			return
 		build_step++
 		to_chat(user, "<span class='notice'>You complete the Securitron! Beep boop.</span>")
-		var/datum/job_objective/make_bot/task = user.mind.findJobTask(/datum/job_objective/make_bot)
-		if(istype(task))
-			task.unit_completed()
 		var/mob/living/simple_animal/bot/secbot/S = new /mob/living/simple_animal/bot/secbot
 		S.forceMove(get_turf(src))
 		S.name = created_name

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -298,7 +298,6 @@ var/robot_arm = /obj/item/robot_parts/l_arm
 		to_chat(user, "<span class='notice'>You add the robot arm to the odd looking toolbox assembly. Boop beep!</span>")
 		user.unEquip(src, 1)
 		qdel(src)
-
 	else if(istype(W, /obj/item/pen))
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-le quita a los robotistas el objetivo departamental de hacer bots
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cuando empecé a hacer esto lo hice para ver  como funcionaba el tema de los objetivos departamentales y en parte también tenia la intención que se recompensara a todos por hacer su trabajo sin en embargo, cuando hacia los objetivos del CE, originalmente iba a ser para todos los ingenieros y alguien mencionó que el endround se llenaria de nombres, algo que yo no habia considerado. El robotista ya tenia dos objetivos y yo le agregué uno dos, todos ellos son significativos salvo este. Hacer bots es algo fácil, rapiddo y poco significativo. No es digno de aparecer en el enround.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Evankhell
del: los robotistas ya no tienen el objetivo de hacer bots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
