### PR TITLE
Añade las camas de Renault y Runtime

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -59950,6 +59950,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/bed/dogbed/runtime,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -96684,6 +96685,10 @@
 	icon_state = "white"
 	},
 /area/assembly/robotics)
+"lnU" = (
+/obj/structure/bed/dogbed/renault,
+/turf/simulated/floor/wood,
+/area/crew_quarters/captain)
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -129264,7 +129269,7 @@ bBE
 bCV
 bEv
 doB
-bzY
+lnU
 bMS
 bOy
 bQM

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -58989,6 +58989,7 @@
 "ccF" = (
 /obj/structure/table/glass,
 /obj/item/stamp/cmo,
+/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -59950,7 +59951,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/bed/dogbed/runtime,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -59967,12 +59967,11 @@
 	},
 /area/medical/cmo)
 "cem" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/bed/dogbed/runtime,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"


### PR DESCRIPTION
## What Does This PR Do
Viendo por el codigo del juego descubri que existe aparte de la cama de Ian la de Runtime y de Renault pero que no estaban en el juego y este PR los añade a sus respectivos sitios,

## Why It's Good For The Game
Usa codigo que antes estaba inutilizado y les da un lugar a las mascotas,

## Images of changes
![imagen](https://user-images.githubusercontent.com/58746682/74590983-0b74e680-5014-11ea-9203-7037cac3d78f.png)![imagen](https://user-images.githubusercontent.com/58746682/74590995-221b3d80-5014-11ea-928f-42756434355c.png)


## Changelog
:cl:
add: Añade las camas de Renault y Runtime al mapa
/:cl: