### PR TITLE
Hold up, valid.

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -92,7 +92,7 @@
 	icon_state = "cuff_white"
 	origin_tech = "engineering=2"
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
-	breakouttime = 150 //Deciseconds = 15s
+	breakouttime = 200 //Deciseconds = 20s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/red
@@ -178,7 +178,7 @@
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	icon_state = "cuff_white"
-	breakouttime = 250 //Deciseconds = 25s
+	breakouttime = 350 //Deciseconds = 35s
 	materials = list()
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -92,7 +92,7 @@
 	icon_state = "cuff_white"
 	origin_tech = "engineering=2"
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
-	breakouttime = 300 //Deciseconds = 30s
+	breakouttime = 150 //Deciseconds = 15s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
 /obj/item/restraints/handcuffs/cable/red
@@ -178,7 +178,7 @@
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	icon_state = "cuff_white"
-	breakouttime = 450 //Deciseconds = 45s
+	breakouttime = 250 //Deciseconds = 25s
 	materials = list()
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -787,7 +787,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			buckled.user_unbuckle_mob(src,src)
 			if(istype(I, /obj/item/restraints/handcuffs/cable))
 				playsound(loc, 'sound/effects/snap.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>As [src] manages to unbuckle It destroys [I] as well!</span>")
+				visible_message("<span class='danger'>As [src] manages to unbuckle... It destroys [I] as well!</span>")
 				handcuffed = null
 				update_handcuffed()
 		else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -785,6 +785,11 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			if(!buckled)
 				return
 			buckled.user_unbuckle_mob(src,src)
+			if(istype(I, /obj/item/restraints/handcuffs/cable))
+				playsound(loc, 'sound/effects/snap.ogg', 50, 1, -1)
+				visible_message("<span class='danger'>As [src] manages to unbuckle, It destroys [I] as well!</span>")
+				handcuffed = null
+				update_handcuffed()
 		else
 			if(src && buckled)
 				to_chat(src, "<span class='warning'>You fail to unbuckle yourself!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -787,7 +787,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			buckled.user_unbuckle_mob(src,src)
 			if(istype(I, /obj/item/restraints/handcuffs/cable))
 				playsound(loc, 'sound/effects/snap.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>As [src] manages to unbuckle, It destroys [I] as well!</span>")
+				visible_message("<span class='danger'>As [src] manages to unbuckle It destroys [I] as well!</span>")
 				handcuffed = null
 				update_handcuffed()
 		else


### PR DESCRIPTION
- Se ha bajado el tiempo de quitarte unas esposas a las zipties y cable restraints.
 **Zipties** = ``45s`` --> ``35s``
 **Cable Restraints** = ``30s`` --> ``20s``
- Al resistirte atado a una silla con unas zipties o cable restraints, Se romperan las esposas y quedaras desbuckleado de la silla.

## Why It's Good For The Game
Las cable cuffs tanto como las zipties son demasiado efectivas para ser versiones baratas de las handcuffs. La unica diferencia que tenían era de un par de segundos que no cambian mucho si al final lograbas amarrarlo a una silla puesto a que esto ya significaba que a quien sea que hayas amarrado, esta a todo tu merced, el problema aquí es lo estúpidamente fácil y efectivo que es.

Es por esto que he implementado estos cambios, para que no sea tan estúpidamente efectivo. Esto definitivamente no resolverá el problema por completo pero YO creo que sera efectivo.
## Changelog
:cl:
balance: Es mas rápido quitarte unos cable restraints. ``30s`` --> ``20s``
balance: Es mas rápido quitarte unas zipties. ``45s`` --> ``35s``
tweak: Al resistirte atado a una silla con unas cable restraints o zipties, se rompen las cuffs a la par de pararte de la silla.
/:cl: