### PR TITLE
Reduce el tiempo de aviso de alerta de evento Terrors

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -1,6 +1,6 @@
 
 /datum/event/spider_terror
-	announceWhen = 240
+	announceWhen = 60
 	var/spawncount = 1
 
 /datum/event/spider_terror/setup()


### PR DESCRIPTION
## What Does This PR Do
Reduce el tiempo de alerta de aproximadamente 7 minutos a 2 minutos y 30 segundos

## Why It's Good For The Game
Terrors bad pls nerf
Así la tripulación tiene un poco más de tiempo para alistarse antes de que las arañas tomen un departamento completo

## Images of changes
![Good Spider](https://user-images.githubusercontent.com/52227547/73602483-504c4800-4553-11ea-8ebb-c1cfdc198f07.jpg)

## Changelog
:cl: DanaDririon
tweak: La alerta de terrors suena más temprano
/:cl: