### PR TITLE
No más creación de energía de la nada: Rechargers

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -116,8 +116,8 @@
 		if(istype(charging, /obj/item/melee/baton))
 			var/obj/item/melee/baton/B = charging
 			if(B.bcell)
-				if(B.bcell.give(B.bcell.chargerate/2.5))
-					use_power(B.bcell.chargerate * 100)
+				if(B.bcell.give(B.bcell.chargerate))
+					use_power(B.bcell.chargerate * 2)
 					using_power = TRUE
 
 		if(istype(charging, /obj/item/modular_computer))

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -67,7 +67,7 @@
 		else
 			to_chat(user, "<span class='notice'>[src] isn't connected to anything!</span>")
 		return 1
-		
+
 	if(anchored && !charging)
 		if(default_deconstruction_screwdriver(user, "rechargeropen", "recharger0", G))
 			return
@@ -116,8 +116,8 @@
 		if(istype(charging, /obj/item/melee/baton))
 			var/obj/item/melee/baton/B = charging
 			if(B.bcell)
-				if(B.bcell.give(B.bcell.chargerate))
-					use_power(200)
+				if(B.bcell.give(B.bcell.chargerate/2.5))
+					use_power(B.bcell.chargerate * 100)
 					using_power = TRUE
 
 		if(istype(charging, /obj/item/modular_computer))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Recargar un stun baton en un recharger es más lento y gasta más energía.

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
los stun baton usan una bateria para funcionar, recargar en un cell charger o un recharger debe ser similar, esto se puede tomar como una continuación de https://github.com/Helixis/Paradise/pull/234 pero como los cambios al cell recharger son más grandes que este quise terlos separados. 

La idea de todos los pr de <No más creación de energía de la nada> es intentar que la producción artificial de energía se reduzca a cero, que será tratado en un proximo pr sobre apcs. Esto es allanar el terrono para ese pr. En este caso, los rechargers consumirán más energía de la necesaria para recargarlos, la idea es que haya una perdida de energía al trasferirla (como pasa irl)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: Recargar un stunbaton consume más energía de la que se necesita para recargar el stunbaton
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
