### PR TITLE
Nuevo objetivo para el botanico

### DIFF
--- a/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
@@ -5,6 +5,6 @@
 	per_unit = 1
 
 /datum/job_objective/further_plants/get_description()
-	var/desc = "create new varieties of plants, and send it to centcomm from cargo."
+	var/desc = "Create new varieties of plants, and send it to centcomm from cargo."
 	desc += "([units_completed] completed.)"
 	return desc

--- a/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
@@ -1,0 +1,16 @@
+// NEW PLATNS
+
+/datum/job_objective/further_plants
+	completion_payment = 250
+	per_unit = 1
+
+/datum/job_objective/further_plants/get_description()
+	var/desc = "create new varieties of plants, and send it to centcomm from cargo."
+	desc += "([units_completed] completed.)"
+	return desc
+
+/datum/job_objective/exotic_plants/check_for_completion()
+	for(var/plant in SSshuttle.techLevels)
+		if(SSshuttle.discoveredPlants[plant] > 0)
+			return 1
+	return 0

--- a/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
@@ -12,5 +12,5 @@
 /datum/job_objective/exotic_plants/check_for_completion()
 	for(var/plant in SSshuttle.techLevels)
 		if(SSshuttle.discoveredPlants[plant] > 0)
-			return 1
-	return 0
+			return TRUE
+	return FALSE

--- a/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
+++ b/code/HISPANIA/game/jobs/job_objectives/hydroponics.dm
@@ -8,9 +8,3 @@
 	var/desc = "create new varieties of plants, and send it to centcomm from cargo."
 	desc += "([units_completed] completed.)"
 	return desc
-
-/datum/job_objective/exotic_plants/check_for_completion()
-	for(var/plant in SSshuttle.techLevels)
-		if(SSshuttle.discoveredPlants[plant] > 0)
-			return TRUE
-	return FALSE

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -87,6 +87,9 @@
 	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
 	minimal_access = list(access_hydroponics, access_morgue, access_maint_tunnels)
 	alt_titles = list("Hydroponicist", "Botanical Researcher")
+	required_objectives = list(
+		/datum/job_objective/further_plants
+	)
 	outfit = /datum/outfit/job/hydro
 
 /datum/outfit/job/hydro

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -208,6 +208,10 @@
 							msg += "<span class='bad'>+0</span>: New sample of \"[capitalize(S.species)]\" is not more potent than existing sample ([SSshuttle.discoveredPlants[S.type]] potency).<br>"
 					else // This is a new discovery!
 						SSshuttle.discoveredPlants[S.type] = S.potency
+						for(var/mob/M in GLOB.player_list)
+							if(M.mind)
+								for(var/datum/job_objective/further_plants/objective in M.mind.job_objectives)
+									objective.unit_completed()
 						msg += "<span class='good'>[S.rarity]</span>: New species discovered: \"[capitalize(S.species)]\". Excellent work.<br>"
 						SSshuttle.points += S.rarity // That's right, no bonus for potency.  Send a crappy sample first to "show improvement" later
 		qdel(MA)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1152,6 +1152,7 @@
 #include "code\HISPANIA\defines\procs\discord.dm"
 #include "code\HISPANIA\game\hispania_items.dm"
 #include "code\HISPANIA\game\jobs\job_objectives\engineering.dm"
+#include "code\HISPANIA\game\jobs\job_objectives\hydroponics.dm"
 #include "code\HISPANIA\game\jobs\job_objectives\science.dm"
 #include "code\HISPANIA\game\machinery\jukebox.dm"
 #include "code\HISPANIA\game\machinery\vending.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-crear nuevas variedades de plantas plantas y enviarlas a cargo. Casi todo el cidog para que esto funcione ya está implmentado, solo faltaba el objetivo en sí. El pago propuesto es 250 por cada nueva planta descubierta y enviada a cargo.
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
¿A cargo le dan puntos cada vez que el botanico envia plantas, por qué al bontánico no le pagan nada por ello? Esto fomenta a que el botanico entregue plantas a cargo y así estos puedan conseguir más puntos. También, sirve para que los nuevos botánicos y los viejos tengan un motivo más tangible del por qué crear plantas nuevas más allá de "porque es divertido" o "para ayudar a ciencias con la investigación"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: El botánico ahora tiene como objetivo crear nuevas variedades de plantas y enviarlas a la central.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
