### PR TITLE
Tweak Emag Limite de Usos

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -67,6 +67,7 @@
 	name = "cryptographic sequencer"
 	icon_state = "emag"
 	item_state = "card-id"
+	var/uses = 20 //Numero de usos posibles
 	origin_tech = "magnets=2;syndicate=2"
 	flags = NOBLUDGEON
 	flags_2 = NO_MAT_REDEMPTION_2
@@ -78,7 +79,14 @@
 	var/atom/A = target
 	if(!proximity)
 		return
-	A.emag_act(user)
+	if(uses > 0)
+		--uses
+		A.emag_act(user)
+		if(uses == 1) //Si es nuestro ultimo uso avisa al usuario que deja de funcionar
+			to_chat(user, "<span class='userdanger'>[src] sparks and seems to stop working. </span>")
+	else
+		to_chat(user, "<span class='userdanger'>[src] its not working anymore. </span>")
+		return
 
 /obj/item/card/id
 	name = "identification card"


### PR DESCRIPTION
## What Does This PR Do
Añade un limite de usos a los EMAG 

## Why It's Good For The Game
Muchos traidores ocupan los emag como herramientas para únicamente malograr la estación sin ninguna clase de relación a sus objetivos, esto hace que valoren mas el numero limite de usos que tienen para este aparato. 

## Images of changes

                                               Pirata local no se logra curar.
![image](https://user-images.githubusercontent.com/46639834/75618801-d3ec5b00-5b38-11ea-9063-6edd57c27371.png)


## Changelog
:cl:
tweak: Limite de usos E-Mag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
