### PR TITLE
Add Emergency Shield Generator Supply Pack

### DIFF
--- a/code/HISPANIA/datums/supplypacks.dm
+++ b/code/HISPANIA/datums/supplypacks.dm
@@ -28,3 +28,13 @@ datum/supply_packs/security/spacesuit
                     /obj/item/clothing/mask/breath)
     cost = 70
     containername = "security space suit crate"
+
+//Emergency//
+
+/datum/supply_packs/engineering/energy_shi
+	name = "Emergency Shield Crate"
+	cost = 120
+	contains = list(/obj/machinery/shieldgen, /obj/machinery/shieldgen, /obj/machinery/shieldgen, /obj/machinery/shieldgen)
+	containername = "emergency shield crate"
+	containertype = /obj/structure/closet/crate/secure/engineering
+	access = ACCESS_ENGINE


### PR DESCRIPTION
## What Does This PR Do
Añade un paquete nuevo a la lista de ingeniería para los pedidos de cargo. Este contiene cuatro generadores de escudo de emergencia por el valor de 120 puntos.

## Why It's Good For The Game
Actualmente estos escudos pueden evitar colisiones o posibles brechas a lugares vitales en la estación pero únicamente hay dos en el juego y no se pueden conseguir por otro medio. Como tal estos objetos no salen en ninguna lista de objetivo de antagonistas como para ser considerando alto riesgo, así que los agrego a la lista para que ingeniería tenga nuevas posibles formas de jugar.

## Images of changes

                                     Listado y Hoja que genera 
![image](https://user-images.githubusercontent.com/46639834/77200511-502aec00-6ab0-11ea-8db8-71ff06da3723.png)

                                     Contenido en caja
![image](https://user-images.githubusercontent.com/46639834/77200594-84061180-6ab0-11ea-8835-bd82d4c38ec9.png)

                                  Escudos que genera
![image](https://user-images.githubusercontent.com/46639834/77200718-c596bc80-6ab0-11ea-9fc7-30090f3b7997.png)


## Changelog
:cl:
add: Emergency Shields Supply Pack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
