### PR TITLE
Fix Runtime Error Survival Pod Ruin

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -218,7 +218,7 @@
 		/obj/item/kitchen/knife/combat/survival=1,
 		/obj/item/mining_voucher=1,
 		/obj/item/t_scanner/adv_mining_scanner/lesser=1,
-///	/obj/item/gun/energy/kinetic_accelerator=1,\
+///	/obj/item/gun/energy/kinetic_accelerator=1,\  //Genera Runtime Error al dar un KA a un muerto en Ruina.
 		/obj/item/stack/marker_beacon/ten=1
 	)
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -218,7 +218,7 @@
 		/obj/item/kitchen/knife/combat/survival=1,
 		/obj/item/mining_voucher=1,
 		/obj/item/t_scanner/adv_mining_scanner/lesser=1,
-		/obj/item/gun/energy/kinetic_accelerator=1,\
+///	/obj/item/gun/energy/kinetic_accelerator=1,\
 		/obj/item/stack/marker_beacon/ten=1
 	)
 


### PR DESCRIPTION
## What Does This PR Do
Repara un Runtime Error que genera un equipamiento pre diseñado que equipa a un muerto causado por un error en el proceso de los KA.

## Why It's Good For The Game
Elimina el KA gratis de la ruina a partir de que se elimina del equipamiento pre diseñado de esta, pero sigue la recompensa de recibir una ID para minería y el mining voucher. A su vez elimina un runtime error que se genera al iniciar el servidor.

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/76129507-1c8a9500-5fcd-11ea-9bd6-0b076143dcff.png)


## Changelog
:cl:
fix: SurvivalPod Ruin Runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
