### PR TITLE
Tweak Unathi x4 daño bruto.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -469,7 +469,6 @@ BLIND     // can't see anything
 	var/shoe_sound = null
 	var/blood_state = BLOOD_STATE_NOT_BLOODY
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0, BLOOD_STATE_XENO = 0, BLOOD_STATE_NOT_BLOODY = 0)
-	species_restricted = list("exclude","Unathi")	//Unathi Stuff
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -469,6 +469,7 @@ BLIND     // can't see anything
 	var/shoe_sound = null
 	var/blood_state = BLOOD_STATE_NOT_BLOODY
 	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0, BLOOD_STATE_XENO = 0, BLOOD_STATE_NOT_BLOODY = 0)
+	species_restricted = list("exclude","Unathi")	//Unathi Stuff
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -36,7 +36,9 @@
 	default_headacc = "Simple"
 	default_headacc_colour = "#404040"
 	butt_sprite = "unathi"
+	stun_mod = 1.05
 	brute_mod = 1.05
+	burn_mod = 0.80
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart/unathi,


### PR DESCRIPTION
## What Does This PR Do
Aumenta el tiempo de stun y la resistencia a la quemadura de los unathis.


## Why It's Good For The Game
Actualmente los unathis únicamente cuentan con un modificador por el frió y merecen tener modificadores que haga la gente los ocupe de forma diferente. 

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/75081833-5a1ff600-54d6-11ea-81c4-efb18fc25473.png)

## Changelog
:cl:
tweak: Unathis mas duración de stun
tweak: Unathis mas defensa contra quemadura
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
