### PR TITLE
welding goggles design

### DIFF
--- a/code/HISPANIA/modules/research/designs/equipment_designs.dm
+++ b/code/HISPANIA/modules/research/designs/equipment_designs.dm
@@ -1,9 +1,19 @@
+/datum/design/welding_goggles
+	name = "Welding Goggles"
+	desc = "Protects the eyes from bright flashes; approved by the mad scientist association."
+	id = "welding_goggles"
+	build_type = PROTOLATHE
+	req_tech = list("magnets" = 2, "engineering" = 2, "plasmatech" = 2)
+	materials = list(MAT_METAL = 300, MAT_GLASS = 350)
+	build_path = /obj/item/clothing/glasses/welding
+	category = list("Equipment")
+
 /datum/design/tray_goggles
 	name = "Optical T-Ray Scanners"
 	desc = "Used by engineering staff to see underfloor objects such as cables and pipes."
 	id = "tray_goggles"
-	req_tech = list("magnets" = 3, "engineering" = 3, "plasmatech" = 3)
 	build_type = PROTOLATHE
+	req_tech = list("magnets" = 3, "engineering" = 3, "plasmatech" = 3)
 	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
 	build_path = /obj/item/clothing/glasses/meson/engine/tray
 	category = list("Equipment")


### PR DESCRIPTION
## What Does This PR Do

añade el diseño de los welding goggles a al protolathe

## Why It's Good For The Game

Estas cosas son limitadas dentro del juego y no se pueden encontrar más allá de los que hay en el mapa, estaria bien poder conseguirlas en algún lado. Y como ya el autolathe en cargo tienen los cascos de soldar,  poner los lentes ahi seria ponerlos a competir directamente y eclipsaria a los cascos. Por lo que me parece que ésta es la mejor solución para que sean más accesibles.

## Changelog
:cl: Evankhell
add: añade el diseño de los lentes de soldar al protolathe.
/:cl: