### PR TITLE
Adios elegantes guantes amarillos para el HoS 

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -96,7 +96,6 @@
 		new /obj/item/storage/backpack/satchel_sec(src)
 	new	/obj/item/radio/headset/heads/hos/alt(src)
 	new /obj/item/cartridge/hos(src)
-	new /obj/item/clothing/gloves/color/yellow(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/storage/lockbox/mindshield(src)
 	new /obj/item/storage/box/flashbangs(src)


### PR DESCRIPTION
## What Does This PR Do
Quita los guantes amarillos que había en el locker del HoS

## Why It's Good For The Game
No había ningún motivo por la que esos elegantes guantes amarillos pudieran estar en el locker del HoS.

## Changelog
:cl: Nothing
del: Guantes amarillos en el locker del HoS.
/:cl:
