### PR TITLE
Balance Ghetto Surgery

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -34,7 +34,7 @@
 
 	allowed_tools = list(
 	/obj/item/bonegel = 100,	\
-	/obj/item/screwdriver = 90
+	/obj/item/screwdriver = 70
 	)
 	can_infect = 1
 	blood_level = 1
@@ -70,7 +70,7 @@
 
 	allowed_tools = list(
 	/obj/item/bonesetter = 100,	\
-	/obj/item/wrench = 90	\
+	/obj/item/wrench = 70	\
 	)
 
 	time = 32
@@ -109,7 +109,7 @@
 
 	allowed_tools = list(
 	/obj/item/bonesetter = 100,	\
-	/obj/item/wrench = 90		\
+	/obj/item/wrench = 70		\
 	)
 
 	time = 32
@@ -144,7 +144,7 @@
 
 	allowed_tools = list(
 	/obj/item/bonegel = 100,	\
-	/obj/item/screwdriver = 90
+	/obj/item/screwdriver = 70
 	)
 	can_infect = 1
 	blood_level = 1

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -22,7 +22,7 @@
 
 	allowed_tools = list(
 	/obj/item/scalpel = 100,		\
-	/obj/item/kitchen/knife = 90,	\
+	/obj/item/kitchen/knife = 70,	\
 	/obj/item/shard = 60, 		\
 	/obj/item/scissors = 12,		\
 	/obj/item/twohanded/chainsaw = 1, \
@@ -60,7 +60,7 @@
 	allowed_tools = list(
 	/obj/item/scalpel/laser = 100, \
 	/obj/item/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/stack/cable_coil = 70, 	\
 	/obj/item/assembly/mousetrap = 25
 	)
 
@@ -94,7 +94,7 @@
 	allowed_tools = list(
 	/obj/item/scalpel/laser/manager = 100, \
 	/obj/item/retractor = 100, 	\
-	/obj/item/crowbar = 90,	\
+	/obj/item/crowbar = 70,	\
 	/obj/item/kitchen/utensil/fork = 60
 	)
 
@@ -199,7 +199,7 @@
 	allowed_tools = list(
 	/obj/item/circular_saw = 100, \
 	/obj/item/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/hatchet = 90, \
+	/obj/item/hatchet = 70, \
 	/obj/item/melee/arm_blade = 75
 	)
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -171,7 +171,7 @@
 	name = "connect limb"
 	allowed_tools = list(
 	/obj/item/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/stack/cable_coil = 70, 	\
 	/obj/item/assembly/mousetrap = 25
 	)
 	can_infect = 1

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -80,7 +80,7 @@
 								/obj/item/reagent_containers/glass/bucket = 50)
 
 	//Finish is just so you can close up after you do other things.
-	var/implements_finsh = list(/obj/item/scalpel/laser/manager = 100,/obj/item/retractor = 100 ,/obj/item/crowbar = 90)
+	var/implements_finsh = list(/obj/item/scalpel/laser/manager = 100,/obj/item/retractor = 100 ,/obj/item/crowbar = 70)
 	var/current_type
 	var/obj/item/organ/internal/I = null
 	var/obj/item/organ/external/affected = null
@@ -457,7 +457,7 @@
 	allowed_tools = list(
 	/obj/item/circular_saw = 100, \
 	/obj/item/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/hatchet = 90
+	/obj/item/hatchet = 70
 	)
 
 	time = 54
@@ -485,7 +485,7 @@
 	name = "cut carapace"
 	allowed_tools = list(
 	/obj/item/scalpel = 100,		\
-	/obj/item/kitchen/knife = 90,	\
+	/obj/item/kitchen/knife = 70,	\
 	/obj/item/shard = 60, 		\
 	/obj/item/scissors = 12,		\
 	/obj/item/twohanded/chainsaw = 1, \
@@ -520,7 +520,7 @@
 	allowed_tools = list(
 	/obj/item/scalpel/laser/manager = 100, \
 	/obj/item/retractor = 100, 	\
-	/obj/item/crowbar = 90,	\
+	/obj/item/crowbar = 70,	\
 	/obj/item/kitchen/utensil/fork = 60
 	)
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -62,7 +62,7 @@
 	name = "mend internal bleeding"
 	allowed_tools = list(
 	/obj/item/FixOVein = 100, \
-	/obj/item/stack/cable_coil = 90
+	/obj/item/stack/cable_coil = 70
 	)
 	can_infect = 1
 	blood_level = 1
@@ -107,7 +107,7 @@
 	name = "remove dead tissue"
 	allowed_tools = list(
 		/obj/item/scalpel = 100,		\
-		/obj/item/kitchen/knife = 90,	\
+		/obj/item/kitchen/knife = 70,	\
 		/obj/item/shard = 60, 		\
 	)
 


### PR DESCRIPTION
## What Does This PR Do
Baja los porcentajes de las herramientas ghetto de 90 a 70 en las operaciones.

## Why It's Good For The Game
Con el sistema de reglas actual todo el personal tiene acceso a ghetto surgery debido a ser conocimiento universal, sin embargo revisando las estadísticas de probabilidad. Únicamente tienes un 10% de probabilidad de fallar una operación si no tienes las herramientas necesarias. Me parece bastante desbalanceado que un cuchillo de cocina o una palanca puedan hacer lo mismo que instrumentaría de cirugía cara impresa de forma especializada. 

## Images of changes

                                  No se que mas poner aqui.
![image](https://user-images.githubusercontent.com/46639834/75296157-0b35d180-57f2-11ea-9cb1-b7220eac0942.png)

                                Probabilidades al operarlo sobre una mesa (Consulta)
![image](https://user-images.githubusercontent.com/46639834/75296417-bcd50280-57f2-11ea-956a-dae443d561a4.png)


## Changelog
:cl:
balance: Ghetto Surgery 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
