### PR TITLE
Fix Pipe Loop Kitchen

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -29345,11 +29345,6 @@
 	pixel_x = 0;
 	tag = ""
 	},
-/obj/structure/disposalpipe/junction{
-	tag = "icon-pipe-j1 (EAST)";
-	icon_state = "pipe-j1";
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -29363,6 +29358,13 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	icon_state = "pipe-j1s";
+	name = "Kitchen";
+	sortType = 20;
+	tag = "icon-pipe-j1s (EAST)"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)


### PR DESCRIPTION
## What Does This PR Do
Repara un error de mapeo dentro del sistema de disposals que causa entrar a un loop constante al intentar enviar algo a la cocina.

## Why It's Good For The Game
Repara un bug causado por un error de mapeo que deja la cocina sin posibilidad para recibir cajas.

## Images of changes

                                     Pipe que se elimino pero no se agrego

![image](https://user-images.githubusercontent.com/46639834/76456784-33e6cb00-639d-11ea-83b4-2a28043c4a72.png)


## Changelog
:cl:
fix: Loop System Kitchen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
