### PR TITLE
Tweak Lavaland ClownPlanet Ruin

### DIFF
--- a/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/map_files/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -139,6 +139,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/mob/living/simple_animal/hostile/retaliate/clown,
 /turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "am" = (
@@ -1091,6 +1092,36 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/noslip/lavaland,
 /area/lavaland/surface/outdoors/explored)
+"fq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/ruin/powered/clownplanet)
+"gc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/simulated/floor/lubed,
+/area/ruin/powered/clownplanet)
 "gX" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/chasm/straight_down/lava_land_surface,
@@ -1100,11 +1131,42 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
+"iz" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/simulated/floor/plasteel,
+/area/ruin/powered/clownplanet)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/clownplanet)
+"wK" = (
+/obj/structure/disposalpipe/segment{
+	invisibility = 101
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "ye" = (
 /turf/simulated/floor/plating/lava/smooth,
@@ -1133,17 +1195,30 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/noslip/lavaland,
 /area/ruin/powered/clownplanet)
-"Mv" = (
-/obj/effect/mapping_helpers/no_lava,
-/mob/living/simple_animal/hostile/retaliate/clown,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
 "MR" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/powered/clownplanet)
+"Qo" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/simulated/floor/lubed,
 /area/ruin/powered/clownplanet)
 "TD" = (
 /obj/structure/disposalpipe/trunk,
@@ -1438,7 +1513,7 @@ aY
 bf
 cc
 bs
-br
+iz
 bB
 cc
 cc
@@ -1490,7 +1565,7 @@ aa
 "}
 (10,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 ac
@@ -1501,7 +1576,7 @@ aL
 am
 aL
 aN
-aN
+fq
 aZ
 bc
 bh
@@ -1558,7 +1633,7 @@ cc
 "}
 (12,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 ae
@@ -1592,7 +1667,7 @@ cc
 "}
 (13,1,1) = {"
 XO
-Mv
+XO
 cc
 ye
 cc
@@ -1633,7 +1708,7 @@ ye
 ac
 af
 af
-af
+wK
 af
 aJ
 af
@@ -1740,7 +1815,7 @@ aL
 an
 aO
 af
-av
+Qo
 bl
 bo
 bt
@@ -1769,7 +1844,7 @@ ye
 aL
 as
 am
-am
+gc
 an
 an
 an
@@ -1796,7 +1871,7 @@ cc
 "}
 (19,1,1) = {"
 XO
-Mv
+XO
 cc
 ye
 ye
@@ -1830,7 +1905,7 @@ cc
 "}
 (20,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 cc
@@ -1898,7 +1973,7 @@ cc
 "}
 (22,1,1) = {"
 aa
-Mv
+XO
 cc
 ye
 aq


### PR DESCRIPTION
## What Does This PR Do
Re posiciona de lugar los 5 payasos que aparecen en esta ruina al interior de la misma con el fin de evitar el log que genera cuando aparecen cerca de animales de lavaland y los atacan. 

## Why It's Good For The Game
Mientras evitemos saturar el inicio con spam a nuestro attack log esperamos un mejor rendimiento. 

## Images of changes

                                                      Versión de DD 
![image](https://user-images.githubusercontent.com/46639834/76674670-ab705200-6577-11ea-8636-5ee060fbf449.png)


## Changelog
:cl:
tweak: ClownPlanet map ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
