### PR TITLE
Ryzorcop tweaks

### DIFF
--- a/code/HISPANIA/defines/procs/discord.dm
+++ b/code/HISPANIA/defines/procs/discord.dm
@@ -1,5 +1,7 @@
-/proc/ryzorbot(var/slash, var/route)
+/proc/ryzorbot(var/slash, var/route, var/msg)
 	if(config.ryzorbot)
-		world.Export("[config.ryzorbot]/[slash]/[route]")
-		return
+		var/content = ""
+		for (var/i = 1 to length(msg))
+			content += "[text2ascii(msg[i])] "
+		world.Export("[config.ryzorbot]/[slash]/[route]/[content]")
 	return

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -1,7 +1,6 @@
 /datum/configuration
 	// Hispania Configs
 	var/ryzorbot = "http://example.org"
-	var/br_operation = 0
 
 
 	var/server_name = null				// server name (for world name / status)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -493,9 +493,6 @@
 				if("ryzorbot")
 					config.ryzorbot = value
 
-				if("br_operation")
-					config.br_operation = 1
-
 				if("repositoryurl")
 					config.repositoryurl = value
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -236,31 +236,3 @@
 
 	dat += "<b><u>RATING:</u></b> [score_rating]"
 	src << browse(dat, "window=roundstats;size=500x600")
-
-	// Ryzor BOT
-/*	var/datum/station_state/end_state = new /datum/station_state()
-	var/station_integrity = min(round( 100.0 *  start_state.score(end_state), 0.1), 100.0)
-	var/list/scorelist = list(
-		"Useful Items Shipped"		=	"[score_stuffshipped] ([score_stuffshipped * 5] Points)",
-		"Hydroponics Harvests"		=	"[score_stuffharvested] ([score_stuffharvested * 5] Points)",
-		"Ore Mined"					=	"[score_oremined] ([score_oremined * 2] Points)",
-		"Refreshments Prepared"		=	"[score_meals] ([score_meals * 5] Points)",
-		"Research Completed"		=	"[score_researchdone] ([score_researchdone * 30] Points)",
-		"Random Events Endured"		=	"[score_eventsendured] ([score_powerbonus * 2500] Points)",
-		"Whole Station Powered" 	=	"[score_powerbonus ? "Yes" : "No"] ([score_powerbonus * 2500] Points)",
-		"Ultra-Clean Station"		=	"[score_mess ? "No" : "Yes"] ([score_messbonus * 3000] Points)",
-		"Dead bodies on station"	=	"[score_deadcrew] (-[score_deadcrew * 25] Points)",
-		"Uncleaned Messes"			=	"[score_mess] (-[score_mess] Points)",
-		"Station Power Issues"		=	"[score_powerloss] (-[score_powerloss * 20] Points)",
-		"Rampant Diseases"			=	"[score_disease]",
-		"AI Destroyed"				=	"[score_deadaipenalty ? "Yes" : "No"]",
-		"Food Eaten"				=	"[score_foodeaten]",
-		"Times a Clown was Abused"	=	"[score_clownabuse]",
-		"Final Score"				=	"[score_crewscore]",
-		"Rating"					=	"[score_rating]",
-		"Round Duration"			=	"[round(ROUND_TIME / 36000)]:[add_zero("[ROUND_TIME / 600 % 60]", 2)]:[ROUND_TIME / 100 % 6][ROUND_TIME / 100 % 10]",
-		"Station Integrity"			=	"[station_integrity]"
-		)
-
-	var/parselist = json_encode(scorelist)
-	discordbot("[config.ryzorbot]", "end", "notify")*/

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -46,7 +46,7 @@
 	if(logged)
 		log_admin("[key_name(usr)] has added a note to [target_ckey]: [notetext]")
 		message_admins("[key_name_admin(usr)] has added a note to [target_ckey]:<br>[notetext]")
-		ryzorbot("notify", "addnote=[key_name(usr)]&[target_ckey]&[json_encode(notetext)]")
+		ryzorbot("notify", "addnote=[key_name(usr)]&[target_ckey]","[notetext]")
 		show_note(target_ckey)
 
 /proc/remove_note(note_id)
@@ -77,7 +77,7 @@
 		return
 	log_admin("[key_name(usr)] has removed a note made by [adminckey] from [ckey]: [notetext]")
 	message_admins("[key_name_admin(usr)] has removed a note made by [adminckey] from [ckey]:<br>[notetext]")
-	ryzorbot("notify", "removenote=[key_name(usr)]&[adminckey]&[ckey]&[json_encode(notetext)]")
+	ryzorbot("notify", "removenote=[key_name(usr)]&[adminckey]&[ckey]","[notetext]")
 	show_note(ckey)
 
 /proc/edit_note(note_id)

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -35,7 +35,7 @@
 
 			log_admin("[key_name(usr)] has stickybanned [ckey].\nReason: [ban["message"]]")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has stickybanned [ckey].\nReason: [ban["message"]]</span>")
-
+			ryzorbot("notify", "sticky=[ckey]&[key_name(usr)]", "[ban["message"]]")
 		if("remove")
 			if(!data["ckey"])
 				return
@@ -54,6 +54,7 @@
 
 			log_admin("[key_name(usr)] removed [ckey]'s stickyban")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] removed [ckey]'s stickyban</span>")
+			ryzorbot("notify", "removesticky=[ckey]&[key_name(usr)]")
 
 		if("remove_alt")
 			if(!data["ckey"])
@@ -102,6 +103,7 @@
 
 			log_admin("[key_name(usr)] has disassociated [alt] from [ckey]'s sticky ban")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] has disassociated [alt] from [ckey]'s sticky ban</span>")
+			ryzorbot("notify", "removesticky=[ckey]&[key_name(usr)]&[alt]")
 
 		if("edit")
 			if(!data["ckey"])

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -839,6 +839,7 @@
 						else
 							msg += ", [job]"
 					add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+					ryzorbot("notify", "jobban=[key_name(usr)]&[key_name(M)]&[msg]&true&[mins]", "[reason]")
 					message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg] for [mins] minutes</span>", 1)
 					to_chat(M, "<span class='warning'><BIG><B>You have been jobbanned by [usr.client.ckey] from: [msg].</B></BIG></span>")
 					to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
@@ -860,6 +861,7 @@
 							if(!msg)	msg = job
 							else		msg += ", [job]"
 						add_note(M.ckey, "Banned  from [msg] - [reason]", null, usr.ckey, 0)
+						ryzorbot("notify", "jobban=[key_name(usr)]&[key_name(M)]&[msg]&false&", "[reason]")
 						message_admins("<span class='notice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg]</span>", 1)
 						to_chat(M, "<span class='warning'><BIG><B>You have been jobbanned by [usr.client.ckey] from: [msg].</B></BIG></span>")
 						to_chat(M, "<span class='danger'>The reason is: [reason]</span>")
@@ -893,6 +895,7 @@
 					else
 						continue
 			if(msg)
+				ryzorbot("notify", "unjobban=[key_name(usr)]&[key_name(M)]&[msg]")
 				message_admins("<span class='notice'>[key_name_admin(usr)] unbanned [key_name_admin(M)] from [msg]</span>", 1)
 				to_chat(M, "<span class='warning'><BIG><B>You have been un-jobbanned by [usr.client.ckey] from [msg].</B></BIG></span>")
 				href_list["jobban2"] = 1 // lets it fall through and refresh
@@ -1001,7 +1004,7 @@
 					to_chat(M, "<span class='warning'>No ban appeals URL has been set.</span>")
 				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
 				message_admins("<span class='notice'>[key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
-				ryzorbot("notify", "addban=[key_name(usr)]&[M.ckey]&[json_encode(reason)]&This will be removed in [mins] minutes.")
+				ryzorbot("notify", "addban=[key_name(usr)]&[M.ckey]&This will be removed in [mins] minutes.","[reason]")
 				to_chat(world, "<b><span class='info'>El jugador <span class='warning'>[M.ckey]</span> fue baneado.</span></b><p><span class='rose'>[reason]</span></p>")
 
 				del(M.client)
@@ -1020,7 +1023,7 @@
 				ban_unban_log_save("[usr.client.ckey] has permabanned [M.ckey]. - Reason: [reason] - This ban does not expire automatically and must be appealed.")
 				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis ban does not expire automatically and must be appealed.")
 				message_admins("<span class='notice'>[key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis ban does not expire automatically and must be appealed.</span>")
-				ryzorbot("notify", "addban=[key_name(usr)]&[M.ckey]&[json_encode(reason)]&This ban does not expire automatically and must be appealed.")
+				ryzorbot("notify", "addban=[key_name(usr)]&[M.ckey]&This ban does not expire automatically and must be appealed.","[reason]")
 				feedback_inc("ban_perma",1)
 				DB_ban_record(BANTYPE_PERMA, M, -1, reason)
 				to_chat(world, "<b><span class='info'>El jugador <span class='warning'>[M.ckey]</span> fue baneado.</span></b><p><span class='rose'>[reason]</span></p>")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -149,19 +149,16 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	var/admin_number_present = adminholders.len - admin_number_afk
 
-	var/regex/R = new ("(\\?)", "g")
-	var/edited_msg = json_encode(R.Replace(original_msg, "�"))
-
 	log_admin("[selected_type]: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins.")
 	if(admin_number_present <= 0)
 		if(!admin_number_afk)
-			ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&[edited_msg]&!!No admins online!!")
+			ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&!!No admins online!!","[original_msg]")
 			send2adminirc("[selected_type] from [key_name(src)]: [original_msg] - !!No admins online!!")
 		else
-			ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&[edited_msg]&!!All admins AFK ([admin_number_afk])!!")
+			ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&!!All admins AFK ([admin_number_afk])!!","[original_msg]")
 			send2adminirc("[selected_type] from [key_name(src)]: [original_msg] - !!All admins AFK ([admin_number_afk])!!")
 	else
-		ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&[edited_msg]&")
+		ryzorbot("notify", "ahelp=[selected_type]&from [key_name(src)]:&","[original_msg]")
 		send2adminirc("[selected_type] from [key_name(src)]: [original_msg]")
 	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -25,27 +25,10 @@
 						message_admins("<font color='red'><B>Notice: </B><font color='blue'><A href='?src=[usr.UID()];priv_msg=[src.client.UID()]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>", 1)
 						log_adminwarn("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 
-/mob/proc/ryzorcop()
-	if(config.br_operation)
-		var/ban = list("admin" = "alfred987", "type" = list("sticky"), "reason" = "(InGameBan)([client.key])", "message" = "Lo sentimos, debido al incremento de griefers brazileños/portugueses ya no son bienvenidos hasta nuevo aviso.")
-		var/http = world.Export("http://ip-api.com/json/[client.address]")
-		if(http)
-			var/F = http["CONTENT"]
-			if(F)
-				var/getJson = json_decode(file2text(F))
-				if(getJson["country"] == "Brazil" || getJson["country"] == "Portugal")
-					world.SetConfig("ban", client.ckey, list2stickyban(ban))
-					ryzorbot("notify", "sticky=[client.ckey]&[json_encode(ban["message"])]")
-				else
-					return
-		else
-			ryzorcop()
-
 /mob/Login()
 	GLOB.player_list |= src
 	update_Login_details()
 	world.update_status()
-	ryzorcop()
 
 	client.images = null				//remove the images such as AIs being unable to see runes
 	client.screen = list()				//remove hud items just in case

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -166,7 +166,6 @@
 				return
 			to_chat(usr, "<span class = 'notice'>ERT request transmitted.</span>")
 			print_centcom_report(ert_reason, station_time_timestamp() + " ERT Request")
-			//discordbot("[config.ryzorbot]", "ert", "isadmin=false&reason=[json_encode(ert_reason)]&timestamp=[station_time_timestamp()]")
 
 			var/fullmin_count = 0
 			for(var/client/C in GLOB.admins)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -449,8 +449,5 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ## Uncomment to give a confirmation before hitting start now
 #START_NOW_CONFIRMATION
 
-## Stickyban all brazilian and portugues
-#BR_OPERATION
-
 ## If uncommented, all gamemodes will respect the number of required players. Defaults to no.
 #ENABLE_GAMEMODE_PLAYER_LIMIT


### PR DESCRIPTION
## What Does This PR Do
Ryzorbot perdía datos de camino a discord, esto era por culpa de mensajes con carácteres especiales y la forma en como se transfieren los datos, así que si transformo los datos en algo que no contenga carácteres especiales entonces ryzorbot recibiría todos los datos sin perdidas, por eso ahora convierto los datos a ascii, los paso a ryzorbot, los regreso a texto y los muestro en discord, además de que ahora recibe también los jobbans y stickybans.

Borro código antiguo que no usaba y también la operación brazuca que era básicamente una función para insta-stickybanear a toda persona carente de cerebro con un extraño gusto por la sopa de monos, desgraciadamente para cuando estaba todo listo no volvieron a asomarse, obviamente ryzorbot los ahuyentó a todos sin siquiera tener que activar su función ultra definitiva.

## Why It's Good For The Game
Registro para admins y el salón de la infamia, nada mas.

## Changelog
:cl:
add: Ryzorcop jobbans & stickybans
del: BR Operation
tweak: Ryzorcop
/:cl: