### PR TITLE
cambios al Rechargestation v2

### DIFF
--- a/code/HISPANIA/game/machinery/rechargestation.dm
+++ b/code/HISPANIA/game/machinery/rechargestation.dm
@@ -8,7 +8,7 @@
 		return
 	if(!ismob(O)) //humans only
 		return
-	if(!ishuman(user) && !isrobot(user) && !(istype(user, /mob/living/simple_animal/spiderbot))) //No ghosts or mice putting people into the sleeper
+	if(!ishuman(user) && !isrobot(user) && !(istype(user, /mob/living/simple_animal/spiderbot)))
 		return
 	if(user.loc==null) // just in case someone manages to get a closet into the blue light dimension, as unlikely as that seems
 		return

--- a/code/HISPANIA/game/machinery/rechargestation.dm
+++ b/code/HISPANIA/game/machinery/rechargestation.dm
@@ -29,7 +29,9 @@
 			to_chat(user, "<span class='warning'>Without a power cell, [R] can't be recharged.</span>")
 		can_accept_user = TRUE
 	if(ishuman(L))
-		if(!L.get_int_organ(/obj/item/organ/internal/cell))
+		if(ismachine(L))
+			can_accept_user = TRUE
+		else if(!L.get_int_organ(/obj/item/organ/internal/cell))
 			to_chat(user, "<span class='notice'>Only non-organics may enter the recharger!</span>")
 			return
 		can_accept_user = TRUE

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -287,27 +287,24 @@
 	if(isrobot(user))
 		var/mob/living/silicon/robot/R = user
 
-		if(R.stat == DEAD)
-			//Whoever had it so that a borg with a dead cell can't enter this thing should be shot. --NEO
-			return
 		if(occupant)
 			to_chat(R, "<span class='warning'>The cell is already occupied!</span>")
 			return
 		if(!R.cell)
 			to_chat(R, "<span class='warning'>Without a power cell, you can't be recharged.</span>")
 			//Make sure they actually HAVE a cell, now that they can get in while powerless. --NEO
-			return
 		can_accept_user = TRUE
 
 	else if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 
-		if(H.stat == DEAD)
-			return
 		if(occupant)
 			to_chat(H, "<span class='warning'>The cell is already occupied!</span>")
 			return
-		if(!H.get_int_organ(/obj/item/organ/internal/cell))
+		if(ismachine(H))
+			can_accept_user = TRUE
+		else if(!H.get_int_organ(/obj/item/organ/internal/cell))
+			to_chat(user, "<span class='notice'>Only non-organics may enter the recharger!</span>")
 			return
 		can_accept_user = TRUE
 


### PR DESCRIPTION
## What Does This PR Do
los ipc pueden entrar a un rechergestation aun si no tienen una celda interna. Esto es para que puedan beneficiarse de los efectos curativos de la máquina.
También permite meter ahi a ipc y borgs muertos o sin bateria por motivos similares. Son máquinas al fin y al cabo, que su cerebro esté muerto no significa que su cuerpo no pueda ser reparado.

## Why It's Good For The Game
Le da más sentido al juego. 

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl: Evankhell
tweak: los borgs muertos pueden entrar a un recargestation.
tweak: los ipc muertos pueden entrar a un recargestation.
tweak: borgs sin bateria interna pueden entrar a un rechargestation.
tweak:  los ipc sin bateria interna pueden entrar a un rechargestation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
