### PR TITLE
Bug con los robots y su maquina de cryo.

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -54417,9 +54417,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -97037,6 +97034,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
+"lND" = (
+/obj/machinery/computer/cryopod/robot{
+	pixel_x = 63;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plasteel,
+/area/medical/research{
+	name = "Research Division"
+	})
 "lVn" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -141222,7 +141228,7 @@ bLU
 bNE
 bQz
 bRy
-bRy
+lND
 cbd
 ccV
 chb


### PR DESCRIPTION
## What Does This PR Do
Añade el ordenador que registra los robots que se fueron a cryo a la zona de ciencias.

## Why It's Good For The Game
Habia un bug que causaba que el cryo de ciencias no funcionara, pero el que se encuentra en el satelite si procedia correctamente, esto era porque al de ciencias le faltaba su ordenador, donde se registran los borgs que se van a cryo, este PR lo añade, para que ahora, si se convierten en fantasmas, desaparezca el robot.

## Images of changes
### `Nuevo ordenador sustituyendo un poster.`
![Screenshot_3](https://user-images.githubusercontent.com/58746682/77337718-8e7f1000-6d29-11ea-9aa6-41e7088431c3.png)
### `Robot dentro de cryo.`
![Screenshot_1](https://user-images.githubusercontent.com/58746682/77337767-a0f94980-6d29-11ea-9cba-b3ed6569b405.png)
![Screenshot_5](https://user-images.githubusercontent.com/58746682/77337789-ab1b4800-6d29-11ea-97d9-cad3dbd4ead4.png)
### `Robot desapareciendo en cryo.`
![Screenshot_2](https://user-images.githubusercontent.com/58746682/77337824-bb332780-6d29-11ea-9cb5-49adfd8cc7ed.png)
![Screenshot_6](https://user-images.githubusercontent.com/58746682/77337832-be2e1800-6d29-11ea-83e9-a198fad66f6a.png)
### `Ordenador con la informacion del robot desaparecido.`
![Screenshot_7](https://user-images.githubusercontent.com/58746682/77337877-d30aab80-6d29-11ea-856b-07da99de2d37.png)

## Changelog
:cl:
add: Añade un ordenador de cryo para borgs a ciencias.
del: Quita un poster aleatorio de ciencias.
/:cl: