### PR TITLE
Tweak Spacepods resisten lava y tormentas

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -78,6 +78,8 @@
 	while(L && !isturf(L))
 		if(ismecha(L)) //Mechs are immune
 			return TRUE
+		if(isspacepod(L))
+			return TRUE
 		if(ishuman(L)) //Are you immune?
 			var/mob/living/carbon/human/H = L
 			var/thermal_protection = H.get_thermal_protection()

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -19,7 +19,7 @@
 	opacity = 0
 
 	anchored = 1
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = LAVA_PROOF | ACID_PROOF
 
 	layer = 3.9
 	infra_luminosity = 15

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -19,7 +19,7 @@
 	opacity = 0
 
 	anchored = 1
-	resistance_flags = ACID_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 	layer = 3.9
 	infra_luminosity = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Convierte a las space pods en maquinas nuevamente para minar. Pueden sobrevolar en lava sin sufrir daños el conductor y ademas resisten las tormentas de ceniza.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Devuelve la posibilidad a los mineros de moverse de formas mas seguras en base a su trabajo y los cambios que se vienen para mineria.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->
![image](https://user-images.githubusercontent.com/46639834/74571355-507d1800-4f43-11ea-8936-ccdf5ff020d5.png)


## Changelog
:cl:
tweak: Spacepod Lavaproof
tweak: Spacepod Ashproof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
