### PR TITLE
Fix Loadout Bag Bug

### DIFF
--- a/code/HISPANIA/modules/client/preference/loadout/loadout_general.dm
+++ b/code/HISPANIA/modules/client/preference/loadout/loadout_general.dm
@@ -20,14 +20,20 @@
 
 /datum/gear/radio_back
 	display_name = "radio-bag , backpack"
+	slot = slot_r_hand
+	cost = 3
 	path = /obj/item/storage/backpack/fluff/krich_back
 
 /datum/gear/cat_back
 	display_name = "cat-bag , backpack"
+	slot = slot_r_hand
+	cost = 3
 	path = /obj/item/storage/backpack/fluff/ssscratches_back
 
 /datum/gear/beer_back
 	display_name = "beer-bag , dufflebag"
+	slot = slot_r_hand
+	cost = 3
 	path = /obj/item/storage/backpack/duffel/fluff/thebrew
 
 /datum/gear/limited_sheet


### PR DESCRIPTION
## What Does This PR Do
Repara un error al agregar mochilas al loadout que te da almacenamientos infinitos en las mochilas. 

## Why It's Good For The Game
Evita que puedas andar con 3 mochilas dentro de tu mochila sin alguna clase de nacionalización. 

## Images of changes

                                           Ahora valen 3 puntos del loadout
![image](https://user-images.githubusercontent.com/46639834/76581164-15192f00-6498-11ea-83da-98f7cbcfb0fb.png)


## Changelog
:cl:
fix: Mochilas de loadout
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
