### PR TITLE
Fix Shuttle Lavaland Windows

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -96673,22 +96673,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
-"hHX" = (
-/obj/structure/window/full/shuttle,
-/obj/structure/grille,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall12";
-	dir = 2
-	},
-/area/shuttle/mining)
-"hMH" = (
-/obj/structure/window/full/shuttle,
-/obj/structure/grille,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
-	},
-/area/shuttle/mining)
 "iaC" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -116824,9 +116808,9 @@ aaa
 aaa
 iAO
 cgF
-hMH
+ceY
 cgF
-hMH
+ceY
 cgF
 xAQ
 aaa
@@ -117593,7 +117577,7 @@ dcY
 bKB
 aaa
 aaa
-hHX
+ceY
 cgB
 cin
 cim


### PR DESCRIPTION
## What Does This PR Do
Repara un error que deje por accidente donde las ventanas de la shuttle tienen una pared debajo.

## Why It's Good For The Game
Ahora puedes ver alrededor al llegar a lavaland desde la shuttle.

## Images of changes

                                                     Ventanas
![image](https://user-images.githubusercontent.com/46639834/77354064-c4130180-6d07-11ea-9e3b-6df5525a98fc.png)


## Changelog
:cl:
fix: Shuttle Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
