### PR TITLE
Más chefs

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -36373,6 +36373,9 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/effect/landmark/start{
+	name = "Chef"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -44,8 +44,8 @@
 	title = "Chef"
 	flag = CHEF
 	department_flag = SUPPORT
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	is_service = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")


### PR DESCRIPTION
## What Does This PR Do
Agrega otro espacio para chef, además de otro spawnpoint en la cocina.

## Why It's Good For The Game
Otros codes funcionan así.
Tener otro chef por si uno se va SSD, o trabajar en conjunto para hacer más comida y dar más situaciones de rol.

## Images of changes
![Screenshot_9](https://user-images.githubusercontent.com/52227547/74502257-b0d07300-4ecb-11ea-85af-a07f9dcc175b.png)

## Changelog
:cl: DanaDririon
add: Agrega otro espacio y spawnpoint de chef 
/:cl: