### PR TITLE
Cambia la temperatura del evento

### DIFF
--- a/code/HISPANIA/modules/events/temperature_change.dm
+++ b/code/HISPANIA/modules/events/temperature_change.dm
@@ -2,7 +2,7 @@
 	startWhen = 12
 	announceWhen = 3
 	endWhen = 160
-	var/temperature = 185.15
+	var/temperature = 373.15
 
 /datum/event/temperature_change/start()
 	alarm_controller()


### PR DESCRIPTION
## What Does This PR Do
Cambia la temperatura del evento de la temperatura de -77°C a 100°C

## Why It's Good For The Game
Esto arregla (en todos los casos que probé) que al terminar el evento la presion del aire quede normal, evitando que los firelock permanezcan cerrados. 
Sigue haciendo daño, al ser una temperatura alta. Mata a las mascotas y a la tripulación y activa los firelocks.
Sin embargo, el único cambio notable es que ya no mueren los slimes de xenobiología.

## Changelog
:cl: DanaDririon
tweak: Cambia la temperatura del evento
/:cl:
