### PR TITLE
los closets de armas del codigo gamma requieren acceso a sec en vez de la armeria

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/secure_closet/guncabinet
 	name = "gun cabinet"
-	req_access = list(access_armory)
+	req_access = list(access_security)
 	icon = 'icons/obj/guncabinet.dmi'
 	icon_state = "base"
 	icon_closed = "base"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-Los closets de armas del codigo gamma requieren acceso a sec en vez de la armeria
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
El segundo departamento que juego es sec, casi siempre como securata ordinario y cuando se llama al codigo gamma, que las ocasiones son pocas es porque todo se ha ido a la mierda, en el 90% de los casos se dan las siguientes situaciones
1. No hay en la partida un warden o un hos
2. Estos ya han muerto
3. el hos, el warden (o quien esté al mando) te mandan a equiparte con las armas del codigo gamma. Ellos están ocupados con otras cosas.
Y en todos los casos la cosa termina igual, te montas en el mecha que viene desbloqueado y con un arma lista para usarse y le disparas a los closets de armas para poder equiparte tú o a tus compañeros. Y te quedas maldiciendo de por qué NT ha enviado armas con un acceso que nadie en la estación tiene y no decidieron enviarte armas listas para usar. 

Esto, considero yo es un paso a resolver las unicas cosas malas del departamento de sec, que son este embotellamiento de armas en código gamma y lo mucho que tardas en desvestir al prisionero y quitarle todo el equipo para ponerle ropa de prisionero y guardar sus antiguas cosas en el closet de la celda en que lo meterás.

El lado negativo de esto es que le quita un poco de poder al hos y el warden pero si ellos quieren prohibirle a los securatas armarse, basta con una orden -que por lo general (y si es que hay) un hos no le niega las armas a sus securatas en codigo gamma- (y aun si no tienen accesos y no quieren seguir la orden del hos lograran tomar las armas de todos modos gracias al mecha) 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: Evankhell
tweak: los closets de armas del codigo gamma ahora requieren accesos de seguridad en vez de acceso a la armeria
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
