### PR TITLE
Scanners solo para medicos

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -128,7 +128,8 @@ REAGENT SCANNER
 
 
 /obj/item/healthanalyzer/attack(mob/living/M, mob/living/user)
-	if(((CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))
+	var/role = user.mind.assigned_role
+	if((((CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50)) || !(role in list("Chief Medical Officer", "Medical Doctor", "Coroner", "Paramedic", "Brig Physician")))
 		to_chat(user, text("<span class='warning'>You try to analyze the floor's vitals!</span>"))
 		for(var/mob/O in viewers(M, null))
 			O.show_message(text("<span class='warning'>[user] has analyzed the floor's vitals!</span>"), 1)


### PR DESCRIPTION
Agrega limite de conocimientos al Health analyzer. Algo dificil de controlar por los admins. Solo para medbay dandole mas importancia a este job y es un gran paso para empezar a bloquear los conocimientos IC y reemplazar las reglas OOC.

Funcionamiento: Al intentar usar un health analyzer sin ser de medbay se leera siempre informacion erronea ?/?/? similar a cuando uno tiene daño cerebral . 

:cl:
balance:  Los health analyzer ahora son cosa de medbay
/:cl:

