### PR TITLE
Spiderbot tweaks

### DIFF
--- a/code/HISPANIA/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/HISPANIA/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -1,0 +1,92 @@
+/mob/living/simple_animal/spiderbot/death(var/gibbed = FALSE)
+	..(TRUE)
+	if(held_item && !isnull(held_item))
+		held_item.forceMove(src.loc)
+		held_item = null
+	robogibs(src.loc)
+	qdel(src)
+
+/mob/living/simple_animal/spiderbot/emp_act(severity)
+	if(flags & GODMODE)
+		return ..()
+
+	switch(severity)
+		if(1)
+			if(prob(5))
+				explode()
+				return
+			adjustBruteLoss(rand(16,20))
+		if(2)
+			adjustBruteLoss(rand(8,12))
+	flash_eyes(visual = 1)
+	to_chat(src, "<span class='danger'>*BZZZT*</span>")
+	to_chat(src, "<span class='warning'>Warning: Electromagnetic pulse detected.</span>")
+	..()
+
+/mob/living/simple_animal/spiderbot/proc/explode()
+	for(var/mob/M in viewers(src, null))
+		if(M.client)
+			M.show_message("<span class='warning'>[src] makes an odd warbling noise, fizzles, and explodes.</span>")
+	explosion(get_turf(loc), -1, -1, 3, 5)
+	if(!emagged)
+		eject_brain()
+	else
+		QDEL_NULL(mmi)
+	death()
+
+/mob/living/simple_animal/spiderbot/verb/drop_held_item()
+	set name = "Drop held item"
+	set category = "Spiderbot"
+	set desc = "Drop the item you're holding."
+
+	if(incapacitated())
+		return
+
+	if(!held_item)
+		to_chat(usr, "<span class='warning'>You have nothing to drop!</span>")
+		return FALSE
+
+	visible_message("<span class='notice'>[src] drops \the [held_item]!</span>", "<span class='notice'>You drop \the [held_item]!</span>", "You hear a skittering noise and a soft thump.")
+
+	held_item.forceMove(src.loc)
+	held_item = null
+	return TRUE
+
+/mob/living/simple_animal/spiderbot/verb/get_item()
+	set name = "Pick up item"
+	set category = "Spiderbot"
+	set desc = "Allows you to take a nearby small item."
+
+	if(incapacitated())
+		return
+
+	if(held_item)
+		to_chat(src, "<span class='warning'>You are already holding \the [held_item]</span>")
+		return TRUE
+
+	var/list/items = list()
+	for(var/obj/item/I in view(1,src))
+		if(I.loc != src && I.w_class <= WEIGHT_CLASS_SMALL)
+			items.Add(I)
+
+	var/obj/selection = input("Select an item.", "Pickup") in items
+
+	if(selection)
+		for(var/obj/item/I in view(1, src))
+			if(selection == I)
+				if(selection.anchored)
+					to_chat(src, "<span class='warning'>It's fastened down!</span>")
+					return FALSE
+				held_item = selection
+				selection.forceMove(src)
+				visible_message("<span class='notice'>[src] scoops up \the [held_item]!</span>", "<span class='notice'>You grab \the [held_item]!</span>", "You hear a skittering noise and a clink.")
+				return held_item
+		to_chat(src, "<span class='warning'>\The [selection] is too far away.</span>")
+		return FALSE
+
+	to_chat(src, "<span class='warning'>There is nothing of interest to take.</span>")
+
+/mob/living/simple_animal/spiderbot/examine(mob/user)
+	..()
+	if(held_item)
+		to_chat(user, "It is carrying \a [held_item] [bicon(held_item)].")

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -6,7 +6,8 @@
 	icon_living = "spiderbot-chassis"
 	icon_dead = "spiderbot-smashed"
 	wander = 0
-	universal_speak = 1
+	voice_name = "synthesized voice"
+	universal_speak = TRUE
 	health = 40
 	maxHealth = 40
 	pass_flags = PASSTABLE
@@ -28,12 +29,14 @@
 	minbodytemp = 0
 	maxbodytemp = 500
 
-	can_hide = 1
+	can_hide = TRUE
 	ventcrawler = 2
 	loot = list(/obj/effect/decal/cleanable/blood/gibs/robot)
 	del_on_death = 1
 
-	var/emagged = 0               //is it getting ready to explode?
+	var/obj/item/held_item = null //Storage for single item they can hold.
+	var/lob_range = 3
+	var/emagged = FALSE               //is it getting ready to explode?
 	var/obj/item/mmi/mmi = null
 	var/mob/emagged_master = null //for administrative purposes, to see who emagged the spiderbot; also for a holder for if someone emags an empty frame first then inserts an MMI.
 
@@ -55,15 +58,15 @@
 			to_chat(user, "<span class='warning'>Sticking an empty MMI into the frame would sort of defeat the purpose.</span>")
 			return
 		if(!B.brainmob.key)
-			var/ghost_can_reenter = 0
+			var/ghost_can_reenter = FALSE
 			if(B.brainmob.mind)
 				for(var/mob/dead/observer/G in GLOB.player_list)
 					if(G.can_reenter_corpse && G.mind == B.brainmob.mind)
-						ghost_can_reenter = 1
+						ghost_can_reenter = TRUE
 						break
 				for(var/mob/living/simple_animal/S in GLOB.player_list)
 					if(S in GLOB.respawnable_list)
-						ghost_can_reenter = 1
+						ghost_can_reenter = TRUE
 						break
 			if(!ghost_can_reenter)
 				to_chat(user, "<span class='notice'>[B] is completely unresponsive; there's no point.</span>")
@@ -85,7 +88,7 @@
 		transfer_personality(B)
 
 		update_icon()
-		return 1
+		return TRUE
 
 	else if(iswelder(O) && user.a_intent == INTENT_HELP)
 		var/obj/item/weldingtool/WT = O
@@ -103,11 +106,11 @@
 	else if(istype(O, /obj/item/card/id) || istype(O, /obj/item/pda))
 		if(!mmi)
 			to_chat(user, "<span class='warning'>There's no reason to swipe your ID - the spiderbot has no brain to remove.</span>")
-			return 0
+			return FALSE
 
 		if(emagged)
 			to_chat(user, "<span class='warning'>[src] doesn't seem to respond.</span>")
-			return 0
+			return FALSE
 
 		var/obj/item/card/id/id_card
 
@@ -120,10 +123,10 @@
 		if(access_robotics in id_card.access)
 			to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of [src].</span>")
 			eject_brain()
-			return 1
+			return TRUE
 		else
 			to_chat(user, "<span class='warning'>You swipe your card, with no effect.</span>")
-			return 0
+			return FALSE
 
 	else
 		..()
@@ -131,9 +134,9 @@
 /mob/living/simple_animal/spiderbot/emag_act(mob/living/user)
 	if(emagged)
 		to_chat(user, "<span class='warning'>[src] doesn't seem to respond.</span>")
-		return 0
+		return FALSE
 	else
-		emagged = 1
+		emagged = TRUE
 		to_chat(user, "<span class='notice'>You short out the security protocols and rewrite [src]'s internal memory.</span>")
 		to_chat(src, "<span class='userdanger'>You have been emagged; you are now completely loyal to [user] and [user.p_their()] every order!</span>")
 		emagged_master = user

--- a/paradise.dme
+++ b/paradise.dme
@@ -1190,6 +1190,7 @@
 #include "code\HISPANIA\modules\mob\living\carbon\human\human.dm"
 #include "code\HISPANIA\modules\mob\living\carbon\human\species\murghal.dm"
 #include "code\HISPANIA\modules\mob\living\simple_animal\kiwi.dm"
+#include "code\HISPANIA\modules\mob\living\simple_animal\friendly\spiderbot.dm"
 #include "code\HISPANIA\modules\mob\living\simple_animal\hostile\venus_human_trap.dm"
 #include "code\HISPANIA\modules\mob\new_player\sprite_accessories\human\human_hair.dm"
 #include "code\HISPANIA\modules\mob\new_player\sprite_accessories\murghal\murghal_hair.dm"


### PR DESCRIPTION
## What Does This PR Do
-las spididerbot son afectadas por los emp
-las spididerbot pueden recoger un objeto pequeño del suelo y dejarlo caer.
caracteristicas porteadas de vg

## Why It's Good For The Game
1. Se supone que las spiderbot son un cuerpo robótico, deberian ser afectados por los emp
2. Actualmente jugar como spiderbot es bastante aburrido, y no puedes hacer màs que solo ir por ahi caminado y hablar, esto intenta volver este rol un poco màs interesante.


## Changelog
:cl: Evankhell
add: las spiderbot son afectadas por los emp.
add: las spiderbot pueden recoger y soltar objetos pequeños.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
