### PR TITLE
Add Wall-Recharger Blueshield Office

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -97554,6 +97554,12 @@
 	},
 /turf/space,
 /area/shuttle/administration)
+"rWK" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -21
+	},
+/turf/simulated/floor/wood,
+/area/blueshield)
 "rYq" = (
 /obj/machinery/door/airlock/centcom{
 	id_tag = "adminshuttle";
@@ -123766,7 +123772,7 @@ cgS
 ciA
 clR
 col
-clR
+rWK
 coY
 cqR
 csy


### PR DESCRIPTION
## What Does This PR Do
Añade un Recharger de pared a la oficina del blueshield. 

## Why It's Good For The Game
Actualmente el blueshield debe de moverse a distancias fuera de su oficina para recargar su equipamiento, al ser una de sus herramientas de trabajo el debería de contar con un recharger en su oficina para una operación mas optima. 

## Images of changes
                                    
                                            Recharger DM 
![image](https://user-images.githubusercontent.com/46639834/77454952-dac85f80-6dbe-11ea-891c-f2842aaeb66b.png)

 
                                           Recharger DS
![image](https://user-images.githubusercontent.com/46639834/77455004-eb78d580-6dbe-11ea-96ad-264c4ead040e.png)


## Changelog
:cl:
add: Recharger a BS Office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
