### PR TITLE
elimina las ruedas de entrenamiento de atmos

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -371,16 +371,6 @@ update_flag
 
 	SSnanoui.update_uis(src) // Update all NanoUIs attached to src
 
-/obj/machinery/portable_atmospherics/canister/replace_tank(mob/living/user, close_valve)
-	. = ..()
-	if(.)
-		if(close_valve)
-			valve_open = FALSE
-			update_icon()
-			investigate_log("Valve was <b>closed</b> by [key_name(user)].<br>", "atmos")
-		else if(valve_open && holding)
-			investigate_log("[key_name(user)] started a transfer into [holding].<br>", "atmos")
-
 /obj/machinery/portable_atmospherics/canister/attack_ai(var/mob/user as mob)
 	src.add_hiddenprint(user)
 	return src.attack_hand(user)
@@ -468,9 +458,6 @@ update_flag
 
 	if(href_list["remove_tank"])
 		if(holding)
-			if(valve_open)
-				valve_open = 0
-				release_log += "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the [holding]<br>"
 			holding.loc = loc
 			holding = null
 

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -82,49 +82,16 @@
 /obj/machinery/portable_atmospherics/portableConnectorReturnAir()
 	return air_contents
 
-/obj/machinery/portable_atmospherics/AltClick(mob/living/user)
-	if(!istype(user) || user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
-		return
-	if(!in_range(src, user))
-		return
-	if(!ishuman(usr) && !issilicon(usr))
-		return
-	if(holding)
-		to_chat(user, "<span class='notice'>You remove [holding] from [src].</span>")
-		replace_tank(user, TRUE)
-
-/obj/machinery/portable_atmospherics/examine(mob/user)
-	. = ..()
-	if(holding)
-		. += "<span class='notice'>\The [src] contains [holding]. Alt-click [src] to remove it.</span>"
-
-/obj/machinery/portable_atmospherics/proc/replace_tank(mob/living/user, close_valve, obj/item/tank/new_tank)
-	if(holding)
-		holding.forceMove(drop_location())
-		if(Adjacent(user) && !issilicon(user))
-			user.put_in_hands(holding)
-	if(new_tank)
-		holding = new_tank
-	else
-		holding = null
-	update_icon()
-	return TRUE
-
-/obj/machinery/portable_atmospherics/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank))
-		if(!(stat & BROKEN))
-			if(!user.drop_item())
-				return
-			var/obj/item/tank/T = W
-			user.drop_item()
-			if(src.holding)
-				to_chat(user, "<span class='notice'>[holding ? "In one smooth motion you pop [holding] out of [src]'s connector and replace it with [T]" : "You insert [T] into [src]"].</span>")
-				replace_tank(user, FALSE)
-			T.loc = src
-			src.holding = T
-			update_icon()
+/obj/machinery/portable_atmospherics/attackby(var/obj/item/W as obj, var/mob/user as mob, params)
+	if((istype(W, /obj/item/tank) && !( src.destroyed )))
+		if(src.holding)
 			return
+		var/obj/item/tank/T = W
+		user.drop_item()
+		T.loc = src
+		src.holding = T
+		update_icon()
+		return
 
 	else if(istype(W, /obj/item/wrench))
 		if(connected_port)

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -95,16 +95,6 @@
 /obj/machinery/portable_atmospherics/pump/return_air()
 	return air_contents
 
-/obj/machinery/portable_atmospherics/pump/replace_tank(mob/living/user, close_valve)
-	. = ..()
-	if(.)
-		if(close_valve)
-			if(on)
-				on = FALSE
-				update_icon()
-		else if(on && holding && direction_out)
-			investigate_log("[key_name(user)] started a transfer into [holding].<br>", "atmos")
-
 /obj/machinery/portable_atmospherics/pump/attack_ai(var/mob/user as mob)
 	src.add_hiddenprint(user)
 	return src.attack_hand(user)
@@ -160,7 +150,6 @@
 
 	if(href_list["remove_tank"])
 		if(holding)
-			on = FALSE
 			holding.loc = loc
 			holding = null
 		update_icon()


### PR DESCRIPTION
## What Does This PR Do
elimina la seguridad de los canister, la cual cerraba el canister automaticamente al sacar el tanque en su interior. 
elimina la funcion de reemplazar un tanque con otro.
elimina la funcion de sacar y cerrar con alt-click

## Why It's Good For The Game
Todas estas son comodidades interesantes a nivel de code y estarian bien en otros depas/labs pero reduce drasticamente el riesgo de accidentes cuando se hace atmos/toxinas y el riesgo de accidente es el 50% de la diversión en estos trabajos donde poco a poco se va aprendiendo y el miedo a cagarla es constante y le da una chispa interesante a estos trabajos. Todas estas funciones eliminan ese miedo casi al por completo, fomentan el uso descuidado de estos depas/laboratorios y hacen una curva de dificultad muchi más plana y aburrida. 


## Changelog
:cl:
del: Funciones de seguridad de los canister.
/:cl:
