### PR TITLE
crossfix

### DIFF
--- a/code/HISPANIA/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/HISPANIA/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -95,6 +95,7 @@ To add a crossbreed:
 	desc = "You shouldn't see this."
 	icon = 'icons/hispania/obj/slimecrossing.dmi'
 	icon_state = "base"
+	container_type = DRAWABLE | INJECTABLE
 	var/del_on_empty = TRUE
 	var/list/list_reagents
 
@@ -121,7 +122,6 @@ To add a crossbreed:
 	desc = "A sphere of liquid blood, somehow managing to stay together."
 	color = "#FF0000"
 	list_reagents = list("blood" = 50)
-	container_type = DRAWABLE
 
 /obj/item/slimecrossbeaker/pax //5u synthpax.
 	name = "peace-inducing extract"
@@ -138,6 +138,7 @@ To add a crossbreed:
 /obj/item/slimecrossbeaker/autoinjector //As with the above, but automatically injects whomever it is used on with contents.
 	var/ignore_flags = FALSE
 	var/self_use_only = FALSE
+	container_type = DRAWABLE
 
 /obj/item/slimecrossbeaker/autoinjector/Initialize()
 	. = ..()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -276,7 +276,7 @@
 	being_used = 1
 
 	var/ghostmsg = "Play as [SM.name], pet of [user.name]?"
-	var/list/candidates = pollCandidates(ghostmsg, ROLE_SENTIENT, 0, 100)
+	var/list/candidates = pollCandidates(ghostmsg, ROLE_SENTIENT, 0, 300)
 
 	if(!src)
 		return


### PR DESCRIPTION
## What Does This PR Do
-los slime beakers ahora se pueden inyectar para sacar o introducir reactivos en ellos
-ahora puedes sacar reactivos de los slimeinyectores
-el tiempo para aceptar introducirse en un mob conciente de xeno es mayor
## Changelog
:cl:
fix: los slime beakers ahora se pueden inyectar para sacar o introducir reactivos en ellos
tweak: ahora puedes sacar reactivos de los slimeautoinyectores mediante una jeringa.
tweak; aumenta el tiempo en que puedes decidir si introducirte en un mob de xenobio.
/:cl:
