### PR TITLE
Tweak Free Golem ID (SpacePods)

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -820,7 +820,7 @@
 	name = "Free Golem ID"
 	desc = "A card used to claim mining points and buy gear. Use it to mark it as yours."
 	icon_state = "research"
-	access = list(access_free_golems, access_robotics, access_clown, access_mime) //access to robots/mechs
+	access = list(access_free_golems, access_robotics, access_clown, access_mime, access_mechanic) //access to robots/mechs and spacepods
 	var/registered = FALSE
 
 /obj/item/card/id/golem/attack_self(mob/user as mob)


### PR DESCRIPTION
## What Does This PR Do
Añade acceso a mecánica para que los golems puedan crear SpacePods y viajar por el espacio.

## Why It's Good For The Game
Actualmente los golems pueden realizar casi todas las tareas en su proceso de expansión por la galaxia pero los viajes espaciales son uno de los puntos que aun les falta, con esto fomenta la expansión de los golems. 

¡Gloria al liberador!

## Images of changes

                                            Haha funny meme
![image](https://user-images.githubusercontent.com/46639834/76365687-89fc3580-62ed-11ea-8832-9ee7c9610d0d.png)


## Changelog
:cl:
tweak: SpacePods para Free Golems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
