### PR TITLE
Fix Camara de Ciencias 

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -54520,12 +54520,6 @@
 /turf/simulated/wall/r_wall,
 /area/medical/genetics)
 "bWj" = (
-/obj/machinery/camera{
-	c_tag = "Research Server Room";
-	dir = 2;
-	network = list("Research","SS13");
-	pixel_x = 22
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -57137,6 +57131,12 @@
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen{
 	anchored = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Research Server Room";
+	dir = 2;
+	network = list("Research","SS13");
+	pixel_x = 22
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"


### PR DESCRIPTION
## What Does This PR Do
Repara una cámara de ciencias la cual esta enlazada a una puerta y queda flotando cuando esta es abierta.

## Why It's Good For The Game
Evita que la cámara flotando se vea en el cuarto cada que entras o sales. 

## Images of changes

                                         Después del Fix
![image](https://user-images.githubusercontent.com/46639834/77590991-a46d0c00-6eb4-11ea-9aef-903f41c5ba5e.png)

                                          Original
![image](https://user-images.githubusercontent.com/46639834/77591009-ae8f0a80-6eb4-11ea-8ae4-d6931b5a1531.png)



## Changelog
:cl:
fix: Camara flotante de ciencias
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
