### PR TITLE
[Map Change] Kitchen and Bar (Cyberiad)

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -19684,29 +19684,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"aHV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/area/hydroponics)
 "aHW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20751,30 +20728,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/fore)
-"aKp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/mob/living/simple_animal/pig,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "asteroid";
-	tag = "icon-asteroid (NORTH)"
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding1 (NORTH)";
-	icon_state = "siding1";
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	tag = "icon-siding2 (NORTH)";
-	icon_state = "siding2";
-	dir = 1
-	},
-/area/hydroponics)
 "aKq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20835,10 +20788,14 @@
 	},
 /area/lawoffice)
 "aKx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Hydroponics Pasture";
+	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -22091,9 +22048,6 @@
 "aNe" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/hispaniabox{
-	anchored = 1
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -24482,15 +24436,13 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "aRM" = (
@@ -24509,8 +24461,10 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze{
+	pixel_x = -1;
+	pixel_y = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -29696,13 +29650,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bbW" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	icon_state = "pipe-j2s";
-	name = "Chapel";
-	sortType = 17
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/firstaid/aquatic_kit/full,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
 /area/crew_quarters/kitchen)
 "bbX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -31165,12 +31124,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/toilet)
-"beF" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/bar)
 "beG" = (
 /obj/machinery/light,
 /turf/simulated/shuttle/floor,
@@ -31538,17 +31491,29 @@
 	pixel_y = 30
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/beer,
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/phone{
+	attack_verb = list("bounced a check off","checked-out","tipped");
+	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
+	icon = 'icons/obj/machines/pos.dmi';
+	icon_state = "pos";
+	name = "point of sale"
+	},
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/reagent_containers/food/drinks/flask/barflask,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
 "bfl" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/hispaniabox{
+	anchored = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -31841,6 +31806,13 @@
 /area/maintenance/fsmaint2)
 "bfH" = (
 /obj/machinery/hydroponics/soil,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bfI" = (
@@ -31861,6 +31833,11 @@
 	pixel_y = 25
 	},
 /obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/camera{
+	c_tag = "Hydroponics Pasture";
+	network = list("SS13")
+	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bfK" = (
@@ -33035,6 +33012,18 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/door/window/eastright{
+	tag = "icon-right";
+	name = "Hydroponics Delivery";
+	icon_state = "right";
+	dir = 2;
+	req_access_txt = "35"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -33692,19 +33681,16 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bjd" = (
-/obj/structure/sink{
-	icon_state = "sink";
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster{
+	pixel_x = -30
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "bje" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/bananium{
@@ -33854,8 +33840,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bjv" = (
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/kitchen_machine/candy_maker,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "bjw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33866,6 +33857,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bjx" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /mob/living/simple_animal/cow{
 	name = "Betsy"
 	},
@@ -33873,6 +33867,18 @@
 /area/hydroponics)
 "bjy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/mob/living/simple_animal/pig,
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "bjz" = (
@@ -33950,11 +33956,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
-/obj/structure/table/wood,
-/obj/item/ashtray/bronze{
-	pixel_x = -1;
-	pixel_y = 1
-	},
+/obj/machinery/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "bjL" = (
@@ -34526,12 +34528,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"bkM" = (
-/obj/machinery/slot_machine,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "bkN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34648,6 +34644,13 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light_switch{
 	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/mob/living/simple_animal/chicken{
+	name = "Commander Clucky"
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -34850,10 +34853,7 @@
 	},
 /area/hallway/secondary/entry)
 "blt" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/slot_machine,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "blu" = (
@@ -35250,10 +35250,6 @@
 	},
 /area/chapel/main)
 "bmh" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 0;
 	pixel_y = 25
@@ -35369,9 +35365,6 @@
 "bmt" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -35838,10 +35831,11 @@
 	c_tag = "Bar East";
 	network = list("SS13")
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/chair/stool/bar,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
 	},
-/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bnm" = (
@@ -36223,29 +36217,10 @@
 /obj/item/assembly/signaler,
 /turf/simulated/floor/plasteel,
 /area/bridge)
-"boi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	tag = ""
-	},
+"boj" = (
 /obj/effect/landmark/start{
 	name = "Chef"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"boj" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
 	dir = 2
@@ -36274,45 +36249,23 @@
 	},
 /area/hallway/secondary/exit)
 "bom" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	base_state = "left";
+	dir = 4;
+	icon_state = "left";
+	name = "Bar Door";
+	req_access_txt = "25"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
-"bon" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	network = list("SS13")
-	},
-/obj/item/radio/intercom{
-	broadcasting = 0;
-	name = "station intercom (General)";
-	pixel_y = 25
-	},
-/obj/machinery/kitchen_machine/candy_maker,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"boo" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "bop" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start{
@@ -36320,6 +36273,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -36363,6 +36319,14 @@
 	pixel_y = 0
 	},
 /obj/machinery/kitchen_machine/oven,
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -36487,24 +36451,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
-"boH" = (
-/obj/machinery/door/window{
-	base_state = "left";
-	dir = 4;
-	icon_state = "left";
-	name = "Bar Door";
-	req_access_txt = "25"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/crew_quarters/bar)
 "boI" = (
 /obj/machinery/door/airlock/external{
 	aiControlDisabled = 0;
@@ -36544,6 +36490,10 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "boN" = (
@@ -36615,18 +36565,14 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/mrchangs)
 "boV" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
+/obj/machinery/fishtank/wall,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "boW" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
@@ -36635,12 +36581,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"boX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
 "boY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -37034,14 +36974,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"bpG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
-	},
-/area/hydroponics)
 "bpI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -37071,14 +37003,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/main)
-"bpL" = (
-/obj/structure/foodcart,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "bpM" = (
 /obj/effect/landmark/start{
 	name = "Chaplain"
@@ -37285,7 +37209,10 @@
 /area/crew_quarters/locker)
 "bqi" = (
 /obj/structure/table/wood,
-/obj/item/kitchen/utensil/fork,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bqj" = (
@@ -37458,10 +37385,6 @@
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
 "bqB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -37470,6 +37393,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -37504,18 +37431,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/storage/tools)
-"bqH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Pasture";
-	req_access_txt = "28"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "bqI" = (
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -37715,19 +37630,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"brg" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (WEST)";
-	icon_state = "wooden_chair_wings";
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "brh" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/taperecorder{
 	pixel_y = 0
@@ -37779,15 +37682,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"brm" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "brn" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -37951,7 +37845,15 @@
 /area/library)
 "brH" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/cakehat,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/candle,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "brI" = (
@@ -38036,10 +37938,6 @@
 	icon_state = "green"
 	},
 /area/bridge)
-"brT" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "brU" = (
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -38475,6 +38373,9 @@
 	layer = 5
 	},
 /obj/item/stack/packageWrap,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
 	dir = 2
@@ -38488,15 +38389,6 @@
 	tag = ""
 	},
 /obj/structure/table,
-/obj/item/book/manual/sop_service,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"bsU" = (
-/obj/structure/table,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3;
 	pixel_y = 0
@@ -38505,22 +38397,9 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
+	dir = 2;
 	icon_state = "cafeteria";
-	dir = 2
-	},
-/area/crew_quarters/kitchen)
-"bsV" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
 "bsW" = (
@@ -38609,27 +38488,9 @@
 "bte" = (
 /turf/simulated/wall,
 /area/hallway/primary/starboard/east)
-"btf" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "btg" = (
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2;
-	pixel_y = 6
-	},
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 4
-	},
+/obj/item/deck/cards,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bth" = (
@@ -38658,22 +38519,16 @@
 /turf/simulated/floor/wood,
 /area/library)
 "btm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "btn" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
 /obj/item/dice,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bto" = (
 /obj/structure/table/wood,
-/obj/item/deck/cards,
 /obj/item/storage/bag/uno,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -38758,24 +38613,10 @@
 	icon_state = "swall_f9"
 	},
 /area/shuttle/transport)
-"btw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair/wood/wings,
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "btx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/wood/wings,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bty" = (
@@ -38875,6 +38716,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -38890,6 +38733,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -38909,20 +38756,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"btP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "btQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39149,16 +38982,13 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "buq" = (
-/obj/structure/chair/wood/wings{
-	tag = "icon-wooden_chair_wings (EAST)";
-	icon_state = "wooden_chair_wings";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/wood,
+/obj/item/clothing/head/cakehat,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bur" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -39181,21 +39011,10 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
 	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
-"buu" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/cream,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
 	},
 /area/crew_quarters/kitchen)
 "buv" = (
@@ -39391,7 +39210,6 @@
 /area/crew_quarters/mrchangs)
 "buN" = (
 /obj/structure/table/wood,
-/obj/item/candle,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "buO" = (
@@ -39418,11 +39236,13 @@
 	},
 /area/hydroponics)
 "buQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/chair/wood/wings{
 	tag = "icon-wooden_chair_wings (NORTH)";
 	icon_state = "wooden_chair_wings";
 	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -39853,15 +39673,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
-"bvM" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
-	},
-/area/crew_quarters/kitchen)
 "bvN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -40827,11 +40638,10 @@
 	},
 /area/bridge)
 "bxE" = (
-/obj/machinery/atm{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants,
+/obj/machinery/disposal,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bxF" = (
@@ -41749,6 +41559,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar)
 "bzf" = (
+/obj/structure/chair/stool/bar,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitecorner"
@@ -41819,13 +41630,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hallway/secondary/exit)
-"bzn" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/crew_quarters/bar)
 "bzo" = (
 /obj/machinery/light,
 /obj/structure/chair/wood/wings{
@@ -42519,6 +42323,9 @@
 "bAH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Civilian"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -50012,6 +49819,13 @@
 	pixel_x = 10;
 	pixel_y = 21;
 	req_access_txt = "57"
+	},
+/obj/machinery/door_control{
+	id = "hopflash";
+	name = "HoP Flash Line";
+	pixel_x = -10;
+	pixel_y = 20;
+	req_one_access_txt = "57"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -91620,19 +91434,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
-"dih" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Hydroponics"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "bot";
-	dir = 1
-	},
-/area/maintenance/fsmaint2)
 "dii" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4;
@@ -92192,28 +91993,20 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/soda,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
 "djj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
-/obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/machinery/status_display{
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/item/clothing/head/that{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/structure/piano,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "djk" = (
 /obj/structure/cable{
@@ -92281,51 +92074,68 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "djt" = (
-/obj/machinery/door/window/eastright{
-	tag = "icon-right";
-	name = "Hydroponics Delivery";
-	icon_state = "right";
-	dir = 2;
-	req_access_txt = "35"
+/obj/item/radio/intercom{
+	broadcasting = 0;
+	name = "station intercom (General)";
+	pixel_y = 25
 	},
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal,
 /turf/simulated/floor/plasteel{
-	icon_state = "hydrofloor"
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "dju" = (
-/obj/machinery/hydroponics/soil,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "djv" = (
 /obj/item/multitool,
 /turf/simulated/floor/plating/airless,
 /area/engine/engineering)
 "djw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Pasture";
-	network = list("SS13")
-	},
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"djx" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/firealarm{
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/simulated/floor/plasteel{
 	dir = 2;
-	pixel_y = 24
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
+"djx" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/fish_eggs/catfish,
+/obj/item/fish_eggs/salmon,
+/obj/item/fish_eggs/salmon,
+/obj/item/fish_eggs/shark,
+/obj/item/fish_eggs/shark,
+/obj/item/fish_eggs/shrimp,
+/obj/item/fish_eggs/shrimp,
+/obj/item/fish_eggs/catfish,
+/obj/item/fish_eggs/electric_eel,
+/obj/item/fish_eggs/electric_eel,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "djy" = (
 /obj/structure/lattice,
 /obj/item/wirecutters,
@@ -93039,20 +92849,12 @@
 	name = "\improper AI Satellite Service"
 	})
 "dkL" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze{
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/phone{
-	attack_verb = list("bounced a check off","checked-out","tipped");
-	desc = "Also known as a cash register, or, more commonly, \"robbery magnet\". It's old and rusty, clearly non-functional and decorative only.";
-	icon = 'icons/obj/machines/pos.dmi';
-	icon_state = "pos";
-	name = "point of sale"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "dkM" = (
 /obj/structure/cable{
@@ -94634,17 +94436,27 @@
 	},
 /area/hallway/primary/central/ne)
 "dnD" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/hydroponics/soil,
-/turf/simulated/floor/grass,
-/area/hydroponics)
-"dnE" = (
-/obj/machinery/hydroponics/soil,
-/mob/living/simple_animal/chicken{
-	name = "Commander Clucky"
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 2;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
-/turf/simulated/floor/grass,
-/area/hydroponics)
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
+"dnE" = (
+/obj/machinery/kitchen_machine/grill,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "dnF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1;
@@ -95080,20 +94892,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/storage)
-"doq" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria";
-	dir = 2
-	},
-/area/crew_quarters/kitchen)
 "dor" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -96486,6 +96284,15 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"dyq" = (
+/obj/structure/table,
+/obj/item/book/manual/sop_service,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "dVJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Arcade"
@@ -96557,6 +96364,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
+"fAS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Hydroponics"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "bot";
+	dir = 1
+	},
+/area/hydroponics)
 "fPn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/plasteel{
@@ -96575,6 +96395,26 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"fTo" = (
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"fVV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/cream,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "gMZ" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 6
@@ -96593,12 +96433,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/toxins/mixing)
+"gPU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/bar)
 "gQL" = (
 /obj/machinery/computer/card,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"gSA" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria";
+	dir = 2
+	},
+/area/crew_quarters/kitchen)
+"gVf" = (
+/obj/item/twohanded/required/kirbyplants,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "hkf" = (
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plating,
@@ -96640,6 +96500,17 @@
 	dir = 2
 	},
 /area/shuttle/mining)
+"itF" = (
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria";
+	dir = 2
+	},
+/area/crew_quarters/kitchen)
 "izn" = (
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 1
@@ -96735,6 +96606,13 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"juV" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "jAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
@@ -96746,6 +96624,30 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/crew_quarters/dorms)
+"ktm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "asteroid";
+	tag = "icon-asteroid (NORTH)"
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding1 (NORTH)";
+	icon_state = "siding1";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	tag = "icon-siding2 (NORTH)";
+	icon_state = "siding2";
+	dir = 1
+	},
+/area/hydroponics)
 "kMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -96832,6 +96734,20 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/mining)
+"mjt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/wood,
+/obj/item/kitchen/utensil/fork,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"mtc" = (
+/obj/machinery/hydroponics/soil,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/grass,
+/area/hydroponics)
 "mut" = (
 /obj/machinery/light{
 	dir = 1;
@@ -96860,6 +96776,13 @@
 	},
 /turf/simulated/shuttle/floor4/vox,
 /area/shuttle/vox)
+"mRt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/stool/bar,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/bar)
 "mTi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -96880,6 +96803,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
+"nCu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/foodcart,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "nMi" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -97065,10 +96999,42 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"tjN" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/candle,
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "tla" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/maintenance/apmaint)
+"tuM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/chair/wood/wings{
+	tag = "icon-wooden_chair_wings (NORTH)";
+	icon_state = "wooden_chair_wings";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"tAf" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/rollingpin,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "tMr" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
@@ -97107,6 +97073,14 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"uNE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "vmZ" = (
 /obj/machinery/newscaster,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -97122,6 +97096,24 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
+"vus" = (
+/obj/structure/chair/stool/bar,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
+"vEQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "vUm" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -97231,6 +97223,27 @@
 	dir = 2
 	},
 /area/shuttle/mining)
+"xCu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
+"xMl" = (
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/turf/simulated/floor/wood,
+/area/crew_quarters/bar)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	tag = "icon-intact (SOUTHEAST)";
@@ -131060,7 +131073,7 @@ aUQ
 aUS
 bhr
 bja
-bkM
+bkO
 bcU
 aNe
 bmq
@@ -131317,15 +131330,15 @@ aUS
 djh
 dkE
 aZR
-bkM
+bkO
 bmr
-brT
-btf
-btf
 bmq
 byD
+byD
+byD
+byD
 bmq
-bmq
+aVG
 aUS
 bAi
 bHt
@@ -131579,10 +131592,10 @@ bmr
 brV
 btg
 bqi
-bmq
+tjN
 buN
 bmq
-aVG
+juV
 aUS
 cMK
 bHy
@@ -131834,9 +131847,9 @@ bnQ
 bkO
 bmr
 bmM
-brg
-brg
-bmq
+bqk
+bqk
+bqk
 bqk
 bmq
 bJQ
@@ -132086,7 +132099,7 @@ baM
 cWG
 aUS
 bfk
-aZR
+biS
 bop
 bkO
 bmr
@@ -132343,17 +132356,17 @@ baL
 cWu
 aUS
 dji
-biS
+gPU
 bom
-bkO
+bpC
 bmr
 bmM
 btm
 brh
 btn
 buQ
-aZV
-bzn
+bmq
+bmq
 bsN
 bAk
 bHy
@@ -132601,11 +132614,11 @@ beJ
 aUS
 djj
 dkL
-boH
-bpC
-bmr
+bot
+bjm
+bmq
 bmM
-btw
+btm
 bri
 bto
 buR
@@ -132857,12 +132870,12 @@ baP
 bkN
 aUS
 aRL
-beF
+bjm
 bot
 bjm
 bmq
 brW
-btq
+xMl
 bmq
 bmq
 bmq
@@ -133116,13 +133129,13 @@ bwX
 djk
 dkN
 boM
-dkN
+mRt
 bqy
 brX
 btx
 buq
-buq
-buq
+mjt
+tuM
 bAU
 bCI
 aUS
@@ -133376,10 +133389,10 @@ bjK
 blt
 bmq
 bmq
-bqi
+btm
 brH
 btr
-bqi
+fTo
 bAH
 bCB
 aUS
@@ -133633,12 +133646,12 @@ bdT
 bdT
 bnm
 bmq
-bqk
-bqk
-bqk
-bqk
-bAV
 bmq
+bmq
+bmq
+btq
+bAV
+gVf
 aUS
 bAo
 bHy
@@ -133889,12 +133902,12 @@ dkR
 dnu
 bdT
 bnl
-bmq
-bmq
-bmq
-bmq
-bmq
-bmq
+bmr
+bmr
+bmr
+bmr
+vus
+aZV
 bxE
 aUS
 bAn
@@ -134404,7 +134417,7 @@ boN
 bdT
 bmh
 bof
-bpL
+bof
 bof
 bof
 bof
@@ -134661,9 +134674,9 @@ boS
 bdT
 bmt
 bof
-bof
-bof
-bof
+fVV
+tAf
+dyq
 bof
 bof
 bxG
@@ -134920,7 +134933,7 @@ bqB
 brY
 btI
 bur
-bvM
+bur
 byE
 bwn
 bdT
@@ -135173,12 +135186,12 @@ bdT
 bdT
 bdT
 bdT
-bdT
-bon
+nCu
+bof
 btK
 but
 bsT
-boi
+but
 bwo
 bdT
 bzg
@@ -135425,15 +135438,15 @@ aVU
 aIc
 bbz
 aGY
-dih
+bdT
 djt
 bjd
 boV
-bpG
+boV
 bbW
 boj
 btJ
-bus
+gSA
 bsS
 bof
 bof
@@ -135682,17 +135695,17 @@ bhk
 bfI
 bbC
 aGY
-beb
+bdT
 djw
-aHV
-boX
-bjv
-bqH
 bof
-btJ
-buu
-bsV
+bof
 buJ
+bof
+bof
+xCu
+gSA
+bus
+bof
 bof
 bxJ
 bzf
@@ -135939,16 +135952,16 @@ bhj
 aIc
 bbh
 aGY
-beb
+bdT
 dju
-aKp
-bjv
+bof
+bof
 dnD
-bmy
-boo
-btJ
-brm
-bsU
+uNE
+uNE
+vEQ
+bof
+gSA
 bof
 bof
 bxI
@@ -136196,14 +136209,14 @@ aGX
 aGX
 bbh
 aGY
-beb
+bdT
 djx
-aKx
+bof
 bjv
 dnE
-bmy
-doq
-btP
+itF
+itF
+bof
 buv
 bof
 bof
@@ -136457,7 +136470,7 @@ beb
 bfH
 aKx
 bjx
-bfH
+mtc
 bmy
 boq
 bof
@@ -136712,7 +136725,7 @@ bbV
 aGY
 beb
 bfJ
-aKx
+ktm
 bjy
 bkY
 bmy
@@ -136967,7 +136980,7 @@ aGY
 aGY
 bbU
 beJ
-beb
+fAS
 bhY
 bjq
 beb

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -49820,12 +49820,12 @@
 	pixel_y = 21;
 	req_access_txt = "57"
 	},
-/obj/machinery/door_control{
+/obj/machinery/flasher_button{
 	id = "hopflash";
 	name = "HoP Flash Line";
 	pixel_x = -10;
 	pixel_y = 20;
-	req_one_access_txt = "57"
+	req_access_txt = "57"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;


### PR DESCRIPTION
## What Does This PR Do
Modifica las áreas de Cocina y bar a la par que agrega un botón para el flash de la oficina del HoP

## Why It's Good For The Game
Ampliar el espacio de la cocina se debe por el cambio efectuado a la base de chefs que ahora pueden ocupar la cocina a la par que el bar se amplia para poder mover la rocola a una mejor modificación y evitar suene fuera del bar causando problemas de lag. 

## Images of changes
    
                                            Bar y Cocina (DM)
![image](https://user-images.githubusercontent.com/46639834/76575731-b34fc980-6485-11ea-86ab-71eb79b93240.png)

                                             Bar y Cocina (DD)
![image](https://user-images.githubusercontent.com/46639834/76575808-e7c38580-6485-11ea-8183-7ecdb34e6714.png)

                                    Rango de la rocola en su posición actual
![image](https://user-images.githubusercontent.com/46639834/76575917-3ec95a80-6486-11ea-90d4-76bf0cb6268a.png)


## Changelog
:cl:
tweak: Modificaciones a Cocina y Bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
