### PR TITLE
Tweak Sentarse en Stool

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -300,6 +300,7 @@
 	name = "bar stool"
 	desc = "It has some unsavory stains on it..."
 	icon_state = "bar"
+	can_buckle = TRUE
 	item_chair = /obj/item/chair/stool/bar
 
 /obj/item/chair
@@ -308,10 +309,10 @@
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "chair_toppled"
 	item_state = "chair"
-	can_buckle = TRUE
 	lefthand_file = 'icons/mob/inhands/chairs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/chairs_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
+	can_buckle = FALSE
 	force = 8
 	throwforce = 10
 	throw_range = 3

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -293,7 +293,7 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = FALSE
+	can_buckle = TRUE
 	item_chair = /obj/item/chair/stool
 
 /obj/structure/chair/stool/bar
@@ -308,6 +308,7 @@
 	icon = 'icons/obj/chairs.dmi'
 	icon_state = "chair_toppled"
 	item_state = "chair"
+	can_buckle = TRUE
 	lefthand_file = 'icons/mob/inhands/chairs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/chairs_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -293,14 +293,13 @@
 	name = "stool"
 	desc = "Apply butt."
 	icon_state = "stool"
-	can_buckle = TRUE
+	//can_buckle = TRUE
 	item_chair = /obj/item/chair/stool
 
 /obj/structure/chair/stool/bar
 	name = "bar stool"
 	desc = "It has some unsavory stains on it..."
 	icon_state = "bar"
-	can_buckle = TRUE
 	item_chair = /obj/item/chair/stool/bar
 
 /obj/item/chair
@@ -312,7 +311,6 @@
 	lefthand_file = 'icons/mob/inhands/chairs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/chairs_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
-	can_buckle = FALSE
 	force = 8
 	throwforce = 10
 	throw_range = 3


### PR DESCRIPTION
## What Does This PR Do
Vuelve a los Stool, entidades donde uno puede tomar asiento al ser objeto tipo silla.

## Why It's Good For The Game
Los asientos actualmente no funcionan como sillas a pesar de ser sillas y muchas veces la gente se empuja entre ellas en la barra por no poder hacer buckle. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/75593830-3582cb80-5a4c-11ea-919a-7e8acd36c59c.png)


## Changelog
:cl:
tweak: Stool can buckle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
