### PR TITLE
Tweak Shuttles requieren combustible [WIP]

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -726,6 +726,9 @@
 	var/admin_controlled
 	var/max_connect_range = 7
 	var/docking_request = 0
+///Solamente pruebas reubico posteriormente
+	var/fuel = 0
+	var/travel_cost = 150
 
 /obj/machinery/computer/shuttle/New(location, obj/item/circuitboard/shuttle/C)
 	..()
@@ -766,6 +769,17 @@
 	connect()
 	add_fingerprint(user)
 	ui_interact(user)
+
+///Solo para prueba, reubico posteriormente
+/obj/machinery/computer/shuttle/attackby(obj/item/I, mob/user, params)
+	var/show_message = 0
+	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
+		qdel(I)
+		fuel = fuel + 50
+		show_message = 1
+		if(show_message)
+			visible_message("[src] converts the plasma into fuel")
+
 
 /obj/machinery/computer/shuttle/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
@@ -809,14 +823,18 @@
 			// Seriously, though, NEVER trust a Topic with something like this. Ever.
 			message_admins("move HREF ([src] attempted to move to: [href_list["move"]]) exploit attempted by [key_name_admin(usr)] on [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 			return
-		switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
-			if(0)
-				atom_say("Shuttle departing! Please stand away from the doors.")
-			if(1)
-				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
-			else
-				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
-		return 1
+		if(fuel == travel_cost)
+			switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
+				if(0)
+					atom_say("Shuttle departing! Please stand away from the doors.")
+					fuel = fuel-150
+				if(1)
+					to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
+				else
+					to_chat(usr, "<span class='notice'>Unable to comply.</span>")
+			return 1
+		to_chat(usr, "<span class='warning'>You dont have enough fuel!.</span>")
+		return 0
 
 /obj/machinery/computer/shuttle/emag_act(mob/user)
 	if(!emagged)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -729,6 +729,7 @@
 ///Solamente pruebas reubico posteriormente
 	var/fuel = 0
 	var/travel_cost = 150
+	var/fuel_limit = 500
 
 /obj/machinery/computer/shuttle/New(location, obj/item/circuitboard/shuttle/C)
 	..()
@@ -772,13 +773,13 @@
 
 ///Solo para prueba, reubico posteriormente
 /obj/machinery/computer/shuttle/attackby(obj/item/I, mob/user, params)
-	var/show_message = 0
 	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
-		qdel(I)
-		fuel = fuel + 50
-		show_message = 1
-		if(show_message)
+		if(fuel < fuel_limit)
+			qdel(I)
+			fuel = fuel + 50
 			visible_message("[src] converts the plasma into fuel")
+		else
+			visible_message("[src] the fuel system its full")
 
 
 /obj/machinery/computer/shuttle/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
@@ -823,7 +824,7 @@
 			// Seriously, though, NEVER trust a Topic with something like this. Ever.
 			message_admins("move HREF ([src] attempted to move to: [href_list["move"]]) exploit attempted by [key_name_admin(usr)] on [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 			return
-		if(fuel == travel_cost)
+		if(fuel >= travel_cost)
 			switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
 				if(0)
 					atom_say("Shuttle departing! Please stand away from the doors.")


### PR DESCRIPTION
## What Does This PR Do
Genera dos variables nuevas para las shuttles, costo de viaje y combustible. Combustible es un valor que se gana metiendo plasma sheets a la consola y costo de viaje es cuantas sheets de plasma requiere para el viaje.

## Why It's Good For The Game
Elimina el combustible infinito que permite los viajes de estas naves.

## Images of changes

                              Intentando viaje sin combustible
![image](https://user-images.githubusercontent.com/46639834/75102159-d5ec7200-55ac-11ea-9e68-378f16bade53.png)

                              Variable nueva a todos los objetos tipo shuttle
![image](https://user-images.githubusercontent.com/46639834/75102182-09c79780-55ad-11ea-95c9-590de42c9d15.png)

                              Costo Default Actual por viaje es 150
![image](https://user-images.githubusercontent.com/46639834/75102185-151ac300-55ad-11ea-8112-a7593aaf5db9.png)

                            Al llegar hace una resta de 150 al total de fuel
![image](https://user-images.githubusercontent.com/46639834/75102190-1f3cc180-55ad-11ea-8461-e6f2f00425c0.png)

                          Limite de Combustible base es 500
![image](https://user-images.githubusercontent.com/46639834/75116247-f6a7dc80-562b-11ea-991b-20314d1632ab.png)

## Changelog
:cl:
tweak: Shuttles requieren combustible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
