### PR TITLE
Add Retro Jumpsuits a Loadout

### DIFF
--- a/code/HISPANIA/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/HISPANIA/modules/client/preference/loadout/loadout_uniform.dm
@@ -1,0 +1,19 @@
+/datum/gear/uniform/medical/retro
+	display_name = "medical retro"
+	path = /obj/item/clothing/under/retro/medical
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Psychiatrist","Paramedic","Coroner")
+
+/datum/gear/uniform/sec/retro
+	display_name = "security retro"
+	path = /obj/item/clothing/under/retro/security
+	allowed_roles = list("Head of Security", "Warden", "Security Officer", "Security Pod Pilot")
+
+/datum/gear/uniform/engi/retro
+	display_name = "engineer retro"
+	path = /obj/item/clothing/under/retro/engineering
+	allowed_roles = list("Chief Engineer","Station Engineer","Life Support Specialist")
+
+/datum/gear/uniform/sci/retro
+	display_name = "scientist retro"
+	path = /obj/item/clothing/under/retro/science
+	allowed_roles = list("Research Director","Scientist")

--- a/paradise.dme
+++ b/paradise.dme
@@ -1212,6 +1212,7 @@
 #include "code\HISPANIA\game\objects\structures\stool_bed_chair_nest\bed.dm"
 #include "code\HISPANIA\modules\assembly\assembly.dm"
 #include "code\HISPANIA\modules\client\preference\loadout\loadout_suit.dm"
+#include "code\HISPANIA\modules\client\preference\loadout\loadout_uniform.dm"
 #include "code\HISPANIA\modules\clothing\glasses\engine_goggles.dm"
 #include "code\HISPANIA\modules\clothing\head\jobs.dm"
 #include "code\HISPANIA\modules\clothing\head\misc.dm"


### PR DESCRIPTION
## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->
Agrega los retro jumpsuits a cada departamento el cual ya posee uno. 

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Actualmente únicamente tienes un diseño bastante llamativo y claro de los diseños de los principales departamentos. Este cambio da la posibilidad a la gente que desagrada de estos diseños y ofrece esta alternativa.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

                                    Cada Distinto Diseño
![image](https://user-images.githubusercontent.com/46639834/74702481-c4cbeb80-51cf-11ea-9e97-f2a11198905e.png)

                                    Casilla en Loadout
![image](https://user-images.githubusercontent.com/46639834/74702688-54719a00-51d0-11ea-8291-f7240a89f96b.png)

![image](https://user-images.githubusercontent.com/46639834/74702724-6fdca500-51d0-11ea-8415-4ebdeeba18d6.png)

## Changelog
:cl:
add: Retro Jumpsuits a loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
