### PR TITLE
Cambia la edad mínima de los personajes a 18

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -13,7 +13,7 @@
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
-#define AGE_MIN 17			//youngest a character can be
+#define AGE_MIN 18			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
 


### PR DESCRIPTION
## What Does This PR Do
Por motivos de rol, cambia la edad mínima de los personajes a 18. Antes era 17 y no hay mucha diferencia, pero lo mejor es no tener personajes menores de edad en la estación.
:cl:
tweak: la edad minima de la crew es 18.
/:cl: