### PR TITLE
hellhound is back

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -8,6 +8,7 @@
 	icon_dead = "hellhound_dead"
 	icon_resting = "hellhound_rest"
 	mutations = list(BREATHLESS)
+	gold_core_spawnable = HOSTILE_SPAWN
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
@@ -113,6 +114,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	environment_smash = 2
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/hellhound/greater/New()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/hellhound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hellhound.dm
@@ -114,7 +114,6 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 30
 	environment_smash = 2
-	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/hellhound/greater/New()
 	. = ..()


### PR DESCRIPTION
What Does This PR Do
regresa los hellhound a la lista de mobs creados por el slime dorado. 

## Why It's Good For The Game
más variedad de mobs en xeno, menos cosas unicas para los admin, cosas que nunca usan.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: los hellhound pueden ser creados mediante el slime dorado.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
