### PR TITLE
ajuste a los pedidos de cargo v2

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -79,11 +79,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 /datum/supply_packs/emergency/evac
 	name = "Emergency Equipment Crate"
-	contains = list(/mob/living/simple_animal/bot/floorbot,
-					/mob/living/simple_animal/bot/floorbot,
-					/mob/living/simple_animal/bot/medbot,
-					/mob/living/simple_animal/bot/medbot,
-					/obj/item/tank/air,
+	contains = list(/obj/item/tank/air,
 					/obj/item/tank/air,
 					/obj/item/tank/air,
 					/obj/item/tank/air,
@@ -95,7 +91,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/mask/gas,
 					/obj/item/grenade/gas/oxygen,
 					/obj/item/grenade/gas/oxygen)
-	cost = 35
+	cost = 40
 	containertype = /obj/structure/closet/crate/internals
 	containername = "emergency crate"
 	group = supply_emergency
@@ -550,10 +546,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	name = "Toolbox Crate"
 	contains = list(/obj/item/storage/toolbox/electrical,
 					/obj/item/storage/toolbox/electrical,
-					/obj/item/storage/toolbox/electrical,
-					/obj/item/storage/toolbox/mechanical,
-					/obj/item/storage/toolbox/mechanical,
-					/obj/item/storage/toolbox/mechanical)
+					/obj/item/storage/toolbox/electrical)
 	cost = 10
 	containername = "electrical maintenance crate"
 


### PR DESCRIPTION
## What Does This PR Do
quita los bots del pedido de evac y algunas toolbox excesivas de los pedidos de cargo.

## Why It's Good For The Game
cargo es un dispensador de todo, en el caso de los bots, es un trabajo que deberia hacer un robotista, en el caso de las tool box, pocas veces se requieren tantas herramientas.

## Changelog
:cl:
balance: el pedido de evac ya no trae bots.
balance: el pedido de toolbox ahora trae solo 3.
/:cl: