### PR TITLE
Tweak Botanical belt y matamoscas

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -207,6 +207,7 @@
 		/obj/item/wrench,
 		/obj/item/reagent_containers/spray/pestspray,
 		/obj/item/reagent_containers/spray/plantbgone,
+		/obj/item/melee/flyswatter,
 	)
 
 /obj/item/storage/belt/security


### PR DESCRIPTION
## What Does This PR Do
Agrega el matamoscas a la lista de objetos que puede guardar el botanical belt. Es una herramienta de trabajo para ellos en especial para el beekeper. 

## Why It's Good For The Game
Una herramienta de trabajo para el botánico tiene sentido se pueda guardar en su tipo de cinturón especifico. 

## Images of changes


## Changelog
:cl:
tweak: Botanical belt carga matamoscas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
