### PR TITLE
cambios al mechfabricator / arregla mi mierda

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -268,7 +268,7 @@
 	return round(D.materials[resource]*component_coeff, roundto)
 
 /obj/machinery/mecha_part_fabricator/proc/get_construction_time_w_coeff(datum/design/D, roundto = 1) //aran
-	return round(initial(D.construction_time)*time_coeff, roundto)
+	return round(initial(D.construction_time)*initial(D.lathe_time_factor)*time_coeff, roundto)
 
 /obj/machinery/mecha_part_fabricator/attack_ghost(mob/user)
 	interact(user)

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -36,7 +36,7 @@ other types of metals and chemistry for reagents).
 	var/list/req_tech = list()			//IDs of that techs the object originated from and the minimum level requirements.
 	var/build_type = null				//Flag as to what kind machine the design is built in. See defines.
 	var/list/materials = list()			//List of materials. Format: "id" = amount.
-	var/construction_time				//Amount of time required for building the object
+	var/construction_time = 50				//Amount of time required for building the object
 	var/build_path = null				//The file path of the object that gets created
 	var/list/make_reagents = list()			//Reagents produced. Format: "id" = amount. Currently only supported by the biogenerator.
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
-inicializa el delay de construccion del mechfabricator en 50.
-ahora el mechfabricator considera el factor de construcción del diseño que se va a imprimir (lo hace compatible con los stocks parts, baterias y otros)

Luego de que https://github.com/Helixis/Paradise/pull/181 se margeara decidí darle una ojeada al codigo nuevamente para garantizar que todo esté en orden. Entonces me fijé en la variable `construction_time ` y me era rara que no estuviera en todos los otros diseños del protolathe pero sí en las baterias... en fin para no hacer el cuento largo: la variable `construction_time` está ahi para determinar cuanto tiempo tarda en construir algo el mech fabricator (y no afecta a cuanto tiempo tarda en construir algo el protolathe), y que el `lathe_time_factor ` solo aplica al protolathe y no al mechfabricator. Por lo que basicamente al borrar la variable `construction_time` en ese pr, las baterias ahora tienen un tiempo de construcción de cero si se fabrican en el mechfabricator. 
  
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Esto facilita el que se compartan diseños del protolathe con el mech fabricator. Y no tener que agregar la variable `construction_time` todo el tiempo a no ser que sea necesario (que no tengas que agregar lineas de código demás vaya). Evita también situaciones en los que el tiempo de construcción sea de cero en caso de que a alguien se le llegue a olvidar, corrige los tiempos de construcción cero que haya en el código (si es que los hay) y hace que diseños especialmente faciles de construir en el protolathe y el autolahte (los que usan un `lathe_time_factor ` menor a uno) tengan un tiempo de construcción similar en el mechfabricator y derivados (como el podfabricator). 

Esto también evita que los diseños de https://github.com/Helixis/Paradise/pull/220 tengan un tiempo de construcción igual a cero y evita tener que agregar nuevas lineas de código innecesarias
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: Evankhell
tweak: el tiempo de construcción por defecto del mechfabricator pasa de cero a 50
add: los diseños que se construyan especialmente rápido el protolathe/autolathe, se construirán especialmente rápido en el mechfabricator y derivados.
fix: las baterias no se fabricarán instantaneamente en el mechfabricator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
