### PR TITLE
Balance players para gameModes

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -44,7 +44,7 @@ var/global/list/all_cults = list()
 	config_tag = "cult"
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Internal Affairs Agent", "Security Officer", "Warden", "Detective", "Security Pod Pilot", "Head of Security", "Captain", "Head of Personnel", "Blueshield", "Nanotrasen Representative", "Magistrate", "Brig Physician", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer")
 	protected_jobs = list()
-	required_players = 30
+	required_players = 20
 	required_enemies = 3
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -438,9 +438,9 @@ var/list/teleport_runes = list()
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar-Sie upon the station.
 /obj/effect/rune/narsie
 	cultist_name = "Tear Reality (God)"
-	cultist_desc = "tears apart dimensional barriers, calling forth your god. Requires 9 invokers."
+	cultist_desc = "tears apart dimensional barriers, calling forth your god. Requires 7 invokers."
 	invocation = "TOK-LYR RQA-NAP G'OLT-ULOFT!!"
-	req_cultists = 9
+	req_cultists = 7
 	icon = 'icons/effects/96x96.dmi'
 	color = rgb(125,23,23)
 	icon_state = "rune_large"
@@ -454,7 +454,7 @@ var/list/teleport_runes = list()
 /obj/effect/rune/narsie/New()
 	..()
 	cultist_name = "Summon [SSticker.cultdat ? SSticker.cultdat.entity_name : "your god"]"
-	cultist_desc = "tears apart dimensional barriers, calling forth [SSticker.cultdat ? SSticker.cultdat.entity_title3 : "your god"]. Requires 9 invokers."
+	cultist_desc = "tears apart dimensional barriers, calling forth [SSticker.cultdat ? SSticker.cultdat.entity_title3 : "your god"]. Requires 7 invokers."
 
 /obj/effect/rune/narsie/check_icon()
 	return

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -9,7 +9,7 @@ proc/issyndicate(mob/living/M as mob)
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 30	// 30 players - 5 players to be the nuke ops = 25 players remaining
+	required_players = 20	// 30 players - 5 players to be the nuke ops = 25 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
 


### PR DESCRIPTION
Modifica algunos valores de ready ya que estos modos nunca estaban saliendo en las semanas de secret.

- Nuclear: 30->20 player minimum
- Cult: 30->20 player minimum

Tambien baja la cantidad de gente necesaria para invocar a nar sie o hacer la ultima invocacion final. 9 Cultistas a esa altura de la ronda eran extremadamente dificil de conseguir, impidiendo a los cultistas jugar de forma sigilosa , obligandolos a hacer un caos en la estacion

Espero que reduciendo el numero de 9 a 7 reduzca un poco las rondas que quedan en standby por no poder invocar a narsie ni tampoco continuar con el turno normal por estar todos muertos.

:cl:
tweak: Culto y nuclear requieren ahora 20 readys en ves de 30
tweak: Culto requiere 7 culstitas en ves de 9 para la invocacion final 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
