### PR TITLE
arregla mi mierda (fix escudos -dos fix-)

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -6,7 +6,7 @@
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		final_block_chance += 30
-	if(owner.get_active_hand())
+	if(owner.is_in_active_hand(src))
 		final_block_chance += 25
 	else
 		final_block_chance -= 10

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -7,7 +7,7 @@
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
 		final_block_chance += 30
 	if(owner.is_in_active_hand(src))
-		final_block_chance += 25
+		final_block_chance += 15
 	else
 		final_block_chance -= 10
 	if(attack_type == LEAP_ATTACK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
1. get_active_hand no se aseguraba que tuvieras el escudo en la mano activa, se asegurara que tuvieras un objeto en la mano activa. Esto quiere decir siempre que tuvieras un escudo + otra cosa, los escudos estaban buffeados sin importar en que mano tuvieras el escudo. 
2. Los escudos estaban bloqueando hasta 75% de las veces cuando los usabas en la mano activa. Se supone que deben bloquear un 65%. Esto lo arregla.

Esto también es la razon por la que pasó mis test y los de ryzor. Nunca probé atacar al usuario del escudo mientras sostenia un objeto diferente en su mano activa.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Esto arregla una mecánica que se intentó introducir al juego. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: si usas el escudo en la mano activa tienes un 65% de probabilidades de bloqueo.
fix: los escudos son mejores o peores dependiendo de si los tienes en la mano activa o no.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
