### PR TITLE
Bug fix de la abeja reina en el closet.

### DIFF
--- a/code/HISPANIA/game/objects/structures/crates_lockers/hydroponics.dm
+++ b/code/HISPANIA/game/objects/structures/crates_lockers/hydroponics.dm
@@ -25,4 +25,4 @@
 	new /obj/item/honey_frame(src)
 	new /obj/item/honey_frame(src)
 	new /obj/item/honey_frame(src)
-	new /obj/item/queen_bee(src)
+	new /obj/item/queen_bee/bought(src)

--- a/code/HISPANIA/game/objects/structures/crates_lockers/hydroponics.dm
+++ b/code/HISPANIA/game/objects/structures/crates_lockers/hydroponics.dm
@@ -25,4 +25,4 @@
 	new /obj/item/honey_frame(src)
 	new /obj/item/honey_frame(src)
 	new /obj/item/honey_frame(src)
-	new /obj/item/queen_bee/bought(src)
+	new /obj/item/queen_bee(src)

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-secret
+extended

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+secret


### PR DESCRIPTION
## What Does This PR Do
Arregla un bug que había con la abeja reina en el closet, no permitía ponerlo en el Apiary.

## Why It's Good For The Game
Ahora nuestros beekeepers no tienen que sufrir por el hecho de que no puedan poner la abeja reina en su sitio :'^)

:cl: Nothing
fix: Abeja reina en el closet que no podía ser añadido al Apiary.
/:cl:
