### PR TITLE
Add Vests a Clothing Crafting

### DIFF
--- a/code/HISPANIA/modules/crafting/tailoring.dm
+++ b/code/HISPANIA/modules/crafting/tailoring.dm
@@ -1,0 +1,15 @@
+/datum/crafting_recipe/black_vest_3
+	name = "Black Vest"
+	result = /obj/item/clothing/accessory/storage/black_vest
+	reqs = list(/obj/item/stack/sheet/cloth = 4,
+				/obj/item/stack/sheet/leather = 2)
+	time = 50
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/brown_vest_3
+	name = "Brown Vest"
+	result = /obj/item/clothing/accessory/storage/brown_vest
+	reqs = list(/obj/item/stack/sheet/cloth = 4,
+				/obj/item/stack/sheet/leather = 2)
+	time = 50
+	category = CAT_CLOTHING

--- a/code/HISPANIA/modules/crafting/tailoring.dm
+++ b/code/HISPANIA/modules/crafting/tailoring.dm
@@ -5,11 +5,3 @@
 				/obj/item/stack/sheet/leather = 2)
 	time = 50
 	category = CAT_CLOTHING
-
-/datum/crafting_recipe/brown_vest_3
-	name = "Brown Vest"
-	result = /obj/item/clothing/accessory/storage/brown_vest
-	reqs = list(/obj/item/stack/sheet/cloth = 4,
-				/obj/item/stack/sheet/leather = 2)
-	time = 50
-	category = CAT_CLOTHING

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -95,7 +95,7 @@
 	desc = "Worn brownish synthcotton vest with lots of pockets to unload your hands."
 	icon_state = "vest_brown"
 	item_color = "vest_brown"
-	slots = 3
+	slots = 5
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -88,14 +88,14 @@
 	desc = "Robust black synthcotton vest with lots of pockets to hold whatever you need, but cannot hold in hands."
 	icon_state = "vest_black"
 	item_color = "vest_black"
-	slots = 5
+	slots = 3
 
 /obj/item/clothing/accessory/storage/brown_vest
 	name = "brown webbing vest"
 	desc = "Worn brownish synthcotton vest with lots of pockets to unload your hands."
 	icon_state = "vest_brown"
 	item_color = "vest_brown"
-	slots = 5
+	slots = 3
 
 /obj/item/clothing/accessory/storage/knifeharness
 	name = "decorated harness"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1226,6 +1226,7 @@
 #include "code\HISPANIA\modules\clothing\suits\reactive_armour.dm"
 #include "code\HISPANIA\modules\clothing\under\jobs\civilian.dm"
 #include "code\HISPANIA\modules\crafting\recipes.dm"
+#include "code\HISPANIA\modules\crafting\tailoring.dm"
 #include "code\HISPANIA\modules\events\oldman.dm"
 #include "code\HISPANIA\modules\events\temperature_change.dm"
 #include "code\HISPANIA\modules\food_and_drinks\drinks\drinks\bottle.dm"


### PR DESCRIPTION
## What Does This PR Do
Añade dos objetos en el code que no se pueden obtener actualmente a la sección de clothing crafting y disminuye su valor total a 3 objetos que pueda almacenar. 

## Why It's Good For The Game
Hace usos de objetos ya existentes en paradise que no se pueden obtener a pesar de su existencia y balancea su cantidad de slots para evitar que sean un toolbelt portable. 

## Images of changes

                                                   Crafting menu and Slots
![image](https://user-images.githubusercontent.com/46639834/75741993-e5b53600-5cd1-11ea-9b2c-e845c79dbdca.png)


## Changelog
:cl:
add: Vests a Clothing Crafting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
