### PR TITLE
Soluciona el sprite invisible del borg DS

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1388,6 +1388,7 @@ var/list/robot_verbs_default = list(
 	base_icon = "nano_bloodhound"
 	icon_state = "nano_bloodhound"
 	designation = "SpecOps"
+	icon = 'icons/mob/robots.dmi'
 	lawupdate = 0
 	scrambledcodes = 1
 	req_one_access = list(access_cent_specops)


### PR DESCRIPTION
## What Does This PR Do
Al añadir nuevos sprites para los borgs se rompio el de los DS quedando Invisibles, esto lo soluciona

## Why It's Good For The Game
Soluciona un fallo y ya no hay borgs invisibles

## Changelog
:cl:
fix: Arregla el sprite invisible de los borg DS
/:cl:
