### PR TITLE
Add Plasteel Chemical Barrel [WIP]

### DIFF
--- a/code/HISPANIA/game/objects/structures/chemical_barrel.dm
+++ b/code/HISPANIA/game/objects/structures/chemical_barrel.dm
@@ -1,0 +1,29 @@
+/obj/structure/chemical_barrel
+	name = "chemical barrel"
+	desc = "A large plasteel barrel. You can store huge ammounts of chemicals inside."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "barrel"
+	density = TRUE
+	anchored = FALSE
+	container_type = DRAINABLE | AMOUNT_VISIBLE
+	pressure_resistance = 2 * ONE_ATMOSPHERE
+	max_integrity = 300
+	var/open = FALSE
+
+/obj/structure/chemical_barrel/Initialize()
+	create_reagents(600) //Son enormes pero no puedes insertarlos en un chem dispenser
+	. = ..()
+
+/obj/structure/chemical_barrel/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It is currently [open ? "open, letting you pour liquids in." : "closed, letting you draw liquids from the tap."] </span>"
+
+/obj/structure/chemical_barrel/attack_hand(mob/user)
+	open = !open
+	if(open)
+		container_type = REFILLABLE | AMOUNT_VISIBLE
+		to_chat(user, "<span class='notice'>You open [src], letting you fill it.</span>")
+	else
+		container_type = DRAINABLE | AMOUNT_VISIBLE
+		to_chat(user, "<span class='notice'>You close [src], letting you draw from its tap.</span>")
+	update_icon()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1200,6 +1200,7 @@
 #include "code\HISPANIA\game\objects\items\weapons\storage\bags.dm"
 #include "code\HISPANIA\game\objects\items\weapons\storage\fancy.dm"
 #include "code\HISPANIA\game\objects\items\weapons\tanks\tank_types.dm"
+#include "code\HISPANIA\game\objects\structures\chemical_barrel.dm"
 #include "code\HISPANIA\game\objects\structures\femur_breaker.dm"
 #include "code\HISPANIA\game\objects\structures\spawner.dm"
 #include "code\HISPANIA\game\objects\structures\crates_lockers\hydroponics.dm"


### PR DESCRIPTION
## What Does This PR Do
Agrega un barril para almacenar químicos en grandes cantidades.

## Why It's Good For The Game
Agrega la posibilidad a los botánicos de tener su propio barril de químico a cargar por los lados con mutageno, medbay puede preparar de forma mas ordenada dosis de medicinas a partir de reagents específicos que se requieren en grandes cantidades para medicamentos diversos. En un futuro se puede ocupar para configurar como bounty a puntos para dar a cargo. 

Por el momento necesito un Sprite, poder tomar reagents de el con algo diferente a un vaso, agregarlo a la lista de craft para plasteel

Actualmente puede almacenar cualquier químico que se le inserte y tomarlo con un vaso.

## Images of changes
//////////En cuanto tenga un sprite puedo poner imagenes///////////

## Changelog
:cl:
add: Chemical Barrel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
