### PR TITLE
La SILLA

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -43892,6 +43892,9 @@
 	icon_state = "tube1";
 	dir = 8
 	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},


### PR DESCRIPTION
## What Does This PR Do
Añade una Silla en la nave del ERT,DS alado de donde se activa su movimiento.

## Why It's Good For The Game
Permite al Capitan que dirige la nave no tener que huir por patas para no estamparse contra el suelo cada vez que quiera moverse, pudiedo asi quedarse seguro en su silla.

## Images of changes
### `Sin Silla`
![imagen](https://user-images.githubusercontent.com/58746682/74614486-8f17fb80-5118-11ea-8c59-d42a16ce7bb8.png)


### `Con Silla`
![imagen](https://user-images.githubusercontent.com/58746682/74614450-4d875080-5118-11ea-82d8-29b925a9521a.png)


## Changelog
:cl:
add: Añade una silla extra a la nave del ERT,DS
/:cl: