### PR TITLE
Fix HoP Shutter Doors and Line

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -49927,6 +49927,20 @@
 /area/hallway/primary/central/se)
 "bOA" = (
 /obj/machinery/computer/account_database,
+/obj/machinery/door_control{
+	id = "hopqueue";
+	name = "HoP Line Shutter";
+	pixel_x = 1;
+	pixel_y = 21;
+	req_access_txt = "57"
+	},
+/obj/machinery/door_control{
+	id = "hop";
+	name = "HoP Office Privacy";
+	pixel_x = 10;
+	pixel_y = 21;
+	req_access_txt = "57"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "blue"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Agrega nuevamente los botones para la linea como para la privacidad del HoP. Requiere acceso a la sala del HoP para activar cada uno de los botones.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Actualmente las shutter door existen pero no hay forma de activarlas por la falta de los botones en la sala. Reparar la privacidad de el HoP era una de las propuestas en Code Suggestion.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/46639834/74560380-0b99b700-4f2c-11ea-9027-9bf245f7f147.png)
Local Naked Baldie Man Breaks into HoP Office

## Changelog
:cl:
fix: HoP Line Shutter
fix: HoP Line Privacy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
