### PR TITLE
Tweak Agrega DF Sound a Lavaland

### DIFF
--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -102,7 +102,7 @@
 	power_equip = FALSE
 	power_light = FALSE
 	requires_power = TRUE
-	ambientsounds = list('sound/ambience/ambilava.ogg')
+	ambientsounds = list('sound/ambience/ambilava.ogg', 'sound/ambience/song_game.ogg')
 
 /area/lavaland/underground
 	name = "Lavaland Caves"


### PR DESCRIPTION
## What Does This PR Do
Agrega la posibilidad de que al salir a las tierras de lavaland puedas escuchar la canción de Dwarf Fortress como ambiente. Es bastante emblemática y ya existe dentro del code del juego sin algún uso. 

## Why It's Good For The Game
Agrega sonidos agradables para el duro y peligroso proceso que es minar en lavaland

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/75064640-efa69000-54ac-11ea-851e-1f3393c1049c.png)


## Changelog
:cl:
tweak: Dwarf Fortress OGG Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
