### PR TITLE
[listo]Ahora puedes sacar a un piloto de su mecha si tener que romper el mecha.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -786,18 +786,18 @@
 		else if(state==3)
 			state=2
 			to_chat(user, "You close the hatch to the power unit")
-		else if(state==4 && pilot_is_mmi())
-			// Since having maint protocols available is controllable by the MMI, I see this as a consensual way to remove an MMI without destroying the mech
-			user.visible_message("[user] begins levering out the MMI from the [src].", "You begin to lever out the MMI from the [src].")
+		else if(state==4 && (pilot_is_mmi() || istype(occupant, /mob/living/carbon)))
+			// Since having maint protocols available is controllable by the pilot, I see this as a consensual way to remove a pilot without destroying the mech
+			if(pilot_is_mmi())
+				user.visible_message("[user] begins levering out the MMI from the [src].", "You begin to lever out the MMI from the [src].")
+			else
+				user.visible_message("[user] begins levering out the pilot from the [src].", "You begin to lever out the pilot from the [src].")
 			to_chat(occupant, "<span class='warning'>[user] is prying you out of the exosuit!</span>")
 			if(do_after(user, 80 * W.toolspeed, target=src))
-				user.visible_message("<span class='notice'>[user] pries the MMI out of the [src]!</span>", "<span class='notice'>You finish removing the MMI from the [src]!</span>")
-				go_out()
-		else if(state==4 && istype(occupant, /mob/living/carbon))
-			user.visible_message("[user] begins levering out the pilot from the [src].", "You begin to lever out the pilot from the [src].")
-			to_chat(occupant, "<span class='warning'>[user] is prying you out of the exosuit!</span>")
-			if(do_after(user, 80 * W.toolspeed, target=src))
-				user.visible_message("<span class='notice'>[user] pries the pilot out of the [src]!</span>", "<span class='notice'>You finish removing the pilot from the [src]!</span>")
+				if(pilot_is_mmi())
+					user.visible_message("<span class='notice'>[user] pries the MMI out of the [src]!</span>", "<span class='notice'>You finish removing the MMI from the [src]!</span>")
+				else
+					user.visible_message("<span class='notice'>[user] pries the pilot out of the [src]!</span>", "<span class='notice'>You finish removing the pilot from the [src]!</span>")
 				go_out()
 		return
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -788,16 +788,10 @@
 			to_chat(user, "You close the hatch to the power unit")
 		else if(state==4 && (pilot_is_mmi() || istype(occupant, /mob/living/carbon)))
 			// Since having maint protocols available is controllable by the pilot, I see this as a consensual way to remove a pilot without destroying the mech
-			if(pilot_is_mmi())
-				user.visible_message("[user] begins levering out the MMI from the [src].", "You begin to lever out the MMI from the [src].")
-			else
-				user.visible_message("[user] begins levering out the pilot from the [src].", "You begin to lever out the pilot from the [src].")
+			user.visible_message("[user] begins levering out the [pilot_is_mmi() ? "MMI" : "pilot"] from the [src].", "You begin to lever out the [pilot_is_mmi() ? "MMI" : "pilot"] from the [src].")
 			to_chat(occupant, "<span class='warning'>[user] is prying you out of the exosuit!</span>")
 			if(do_after(user, 80 * W.toolspeed, target=src))
-				if(pilot_is_mmi())
-					user.visible_message("<span class='notice'>[user] pries the MMI out of the [src]!</span>", "<span class='notice'>You finish removing the MMI from the [src]!</span>")
-				else
-					user.visible_message("<span class='notice'>[user] pries the pilot out of the [src]!</span>", "<span class='notice'>You finish removing the pilot from the [src]!</span>")
+				user.visible_message("<span class='notice'>[user] pries the [pilot_is_mmi() ? "MMI" : "pilot"] out of the [src]!</span>", "<span class='notice'>You finish removing the [pilot_is_mmi() ? "MMI" : "pilot"] from the [src]!</span>")
 				go_out()
 		return
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -793,6 +793,12 @@
 			if(do_after(user, 80 * W.toolspeed, target=src))
 				user.visible_message("<span class='notice'>[user] pries the MMI out of the [src]!</span>", "<span class='notice'>You finish removing the MMI from the [src]!</span>")
 				go_out()
+		else if(state==4 && istype(occupant, /mob/living/carbon))
+			user.visible_message("[user] begins levering out the pilot from the [src].", "You begin to lever out the pilot from the [src].")
+			to_chat(occupant, "<span class='warning'>[user] is prying you out of the exosuit!</span>")
+			if(do_after(user, 80 * W.toolspeed, target=src))
+				user.visible_message("<span class='notice'>[user] pries the pilot out of the [src]!</span>", "<span class='notice'>You finish removing the pilot from the [src]!</span>")
+				go_out()
 		return
 
 	else if(istype(W, /obj/item/stack/cable_coil))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-Da la posibilidad de sacar a un piloto de mecha sin tener que romper el mecha. La forma de hacerlo es la misma con la que sacarias a un MMI del mecha. 

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ésta es una caracteristia que viene desde la guia de robotica de paradise y cuando intenté aplicarla  en mis primeros dias en ciencias me di cuenta de que esa caracteristica no existia. Es util para cuando el piloto está inconciente dentro del mecha, ya sea porque ha muerto, o dormido. También es útil para cuando un tonto se roba un mecha y logras activarle los protocolos de mantenimiento para que no se mueva pero luego se niega a bajarse de ahi. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ahora puedes sacar a un piloto de su mecha si tener que romper el mecha.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
