### PR TITLE
RE Oficina del Magistrado de Delta

### DIFF
--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -48293,6 +48293,11 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Magistrate";
+	dir = 8;
+	network = list("SS13")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -116081,6 +116086,10 @@
 /obj/structure/sign/poster/official/state_laws,
 /turf/simulated/wall/r_wall,
 /area/magistrateoffice)
+"soy" = (
+/obj/machinery/newscaster/security_unit,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 "svX" = (
 /obj/machinery/firealarm,
 /turf/simulated/wall/r_wall,
@@ -162727,7 +162736,7 @@ bwv
 bvc
 btL
 abj
-vOI
+soy
 bHI
 bJt
 bFS

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -4874,10 +4874,7 @@
 /area/shuttle/specops)
 "akw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
@@ -6925,10 +6922,7 @@
 /area/security/vacantoffice)
 "aoU" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -7010,10 +7004,7 @@
 /area/security/vacantoffice)
 "apc" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -7742,10 +7733,7 @@
 /area/maintenance/electrical_shop)
 "aqA" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -8034,10 +8022,7 @@
 /area/maintenance/fsmaint)
 "ari" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8398,10 +8383,7 @@
 	tag = ""
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
@@ -8732,10 +8714,7 @@
 /area/bridge)
 "asy" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -8802,10 +8781,7 @@
 /area/security/checkpoint2)
 "asG" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
@@ -9085,10 +9061,7 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -9173,10 +9146,7 @@
 /area/security/vacantoffice)
 "ats" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -9737,10 +9707,7 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -12699,10 +12666,7 @@
 /area/quartermaster/storage)
 "azM" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15751,10 +15715,7 @@
 /area/crew_quarters/sleep)
 "aFs" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -19593,10 +19554,7 @@
 /area/quartermaster/office)
 "aMa" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -20068,10 +20026,7 @@
 /area/maintenance/fsmaint)
 "aNa" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -20528,10 +20483,7 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel,
 /area/security/prison)
 "aNM" = (
@@ -20799,10 +20751,7 @@
 /area/maintenance/gambling_den)
 "aOr" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -21550,10 +21499,7 @@
 "aPL" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -22172,10 +22118,7 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -22206,10 +22149,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -23798,10 +23738,7 @@
 	dir = 6
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/restraints/handcuffs,
 /obj/item/taperecorder,
 /obj/machinery/camera{
@@ -24405,10 +24342,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/newscaster{
 	layer = 3.3;
 	pixel_x = -27;
@@ -24498,10 +24432,7 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -24561,10 +24492,7 @@
 /area/quartermaster/storage)
 "aUY" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27313,10 +27241,7 @@
 	},
 /area/quartermaster/qm)
 "aZy" = (
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -29306,10 +29231,7 @@
 /area/shuttle/mining)
 "bcU" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/security/prison)
@@ -29937,10 +29859,7 @@
 /area/hallway/primary/fore)
 "bdV" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light{
 	dir = 8
@@ -34293,10 +34212,7 @@
 /area/security/main)
 "bmb" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/clothing/mask/gas/sechailer,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -34364,10 +34280,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/machinery/keycard_auth{
 	pixel_x = 26;
 	pixel_y = 10
@@ -34645,10 +34558,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
@@ -35083,10 +34993,7 @@
 "bny" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/folder/blue{
 	pixel_x = 5;
 	pixel_y = 5
@@ -36019,10 +35926,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/stamp/hos,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -37168,10 +37072,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -38017,10 +37918,7 @@
 /area/shuttle/siberia)
 "bsz" = (
 /obj/structure/table,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/restraints/handcuffs,
 /obj/machinery/light{
 	dir = 4;
@@ -38291,10 +38189,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -38313,10 +38208,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -39178,10 +39070,7 @@
 /area/security/hos)
 "bum" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -39565,31 +39454,21 @@
 /turf/space,
 /area/atmos)
 "buY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/table/reinforced/brass,
-/obj/item/pen/multi/gold{
-	step_x = 7;
-	step_y = 2
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
 	},
-/obj/item/stamp/magistrate{
-	step_x = -4;
-	step_y = -1
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
+/obj/effect/decal/warning_stripes/yellow,
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40707,10 +40586,7 @@
 /area/engine/break_room)
 "bwX" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 22;
@@ -40978,13 +40854,19 @@
 	},
 /area/bridge)
 "bxx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced/brass,
-/obj/item/stack/tile/carpet/black{
-	step_y = 3
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
 	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
+/obj/machinery/door/airlock/maintenance{
+	name = "Auxiliary Storage";
+	req_access_txt = "0";
+	req_one_access_txt = "65;12"
+	},
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
 "bxy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -42179,10 +42061,7 @@
 /area/security/main)
 "bzp" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -42241,15 +42120,9 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/book/manual/security_space_law,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -42274,10 +42147,7 @@
 /area/turret_protected/ai)
 "bzw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -43121,10 +42991,7 @@
 /area/security/main)
 "bBc" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43554,10 +43421,7 @@
 /area/atmos)
 "bBN" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -47247,10 +47111,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -47261,10 +47122,7 @@
 /area/bridge)
 "bHw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -47314,6 +47172,12 @@
 /area/hallway/primary/central)
 "bHB" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
@@ -47330,22 +47194,40 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central)
-"bHD" = (
-/obj/effect/spawner/window/reinforced,
+"bHC" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
-/turf/simulated/floor/plating,
-/area/magistrateoffice)
-"bHE" = (
-/obj/structure/disposalpipe/trunk{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
 	dir = 4
 	},
-/obj/machinery/disposal,
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
+/area/hallway/primary/central)
+"bHD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
+"bHE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
 "bHF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47372,11 +47254,8 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
 "bHI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -47384,12 +47263,11 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/table/reinforced/brass,
-/obj/machinery/computer/secure_data/laptop,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel,
+/area/maintenance/starboard)
 "bHJ" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -47627,10 +47505,7 @@
 	dir = 8;
 	network = list("SS13","Security")
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48405,13 +48280,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
+/turf/simulated/floor/plating,
+/area/maintenance/starboard)
 "bJu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48419,7 +48289,11 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/airlock/maintenance{
+	name = "Detective Maintenance";
+	req_access_txt = "4"
+	},
+/turf/simulated/floor/plasteel,
 /area/security/detectives_office)
 "bJv" = (
 /obj/structure/cable{
@@ -49492,55 +49366,64 @@
 	},
 /area/crew_quarters/captain)
 "bLh" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1;
-	d2 = 2
-	},
 /turf/simulated/wall,
-/area/magistrateoffice)
+/area/storage/tools)
 "bLi" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "yellow"
 	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
+/area/storage/tools)
 "bLj" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/paper_bin{
-	step_x = 0;
-	step_y = 5
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/door_control{
-	name = "Office Door";
-	step_x = -2;
-	step_y = -8;
-	pixel_x = -6;
-	pixel_y = 16;
-	req_access_txt = "74";
-	id = "magistrateofficedoor";
-	normaldoorcontrol = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"bLk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced/brass,
-/obj/item/book/manual/security_space_law/black{
-	step_x = 1;
-	step_y = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"bLm" = (
-/obj/machinery/light{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/machinery/disposal,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
-/area/magistrateoffice)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/storage/tools)
+"bLk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plasteel,
+/area/storage/tools)
+"bLl" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "cautioncorner"
+	},
+/area/storage/tools)
+"bLm" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "yellow"
+	},
+/area/storage/tools)
 "bLn" = (
 /turf/simulated/wall,
 /area/security/detectives_office)
@@ -50095,10 +49978,7 @@
 /area/crew_quarters/chief)
 "bMi" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50171,10 +50051,7 @@
 /area/engine/break_room)
 "bMr" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -50451,10 +50328,7 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/lighter/zippo,
 /obj/structure/cable{
 	d1 = 1;
@@ -50647,28 +50521,58 @@
 	icon_state = "wood"
 	},
 /area/crew_quarters/captain)
+"bNi" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/multitool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28;
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/storage/tools)
 "bNj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bNk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bNl" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 8;
+	icon_state = "neutralfull"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bNm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50739,10 +50643,7 @@
 /area/security/detectives_office)
 "bNs" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -50780,10 +50681,7 @@
 "bNv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -50924,10 +50822,7 @@
 /area/security/brig)
 "bNI" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -51441,10 +51336,7 @@
 /area/bridge/meeting_room)
 "bOJ" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
 	initialize_directions = 11
@@ -51651,49 +51543,61 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
 "bPd" = (
-/obj/item/twohanded/required/kirbyplants,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 10;
+	icon_state = "yellow"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bPe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -2;
+	pixel_y = 3
 	},
-/area/magistrateoffice)
+/obj/item/stack/rods,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/storage/tools)
+"bPf" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/storage/tools)
 "bPg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 2;
+	icon_state = "yellowcorner"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bPh" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/structure/table/reinforced/brass,
-/obj/machinery/photocopier/faxmachine/longrange{
-	step_y = 3;
-	department = "Magistrate's Office"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "grimy"
+	dir = 6;
+	icon_state = "yellow"
 	},
-/area/magistrateoffice)
+/area/storage/tools)
 "bPi" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -51756,10 +51660,7 @@
 /area/security/detectives_office)
 "bPo" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -51842,10 +51743,7 @@
 	tag = ""
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52699,10 +52597,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "bQQ" = (
@@ -52776,45 +52671,26 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
+/turf/simulated/wall,
+/area/storage/tools)
 "bQW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
 /turf/simulated/floor/plating,
-/area/magistrateoffice)
+/area/storage/tools)
 "bQX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock{
-	id_tag = "magistrateofficedoor";
-	name = "Magistrate's Office";
-	req_access_txt = "74"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/airlock/glass{
+	name = "Auxiliary Tool Storage";
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plasteel,
-/area/magistrateoffice)
+/area/storage/tools)
 "bQY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
-/area/magistrateoffice)
+/area/storage/tools)
 "bQZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -54163,12 +54039,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "cautioncorner"
@@ -54231,14 +54101,12 @@
 	pixel_y = 0
 	},
 /obj/machinery/camera{
-	c_tag = "Magistrate";
+	c_tag = "Auxiliary Tool Storage";
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
+/turf/simulated/floor/plasteel,
+/area/storage/tools)
 "bTe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55349,10 +55217,7 @@
 /area/hallway/primary/central)
 "bUO" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55377,10 +55242,7 @@
 	name = "Head of Personnel Requests Console";
 	pixel_y = 30
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/stamp/hop,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57366,10 +57228,7 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -58400,10 +58259,7 @@
 /area/library)
 "bZO" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -58878,7 +58734,6 @@
 /area/lawoffice)
 "caJ" = (
 /obj/machinery/photocopier/faxmachine/longrange{
-	step_y = 3;
 	department = "Magistrate's Office"
 	},
 /obj/structure/table/wood,
@@ -58901,10 +58756,7 @@
 /area/lawoffice)
 "caM" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -59017,10 +58869,7 @@
 /area/security/armoury)
 "caS" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -59529,10 +59378,7 @@
 /area/library)
 "cbM" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/status_display{
 	pixel_x = 32;
@@ -59657,10 +59503,7 @@
 /area/ntrep)
 "cbX" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/paper/ntrep,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -5;
@@ -60988,10 +60831,7 @@
 /area/crew_quarters/courtroom)
 "cef" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -61786,10 +61626,7 @@
 /area/maintenance/fpmaint2)
 "cfq" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 4;
@@ -62150,10 +61987,7 @@
 	level = 1
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -62193,10 +62027,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/stamp/law,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -62249,10 +62080,7 @@
 	icon_state = "bulb1";
 	dir = 8
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -62784,10 +62612,7 @@
 "chh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -63101,10 +62926,7 @@
 /area/lawoffice)
 "chM" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
@@ -64832,10 +64654,7 @@
 /area/crew_quarters/courtroom)
 "ckQ" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -67003,10 +66822,7 @@
 /area/crew_quarters/courtroom)
 "coL" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light{
 	dir = 8
@@ -69812,10 +69628,7 @@
 /area/crew_quarters/fitness)
 "ctA" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -70104,10 +69917,7 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "bluecorner"
@@ -70910,10 +70720,7 @@
 /area/ai_monitored/storage/eva)
 "cvu" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Courtroom West";
@@ -71640,10 +71447,7 @@
 /area/library)
 "cwN" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -72884,10 +72688,7 @@
 /area/crew_quarters/sleep)
 "cyW" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = 0;
@@ -73085,10 +72886,7 @@
 /area/maintenance/fpmaint2)
 "czp" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -73435,10 +73233,7 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet,
 /area/assembly/showroom)
 "czR" = (
@@ -73738,10 +73533,7 @@
 /area/crew_quarters/sleep)
 "cAt" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -75108,10 +74900,7 @@
 	name = "station intercom (General)";
 	pixel_x = 28
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -75245,10 +75034,7 @@
 	},
 /area/crew_quarters/locker)
 "cDm" = (
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -77528,10 +77314,7 @@
 /area/crew_quarters/fitness)
 "cHd" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -79102,10 +78885,7 @@
 /area/security/checkpoint/science)
 "cKw" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/sign/poster/official/science{
 	pixel_x = -32
@@ -81145,10 +80925,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -81162,10 +80939,7 @@
 /area/crew_quarters/sleep)
 "cOr" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep)
@@ -81310,10 +81084,7 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light_switch{
 	pixel_x = 4;
@@ -82209,10 +81980,7 @@
 /area/crew_quarters/fitness)
 "cQn" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83422,10 +83190,7 @@
 "cSr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -83479,10 +83244,7 @@
 /area/hallway/primary/aft)
 "cSx" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -83575,10 +83337,7 @@
 /area/medical/medbay)
 "cSG" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -83849,10 +83608,7 @@
 /area/maintenance/electrical)
 "cTk" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -86111,10 +85867,7 @@
 /area/toxins/lab)
 "cWT" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/storage/bag/bio,
 /obj/item/storage/bag/bio,
@@ -87713,10 +87466,7 @@
 /area/medical/medbay3)
 "cZX" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -88119,10 +87869,7 @@
 /area/toxins/lab)
 "daN" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -88146,10 +87893,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "orangefull"
@@ -89640,10 +89384,7 @@
 /area/toxins/lab)
 "ddH" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -90309,10 +90050,7 @@
 /area/medical/research)
 "deM" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -91855,10 +91593,7 @@
 /area/crew_quarters/hor)
 "dhP" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -92232,10 +91967,7 @@
 /area/assembly/chargebay)
 "dit" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -92862,10 +92594,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -95554,10 +95283,7 @@
 /area/assembly/chargebay)
 "doz" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
@@ -97095,10 +96821,7 @@
 /area/hallway/secondary/construction)
 "dqY" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -97446,10 +97169,7 @@
 /area/assembly/robotics)
 "drK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -98007,10 +97727,7 @@
 /area/assembly/robotics)
 "dsK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
@@ -98314,10 +98031,7 @@
 	level = 1
 	},
 /obj/structure/table/glass,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cmo"
@@ -101531,10 +101245,7 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 8
@@ -102737,10 +102448,7 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Research Toxins Storage Room";
@@ -102924,10 +102632,7 @@
 "dBt" = (
 /obj/structure/table/wood,
 /obj/item/folder/white,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -102935,10 +102640,7 @@
 /area/security/detectives_office)
 "dBu" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -104877,10 +104579,7 @@
 	},
 /area/hallway/primary/aft)
 "dFb" = (
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/structure/table,
 /obj/item/pen,
 /obj/machinery/newscaster{
@@ -105184,10 +104883,7 @@
 "dFK" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plating,
 /area/library/abandoned)
@@ -105364,10 +105060,7 @@
 /area/medical/research)
 "dGe" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -105635,10 +105328,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -105818,10 +105508,7 @@
 /area/bridge)
 "dGS" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -106194,10 +105881,7 @@
 "dHv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "carpet"
@@ -107325,10 +107009,7 @@
 /area/library/abandoned)
 "dJs" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -107717,10 +107398,7 @@
 /area/chapel/main)
 "dKl" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/light_switch{
 	pixel_x = 0;
 	pixel_y = 24
@@ -109137,10 +108815,7 @@
 /area/medical/virology)
 "dMI" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -109588,10 +109263,7 @@
 /area/library/abandoned)
 "dNE" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /turf/simulated/floor/plating,
 /area/library/abandoned)
 "dNF" = (
@@ -110046,10 +109718,7 @@
 /area/chapel/main)
 "dOu" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -110261,10 +109930,7 @@
 	level = 1
 	},
 /obj/structure/table/glass,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/machinery/newscaster{
 	pixel_x = 32;
 	pixel_y = 0
@@ -111621,10 +111287,7 @@
 /obj/structure/sign/deathsposal{
 	pixel_y = -32
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/virology)
@@ -112864,10 +112527,7 @@
 /area/security/checkpoint)
 "dTB" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -112888,10 +112548,7 @@
 	pixel_y = 8;
 	req_access_txt = "63"
 	},
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -113129,10 +112786,7 @@
 	dir = 4;
 	level = 1
 	},
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/structure/table/wood,
 /obj/item/pen,
 /turf/simulated/floor/carpet,
@@ -113477,10 +113131,7 @@
 /area/chapel/office)
 "dUM" = (
 /obj/structure/table/wood,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -113859,10 +113510,7 @@
 /area/shuttle/escape)
 "dVt" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -114068,10 +113716,7 @@
 /area/shuttle/escape)
 "dVS" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	step_x = -1;
-	step_y = 6
-	},
+/obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -114080,10 +113725,7 @@
 /area/shuttle/escape)
 "dVT" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
@@ -115850,10 +115492,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red{
-	step_x = -3;
-	step_y = 3
-	},
+/obj/item/folder/red,
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/brigdoor{
@@ -116352,170 +115991,12 @@
 	},
 /turf/space,
 /area/space)
-"etB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/central)
-"eFY" = (
-/obj/structure/sign/poster/official/nanotrasen_logo,
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
-"eWi" = (
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"gvF" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start{
-	name = "Magistrate"
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"hcC" = (
-/obj/machinery/firealarm,
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
-"iPr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/closet/secure_closet/magistrate,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
-"jVH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/filingcabinet/security,
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"lya" = (
-/obj/machinery/light_switch{
-	step_x = -9
-	},
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
-"lKx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/table/reinforced/brass,
-/obj/item/folder/blue,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
-"mSs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
-	dir = 4
-	},
-/area/hallway/primary/central)
-"nTA" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/magistrateoffice)
-"pQL" = (
-/obj/structure/sign/poster/official/state_laws,
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
-"rgE" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/turf/simulated/wall,
-/area/magistrateoffice)
-"tev" = (
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
 "udT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
-"ufQ" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/wall,
-/area/magistrateoffice)
-"uXJ" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/magistrateoffice)
-"wHT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/hallway/primary/starboard)
-"xcb" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/simulated/wall/r_wall,
-/area/magistrateoffice)
 
 (1,1,1) = {"
 aaa
@@ -160838,10 +160319,10 @@ bCD
 bEp
 bFs
 bHB
-etB
 bva
 bva
-etB
+bva
+bva
 bSi
 bwn
 bVd
@@ -161094,8 +160575,8 @@ bvb
 bCE
 bEq
 bEq
+bHC
 bvb
-mSs
 bvb
 bvb
 bPc
@@ -161350,12 +160831,12 @@ btH
 btH
 bsv
 bsv
-tev
+bng
 bHD
-rgE
-tev
+bng
 bLh
-ufQ
+bLh
+bLh
 bQV
 bXC
 bYL
@@ -161607,13 +161088,13 @@ btH
 aaa
 abj
 aaa
-xcb
+bng
 bHE
-eWi
+bng
 bLi
-uXJ
+bNi
 bPd
-tev
+bLh
 bSW
 bVg
 bXc
@@ -161864,9 +161345,9 @@ bzc
 btL
 btL
 aaa
-eFY
-jVH
-gvF
+bng
+bHF
+bng
 bLj
 bNj
 bPe
@@ -162121,15 +161602,15 @@ bwv
 bvc
 btL
 abj
-tev
+bng
 buY
 bxx
 bLk
 bNk
-bNk
+bPf
 bQX
 bSY
-wHT
+bVg
 bXc
 bZi
 cax
@@ -162378,10 +161859,10 @@ bwu
 bAI
 btL
 aaa
-hcC
+bng
 bHH
-nTA
-nTA
+bng
+bLl
 bNl
 bPg
 bQY
@@ -162635,13 +162116,13 @@ bzd
 bAJ
 btL
 aaa
-tev
-iPr
-uXJ
+bng
+bHF
+bqC
 bLm
 bTd
 bPh
-tev
+bLh
 bTa
 bVg
 bXc
@@ -162892,13 +162373,13 @@ bwu
 bAK
 btL
 aaa
-pQL
-lKx
-uXJ
-lya
-tev
-tev
-tev
+bqC
+bHF
+bqC
+bLn
+bLn
+bLn
+bLn
 bTb
 bVi
 bXf
@@ -163149,13 +162630,13 @@ bwv
 bvc
 btL
 abj
-tev
+bng
 bHI
 bJt
-tev
+bLn
 bNn
 bPi
-bFS
+bLn
 bQz
 bVB
 bVD
@@ -163412,7 +162893,7 @@ bJu
 bFS
 bNo
 bPj
-bFS
+bLn
 bXD
 bVg
 bXc

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -4874,7 +4874,10 @@
 /area/shuttle/specops)
 "akw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
@@ -6922,7 +6925,10 @@
 /area/security/vacantoffice)
 "aoU" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -7004,7 +7010,10 @@
 /area/security/vacantoffice)
 "apc" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -7733,7 +7742,10 @@
 /area/maintenance/electrical_shop)
 "aqA" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -8022,7 +8034,10 @@
 /area/maintenance/fsmaint)
 "ari" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8383,7 +8398,10 @@
 	tag = ""
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
@@ -8714,7 +8732,10 @@
 /area/bridge)
 "asy" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -8781,7 +8802,10 @@
 /area/security/checkpoint2)
 "asG" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
@@ -9061,7 +9085,10 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -9146,7 +9173,10 @@
 /area/security/vacantoffice)
 "ats" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -9707,7 +9737,10 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -12666,7 +12699,10 @@
 /area/quartermaster/storage)
 "azM" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -15715,7 +15751,10 @@
 /area/crew_quarters/sleep)
 "aFs" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -19554,7 +19593,10 @@
 /area/quartermaster/office)
 "aMa" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel{
@@ -20026,7 +20068,10 @@
 /area/maintenance/fsmaint)
 "aNa" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
 	},
@@ -20483,7 +20528,10 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/security/prison)
 "aNM" = (
@@ -20751,7 +20799,10 @@
 /area/maintenance/gambling_den)
 "aOr" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -21499,7 +21550,10 @@
 "aPL" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -22118,7 +22172,10 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -22149,7 +22206,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -23738,7 +23798,10 @@
 	dir = 6
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/restraints/handcuffs,
 /obj/item/taperecorder,
 /obj/machinery/camera{
@@ -24342,7 +24405,10 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/newscaster{
 	layer = 3.3;
 	pixel_x = -27;
@@ -24432,7 +24498,10 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -24492,7 +24561,10 @@
 /area/quartermaster/storage)
 "aUY" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -27241,7 +27313,10 @@
 	},
 /area/quartermaster/qm)
 "aZy" = (
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -29231,7 +29306,10 @@
 /area/shuttle/mining)
 "bcU" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/security/prison)
@@ -29859,7 +29937,10 @@
 /area/hallway/primary/fore)
 "bdV" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light{
 	dir = 8
@@ -34212,7 +34293,10 @@
 /area/security/main)
 "bmb" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/clothing/mask/gas/sechailer,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -34280,7 +34364,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/machinery/keycard_auth{
 	pixel_x = 26;
 	pixel_y = 10
@@ -34558,7 +34645,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
@@ -34993,7 +35083,10 @@
 "bny" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/folder/blue{
 	pixel_x = 5;
 	pixel_y = 5
@@ -35926,7 +36019,10 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/stamp/hos,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -37072,7 +37168,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -37918,7 +38017,10 @@
 /area/shuttle/siberia)
 "bsz" = (
 /obj/structure/table,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/restraints/handcuffs,
 /obj/machinery/light{
 	dir = 4;
@@ -38189,7 +38291,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/storage/secure/briefcase,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -38208,7 +38313,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -39070,7 +39178,10 @@
 /area/security/hos)
 "bum" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -39454,21 +39565,31 @@
 /turf/space,
 /area/atmos)
 "buY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table/reinforced/brass,
+/obj/item/pen/multi/gold{
+	step_x = 7;
+	step_y = 2
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/item/stamp/magistrate{
+	step_x = -4;
+	step_y = -1
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40586,7 +40707,10 @@
 /area/engine/break_room)
 "bwX" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 22;
@@ -40854,19 +40978,13 @@
 	},
 /area/bridge)
 "bxx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/brass,
+/obj/item/stack/tile/carpet/black{
+	step_y = 3
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Auxiliary Storage";
-	req_access_txt = "0";
-	req_one_access_txt = "65;12"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bxy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -42061,7 +42179,10 @@
 /area/security/main)
 "bzp" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -42120,9 +42241,15 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/book/manual/security_space_law,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -42147,7 +42274,10 @@
 /area/turret_protected/ai)
 "bzw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -42991,7 +43121,10 @@
 /area/security/main)
 "bBc" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43421,7 +43554,10 @@
 /area/atmos)
 "bBN" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -47111,7 +47247,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -47122,7 +47261,10 @@
 /area/bridge)
 "bHw" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -47172,12 +47314,6 @@
 /area/hallway/primary/central)
 "bHB" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2";
@@ -47194,40 +47330,22 @@
 	icon_state = "neutralfull"
 	},
 /area/hallway/primary/central)
-"bHC" = (
+"bHD" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutralcorner";
+/turf/simulated/floor/plating,
+/area/magistrateoffice)
+"bHE" = (
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/area/hallway/primary/central)
-"bHD" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
-"bHE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/machinery/disposal,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bHF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47254,8 +47372,11 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bHI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -47263,11 +47384,12 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/structure/table/reinforced/brass,
+/obj/machinery/computer/secure_data/laptop,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bHJ" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -47505,7 +47627,10 @@
 	dir = 8;
 	network = list("SS13","Security")
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48280,8 +48405,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bJu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48289,11 +48419,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	req_access_txt = "4"
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "bJv" = (
 /obj/structure/cable{
@@ -49366,64 +49492,55 @@
 	},
 /area/crew_quarters/captain)
 "bLh" = (
-/turf/simulated/wall,
-/area/storage/tools)
-"bLi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
-	},
-/area/storage/tools)
-"bLj" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
 	},
-/obj/structure/disposalpipe/trunk{
+/turf/simulated/wall,
+/area/magistrateoffice)
+"bLi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"bLj" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/paper_bin{
+	step_x = 0;
+	step_y = 5
+	},
+/obj/machinery/door_control{
+	name = "Office Door";
+	step_x = -2;
+	step_y = -8;
+	pixel_x = -6;
+	pixel_y = 16;
+	req_access_txt = "74";
+	id = "magistrateofficedoor";
+	normaldoorcontrol = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"bLk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/brass,
+/obj/item/book/manual/security_space_law/black{
+	step_x = 1;
+	step_y = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"bLm" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
-"bLk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
-"bLl" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
-	},
-/area/storage/tools)
-"bLm" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "yellow"
-	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bLn" = (
 /turf/simulated/wall,
 /area/security/detectives_office)
@@ -49978,7 +50095,10 @@
 /area/crew_quarters/chief)
 "bMi" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50051,7 +50171,10 @@
 /area/engine/break_room)
 "bMr" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -50328,7 +50451,10 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/lighter/zippo,
 /obj/structure/cable{
 	d1 = 1;
@@ -50521,58 +50647,28 @@
 	icon_state = "wood"
 	},
 /area/crew_quarters/captain)
-"bNi" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/multitool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/storage/tools)
 "bNj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNl" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50643,7 +50739,10 @@
 /area/security/detectives_office)
 "bNs" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/hand_labeler,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -50681,7 +50780,10 @@
 "bNv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -50822,7 +50924,10 @@
 /area/security/brig)
 "bNI" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -51336,7 +51441,10 @@
 /area/bridge/meeting_room)
 "bOJ" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8;
 	initialize_directions = 11
@@ -51543,61 +51651,49 @@
 	icon_state = "tube1";
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
 "bPd" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "yellow"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bPe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/stack/rods,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
-"bPf" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
+/area/magistrateoffice)
 "bPg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "yellowcorner"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bPh" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "yellow"
+/obj/structure/table/reinforced/brass,
+/obj/machinery/photocopier/faxmachine/longrange{
+	step_y = 3;
+	department = "Magistrate's Office"
 	},
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bPi" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -51660,7 +51756,10 @@
 /area/security/detectives_office)
 "bPo" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -51743,7 +51842,10 @@
 	tag = ""
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -52597,7 +52699,10 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "bQQ" = (
@@ -52671,26 +52776,45 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/turf/simulated/wall,
-/area/storage/tools)
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 "bQW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
 /turf/simulated/floor/plating,
-/area/storage/tools)
+/area/magistrateoffice)
 "bQX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Tool Storage";
-	req_access_txt = "12"
+/obj/machinery/door/airlock{
+	id_tag = "magistrateofficedoor";
+	name = "Magistrate's Office";
+	req_access_txt = "74"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/storage/tools)
+/area/magistrateoffice)
 "bQY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/storage/tools)
+/area/magistrateoffice)
 "bQZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -54039,6 +54163,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "cautioncorner"
@@ -54101,12 +54231,14 @@
 	pixel_y = 0
 	},
 /obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
+	c_tag = "Magistrate";
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bTe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55217,7 +55349,10 @@
 /area/hallway/primary/central)
 "bUO" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -55242,7 +55377,10 @@
 	name = "Head of Personnel Requests Console";
 	pixel_y = 30
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/stamp/hop,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -57228,7 +57366,10 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -58259,7 +58400,10 @@
 /area/library)
 "bZO" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -58734,6 +58878,7 @@
 /area/lawoffice)
 "caJ" = (
 /obj/machinery/photocopier/faxmachine/longrange{
+	step_y = 3;
 	department = "Magistrate's Office"
 	},
 /obj/structure/table/wood,
@@ -58756,7 +58901,10 @@
 /area/lawoffice)
 "caM" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -58869,7 +59017,10 @@
 /area/security/armoury)
 "caS" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
@@ -59378,7 +59529,10 @@
 /area/library)
 "cbM" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/status_display{
 	pixel_x = 32;
@@ -59503,7 +59657,10 @@
 /area/ntrep)
 "cbX" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/paper/ntrep,
 /obj/item/flashlight/lamp/green{
 	pixel_x = -5;
@@ -60831,7 +60988,10 @@
 /area/crew_quarters/courtroom)
 "cef" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -61626,7 +61786,10 @@
 /area/maintenance/fpmaint2)
 "cfq" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/alarm{
 	dir = 4;
@@ -61987,7 +62150,10 @@
 	level = 1
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blue"
@@ -62027,7 +62193,10 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/stamp/law,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -62080,7 +62249,10 @@
 	icon_state = "bulb1";
 	dir = 8
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -62612,7 +62784,10 @@
 "chh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -62926,7 +63101,10 @@
 /area/lawoffice)
 "chM" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/requests_console{
 	name = "Detective Requests Console";
@@ -64654,7 +64832,10 @@
 /area/crew_quarters/courtroom)
 "ckQ" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -66822,7 +67003,10 @@
 /area/crew_quarters/courtroom)
 "coL" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light{
 	dir = 8
@@ -69628,7 +69812,10 @@
 /area/crew_quarters/fitness)
 "ctA" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -69917,7 +70104,10 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "bluecorner"
@@ -70720,7 +70910,10 @@
 /area/ai_monitored/storage/eva)
 "cvu" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Courtroom West";
@@ -71447,7 +71640,10 @@
 /area/library)
 "cwN" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -72688,7 +72884,10 @@
 /area/crew_quarters/sleep)
 "cyW" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = 0;
@@ -72886,7 +73085,10 @@
 /area/maintenance/fpmaint2)
 "czp" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -73233,7 +73435,10 @@
 	tag = ""
 	},
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/carpet,
 /area/assembly/showroom)
 "czR" = (
@@ -73533,7 +73738,10 @@
 /area/crew_quarters/sleep)
 "cAt" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -74900,7 +75108,10 @@
 	name = "station intercom (General)";
 	pixel_x = 28
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -75034,7 +75245,10 @@
 	},
 /area/crew_quarters/locker)
 "cDm" = (
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/structure/table,
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
@@ -77314,7 +77528,10 @@
 /area/crew_quarters/fitness)
 "cHd" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -78885,7 +79102,10 @@
 /area/security/checkpoint/science)
 "cKw" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/structure/sign/poster/official/science{
 	pixel_x = -32
@@ -80925,7 +81145,10 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -80939,7 +81162,10 @@
 /area/crew_quarters/sleep)
 "cOr" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep)
@@ -81084,7 +81310,10 @@
 	dir = 1;
 	on = 1
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light_switch{
 	pixel_x = 4;
@@ -81980,7 +82209,10 @@
 /area/crew_quarters/fitness)
 "cQn" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -83190,7 +83422,10 @@
 "cSr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -83244,7 +83479,10 @@
 /area/hallway/primary/aft)
 "cSx" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -83337,7 +83575,10 @@
 /area/medical/medbay)
 "cSG" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -83608,7 +83849,10 @@
 /area/maintenance/electrical)
 "cTk" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -85867,7 +86111,10 @@
 /area/toxins/lab)
 "cWT" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/item/storage/bag/bio,
 /obj/item/storage/bag/bio,
@@ -87466,7 +87713,10 @@
 /area/medical/medbay3)
 "cZX" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -87869,7 +88119,10 @@
 /area/toxins/lab)
 "daN" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
 	},
@@ -87893,7 +88146,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "orangefull"
@@ -89384,7 +89640,10 @@
 /area/toxins/lab)
 "ddH" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light,
 /obj/machinery/door_control{
@@ -90050,7 +90309,10 @@
 /area/medical/research)
 "deM" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
@@ -91593,7 +91855,10 @@
 /area/crew_quarters/hor)
 "dhP" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /turf/simulated/floor/plasteel,
@@ -91967,7 +92232,10 @@
 /area/assembly/chargebay)
 "dit" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -92594,7 +92862,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/northeast,
 /turf/simulated/floor/plasteel,
@@ -95283,7 +95554,10 @@
 /area/assembly/chargebay)
 "doz" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/medical/research)
@@ -96821,7 +97095,10 @@
 /area/hallway/secondary/construction)
 "dqY" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 0;
@@ -97169,7 +97446,10 @@
 /area/assembly/robotics)
 "drK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "purplefull"
@@ -97727,7 +98007,10 @@
 /area/assembly/robotics)
 "dsK" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/item/assembly/prox_sensor,
 /obj/item/assembly/prox_sensor,
@@ -98031,7 +98314,10 @@
 	level = 1
 	},
 /obj/structure/table/glass,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "cmo"
@@ -101245,7 +101531,10 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 8
@@ -102448,7 +102737,10 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Research Toxins Storage Room";
@@ -102632,7 +102924,10 @@
 "dBt" = (
 /obj/structure/table/wood,
 /obj/item/folder/white,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -102640,7 +102935,10 @@
 /area/security/detectives_office)
 "dBu" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -104579,7 +104877,10 @@
 	},
 /area/hallway/primary/aft)
 "dFb" = (
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/structure/table,
 /obj/item/pen,
 /obj/machinery/newscaster{
@@ -104883,7 +105184,10 @@
 "dFK" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plating,
 /area/library/abandoned)
@@ -105060,7 +105364,10 @@
 /area/medical/research)
 "dGe" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -105328,7 +105635,10 @@
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitegreencorner"
@@ -105508,7 +105818,10 @@
 /area/bridge)
 "dGS" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -105881,7 +106194,10 @@
 "dHv" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "carpet"
@@ -107009,7 +107325,10 @@
 /area/library/abandoned)
 "dJs" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/wood{
 	broken = 1;
@@ -107398,7 +107717,10 @@
 /area/chapel/main)
 "dKl" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/light_switch{
 	pixel_x = 0;
 	pixel_y = 24
@@ -108815,7 +109137,10 @@
 /area/medical/virology)
 "dMI" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "wood"
@@ -109263,7 +109588,10 @@
 /area/library/abandoned)
 "dNE" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /turf/simulated/floor/plating,
 /area/library/abandoned)
 "dNF" = (
@@ -109718,7 +110046,10 @@
 /area/chapel/main)
 "dOu" = (
 /obj/structure/table,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
@@ -109930,7 +110261,10 @@
 	level = 1
 	},
 /obj/structure/table/glass,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/machinery/newscaster{
 	pixel_x = 32;
 	pixel_y = 0
@@ -111287,7 +111621,10 @@
 /obj/structure/sign/deathsposal{
 	pixel_y = -32
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/effect/decal/warning_stripes/north,
 /turf/simulated/floor/plasteel,
 /area/medical/virology)
@@ -112527,7 +112864,10 @@
 /area/security/checkpoint)
 "dTB" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -112548,7 +112888,10 @@
 	pixel_y = 8;
 	req_access_txt = "63"
 	},
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "redfull";
@@ -112786,7 +113129,10 @@
 	dir = 4;
 	level = 1
 	},
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/structure/table/wood,
 /obj/item/pen,
 /turf/simulated/floor/carpet,
@@ -113131,7 +113477,10 @@
 /area/chapel/office)
 "dUM" = (
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -113510,7 +113859,10 @@
 /area/shuttle/escape)
 "dVt" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -113716,7 +114068,10 @@
 /area/shuttle/escape)
 "dVS" = (
 /obj/structure/table/reinforced,
-/obj/item/paper_bin,
+/obj/item/paper_bin{
+	step_x = -1;
+	step_y = 6
+	},
 /obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -113725,7 +114080,10 @@
 /area/shuttle/escape)
 "dVT" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
 /turf/simulated/floor/plasteel{
@@ -115492,7 +115850,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
+/obj/item/folder/red{
+	step_x = -3;
+	step_y = 3
+	},
 /obj/item/pen,
 /obj/effect/decal/warning_stripes/yellow,
 /obj/machinery/door/window/brigdoor{
@@ -115991,12 +116352,170 @@
 	},
 /turf/space,
 /area/space)
+"etB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central)
+"eFY" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"eWi" = (
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"gvF" = (
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start{
+	name = "Magistrate"
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"hcC" = (
+/obj/machinery/firealarm,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"iPr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/closet/secure_closet/magistrate,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"jVH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/filingcabinet/security,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"lya" = (
+/obj/machinery/light_switch{
+	step_x = -9
+	},
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"lKx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/table/reinforced/brass,
+/obj/item/folder/blue,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"mSs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 4
+	},
+/area/hallway/primary/central)
+"nTA" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"pQL" = (
+/obj/structure/sign/poster/official/state_laws,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"rgE" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/turf/simulated/wall,
+/area/magistrateoffice)
+"tev" = (
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 "udT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"ufQ" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/wall,
+/area/magistrateoffice)
+"uXJ" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"wHT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/starboard)
+"xcb" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 
 (1,1,1) = {"
 aaa
@@ -160319,10 +160838,10 @@ bCD
 bEp
 bFs
 bHB
+etB
 bva
 bva
-bva
-bva
+etB
 bSi
 bwn
 bVd
@@ -160575,8 +161094,8 @@ bvb
 bCE
 bEq
 bEq
-bHC
 bvb
+mSs
 bvb
 bvb
 bPc
@@ -160831,12 +161350,12 @@ btH
 btH
 bsv
 bsv
-bng
+tev
 bHD
-bng
+rgE
+tev
 bLh
-bLh
-bLh
+ufQ
 bQV
 bXC
 bYL
@@ -161088,13 +161607,13 @@ btH
 aaa
 abj
 aaa
-bng
+xcb
 bHE
-bng
+eWi
 bLi
-bNi
+uXJ
 bPd
-bLh
+tev
 bSW
 bVg
 bXc
@@ -161345,9 +161864,9 @@ bzc
 btL
 btL
 aaa
-bng
-bHF
-bng
+eFY
+jVH
+gvF
 bLj
 bNj
 bPe
@@ -161602,15 +162121,15 @@ bwv
 bvc
 btL
 abj
-bng
+tev
 buY
 bxx
 bLk
 bNk
-bPf
+bNk
 bQX
 bSY
-bVg
+wHT
 bXc
 bZi
 cax
@@ -161859,10 +162378,10 @@ bwu
 bAI
 btL
 aaa
-bng
+hcC
 bHH
-bng
-bLl
+nTA
+nTA
 bNl
 bPg
 bQY
@@ -162116,13 +162635,13 @@ bzd
 bAJ
 btL
 aaa
-bng
-bHF
-bqC
+tev
+iPr
+uXJ
 bLm
 bTd
 bPh
-bLh
+tev
 bTa
 bVg
 bXc
@@ -162373,13 +162892,13 @@ bwu
 bAK
 btL
 aaa
-bqC
-bHF
-bqC
-bLn
-bLn
-bLn
-bLn
+pQL
+lKx
+uXJ
+lya
+tev
+tev
+tev
 bTb
 bVi
 bXf
@@ -162630,13 +163149,13 @@ bwv
 bvc
 btL
 abj
-bng
+tev
 bHI
 bJt
-bLn
+tev
 bNn
 bPi
-bLn
+bFS
 bQz
 bVB
 bVD
@@ -162893,7 +163412,7 @@ bJu
 bFS
 bNo
 bPj
-bLn
+bFS
 bXD
 bVg
 bXc

--- a/_maps/map_files/Delta/delta.dmm
+++ b/_maps/map_files/Delta/delta.dmm
@@ -39454,21 +39454,15 @@
 /turf/space,
 /area/atmos)
 "buY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/structure/table/reinforced/brass,
+/obj/item/pen/multi/gold,
+/obj/item/stamp/magistrate,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "buZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -40854,19 +40848,19 @@
 	},
 /area/bridge)
 "bxx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/brass,
+/obj/item/paper_bin,
+/obj/machinery/door_control{
+	id = "magistrateofficedoor";
+	name = "Office Door";
+	normaldoorcontrol = 1;
+	pixel_x = -6;
+	pixel_y = 16;
+	req_access_txt = "74"
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Auxiliary Storage";
-	req_access_txt = "0";
-	req_one_access_txt = "65;12"
-	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bxy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -47209,25 +47203,27 @@
 	},
 /area/hallway/primary/central)
 "bHD" = (
+/obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bHE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/machinery/disposal,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bHF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47249,13 +47245,20 @@
 /area/quartermaster/miningdock)
 "bHH" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	tag = ""
+	icon_state = "0-4";
+	d2 = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bHI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -47263,11 +47266,13 @@
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
-/area/maintenance/starboard)
+/obj/structure/table/reinforced/brass,
+/obj/machinery/computer/secure_data/laptop,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bHJ" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -48280,8 +48285,18 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bJu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48289,11 +48304,7 @@
 	icon_state = "4-8";
 	tag = ""
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	req_access_txt = "4"
-	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/wall/r_wall,
 /area/security/detectives_office)
 "bJv" = (
 /obj/structure/cable{
@@ -49366,64 +49377,35 @@
 	},
 /area/crew_quarters/captain)
 "bLh" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/storage/tools)
 "bLi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "yellow"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/storage/tools)
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bLj" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/storage/tools)
+/obj/structure/table/reinforced/brass,
+/obj/item/gavelhammer,
+/obj/item/megaphone,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bLk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
-"bLl" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
-	},
-/area/storage/tools)
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/brass,
+/obj/item/book/manual/security_space_law/black,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
 "bLm" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "yellow"
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
 	},
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bLn" = (
 /turf/simulated/wall,
 /area/security/detectives_office)
@@ -50521,58 +50503,28 @@
 	icon_state = "wood"
 	},
 /area/crew_quarters/captain)
-"bNi" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/multitool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28;
-	pixel_y = 0
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/storage/tools)
 "bNj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNl" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	on = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bNm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -51549,55 +51501,36 @@
 	},
 /area/hallway/primary/central)
 "bPd" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "yellow"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bPe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/stack/rods,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellowcorner"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
-"bPf" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
+/area/magistrateoffice)
 "bPg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "yellowcorner"
+	icon_state = "grimy"
 	},
-/area/storage/tools)
+/area/magistrateoffice)
 "bPh" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "yellow"
+/obj/structure/table/reinforced/brass,
+/obj/machinery/photocopier/faxmachine/longrange{
+	department = "Magistrate's Office"
 	},
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bPi" = (
 /obj/structure/morgue,
 /obj/machinery/light/small{
@@ -52671,26 +52604,40 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/turf/simulated/wall,
-/area/storage/tools)
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 "bQW" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/storage/tools)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bQX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Tool Storage";
-	req_access_txt = "12"
+/obj/machinery/door/airlock{
+	name = "Magistrate's Office";
+	req_access_txt = "74"
 	},
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bQY" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/storage/tools)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bQZ" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -54027,6 +53974,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "cautioncorner"
@@ -54051,6 +54003,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -54094,19 +54051,15 @@
 /turf/simulated/floor/plating,
 /area/turret_protected/aisat)
 "bTd" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "station intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
-	},
 /obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
+	c_tag = "Magistrate";
 	dir = 8;
 	network = list("SS13")
 	},
-/turf/simulated/floor/plasteel,
-/area/storage/tools)
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
 "bTe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69560,18 +69513,6 @@
 	icon_state = "neutralfull"
 	},
 /area/crew_quarters/locker)
-"ctt" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Magistrate"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "neutralfull"
-	},
-/area/crew_quarters/courtroom)
 "ctu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
@@ -115991,12 +115932,168 @@
 	},
 /turf/space,
 /area/space)
+"ebH" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"ekn" = (
+/obj/machinery/light_switch,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"eyJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/magistrate,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"eEt" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"eQo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/table/reinforced/brass,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"fzr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/starboard)
+"ivq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/filingcabinet/security,
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"iOG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/central)
+"keG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner";
+	dir = 4
+	},
+/area/hallway/primary/central)
+"kls" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"lkB" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Magistrate"
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"lGh" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"ndY" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/magistrateoffice)
+"nGP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralfull"
+	},
+/area/hallway/primary/starboard)
+"ofg" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/magistrateoffice)
+"saH" = (
+/obj/structure/sign/poster/official/state_laws,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
+"svX" = (
+/obj/machinery/firealarm,
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 "udT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"vOI" = (
+/turf/simulated/wall/r_wall,
+/area/magistrateoffice)
 
 (1,1,1) = {"
 aaa
@@ -160321,7 +160418,7 @@ bFs
 bHB
 bva
 bva
-bva
+iOG
 bva
 bSi
 bwn
@@ -160578,7 +160675,7 @@ bEq
 bHC
 bvb
 bvb
-bvb
+keG
 bPc
 bSV
 bSU
@@ -160831,12 +160928,12 @@ btH
 btH
 bsv
 bsv
-bng
+vOI
 bHD
-bng
-bLh
-bLh
-bLh
+ofg
+vOI
+bHD
+ofg
 bQV
 bXC
 bYL
@@ -161088,13 +161185,13 @@ btH
 aaa
 abj
 aaa
-bng
+lGh
 bHE
-bng
+ebH
 bLi
-bNi
+eEt
 bPd
-bLh
+vOI
 bSW
 bVg
 bXc
@@ -161345,15 +161442,15 @@ bzc
 btL
 btL
 aaa
-bng
-bHF
-bng
+kls
+ivq
+lkB
 bLj
 bNj
 bPe
 bQW
 bSX
-bVg
+fzr
 bXd
 bYI
 caw
@@ -161602,12 +161699,12 @@ bwv
 bvc
 btL
 abj
-bng
+svX
 buY
 bxx
 bLk
 bNk
-bPf
+bNk
 bQX
 bSY
 bVg
@@ -161859,15 +161956,15 @@ bwu
 bAI
 btL
 aaa
-bng
+vOI
 bHH
-bng
-bLl
+ndY
+ndY
 bNl
 bPg
 bQY
 bSZ
-bVh
+nGP
 bXe
 bYK
 cay
@@ -162116,9 +162213,9 @@ bzd
 bAJ
 btL
 aaa
-bng
-bHF
-bqC
+vOI
+eyJ
+eEt
 bLm
 bTd
 bPh
@@ -162373,13 +162470,13 @@ bwu
 bAK
 btL
 aaa
-bqC
-bHF
-bqC
-bLn
-bLn
-bLn
-bLn
+saH
+eQo
+eEt
+ekn
+vOI
+vOI
+vOI
 bTb
 bVi
 bXf
@@ -162630,10 +162727,10 @@ bwv
 bvc
 btL
 abj
-bng
+vOI
 bHI
 bJt
-bLn
+bFS
 bNn
 bPi
 bLn
@@ -163673,7 +163770,7 @@ caE
 ccv
 cej
 cfY
-ctt
+chJ
 cjh
 ckQ
 cml


### PR DESCRIPTION
## What Does This PR Do
Añade la oficina del magistrado hecho por Saga al mapa de Delta.

## Why It's Good For The Game
Permite la existencia de una oficina muy importante en el mapa Delta.

## Images of changes
### `Antes no Oficina Magistrado`
![66250358-ae852d80-e70f-11e9-9b2b-76e251e4ac6c](https://user-images.githubusercontent.com/58746682/74694074-f1433000-51ee-11ea-9e2b-b6a97c7759e9.png)

### `Oficina Magistrado`
![imagen](https://user-images.githubusercontent.com/58746682/74746201-55a0d680-5265-11ea-9f96-55d601662801.png)


## Changelog
:cl:
del: Remueve el maint de Detective.
add: Añade la oficina de Magistrado.
del: Quita la antigua Landmark de spawn del Magistrado
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
