### PR TITLE
Piel negra de pura raza.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -198,6 +198,7 @@
 #define isdiona(A) (is_species(A, /datum/species/diona))
 #define ismachine(A) (is_species(A, /datum/species/machine))
 #define isdrask(A) (is_species(A, /datum/species/drask))
+#define isashwalker(A) (is_species(A, /datum/species/unathi/ashwalker))
 
 #define isanimal(A)		(istype((A), /mob/living/simple_animal))
 #define isdog(A)		(istype((A), /mob/living/simple_animal/pet/dog))

--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -80,6 +80,8 @@
 			return TRUE
 		if(isspacepod(L))
 			return TRUE
+		if(isashwalker(L))
+			return TRUE
 		if(ishuman(L)) //Are you immune?
 			var/mob/living/carbon/human/H = L
 			var/thermal_protection = H.get_thermal_protection()

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -117,7 +117,5 @@
 	default_language = "Sinta'unathi"
 
 	speed_mod = -0.80
-	burn_mod = 0
-	brute_mod = 1.1
-	tox_mod = 2
+	burn_mod = 0.9
 	species_traits = list(NO_BREATHE, NOGUNS)

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -117,4 +117,7 @@
 	default_language = "Sinta'unathi"
 
 	speed_mod = -0.80
+	burn_mod = 0
+	brute_mod = 1.1
+	tox_mod = 2
 	species_traits = list(NO_BREATHE, NOGUNS)


### PR DESCRIPTION
## What Does This PR Do
Este PR hace que los ash walkers sean imnunes al daño de quemaduras causadas por las tormentas de cenizas y que sean algo mas resistente a las daño de quemaduras en general.

## Why It's Good For The Game
Los mineros tienen muchas oportunidades para escapar de una tormenta de cenizas por su alta tecnologia, más, los ash walkers no poseen dicha tecnologia para poder escapar rapido o crearse un refugio, muriendo muchas veces por estar lejos de la base, además son seres cazadores de lavaland nacidos de los tendrils como las demas criaturas, siendo asi poco logico que no resistan las tormentas.

## Images of changes
### `Chad Ash walker resistiendo una tormenta.`
![imagen](https://user-images.githubusercontent.com/58746682/76274601-68656480-6281-11ea-87a8-049ada78fdc6.png)
### `Virgen Ash walker muriendo en lava.`
![imagen](https://user-images.githubusercontent.com/58746682/76274684-9b0f5d00-6281-11ea-9a7b-5c3df86263bc.png)

## Changelog
:cl:
tweak: Añade  a los ash walkers resistencia a las tormentas de cenizas y algo mas de resistencia a daños de quemaduras.
/:cl: