### PR TITLE
[Map Change] Dorms Arrivals (Cyberiad)

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -20048,6 +20048,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aIK" = (
@@ -20612,10 +20613,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/fpmaint)
-"aJX" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint2)
 "aJY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
@@ -21048,6 +21045,7 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
 "aKX" = (
@@ -34365,6 +34363,9 @@
 /area/hallway/primary/central/nw)
 "bkx" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Dormitories"
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bky" = (
@@ -35781,15 +35782,6 @@
 	icon_state = "L8"
 	},
 /area/hallway/primary/central/north)
-"bng" = (
-/obj/item/radio/intercom{
-	name = "station intercom (General)";
-	pixel_y = -28
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/southeastcorner,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "bnh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -35916,7 +35908,11 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/camera{
+	c_tag = "Central Hallway North-West";
+	dir = 2;
+	network = list("SS13")
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bns" = (
@@ -37355,16 +37351,9 @@
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
-"bqv" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "bqw" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/clothing/head/soft/grey,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqx" = (
@@ -37924,9 +37913,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
 "brN" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/locker)
 "brO" = (
 /turf/simulated/shuttle/wall{
@@ -38071,11 +38058,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsg" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey{
-	pixel_x = -2;
-	pixel_y = 3
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bsh" = (
@@ -38173,9 +38156,16 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bst" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/bed,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/bedsheet,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/locker)
 "bsu" = (
 /obj/effect/spawner/window/reinforced,
@@ -38865,10 +38855,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bua" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light,
-/obj/effect/decal/warning_stripes/yellow,
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/locker)
 "bub" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -38909,20 +38902,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"bug" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "buh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 2;
@@ -39528,22 +39507,15 @@
 "bvs" = (
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
-"bvt" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
 "bvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvw" = (
@@ -39558,6 +39530,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -39873,6 +39848,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/clothing/head/soft/grey,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwb" = (
@@ -40068,6 +40045,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bwx" = (
@@ -41052,10 +41030,7 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "byj" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office";
-	dir = 1
-	},
+/obj/machinery/camera,
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /turf/simulated/floor/wood,
@@ -41111,15 +41086,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
-"byp" = (
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "barber"
-	},
-/area/crew_quarters/locker)
 "byq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41714,20 +41680,6 @@
 	},
 /turf/simulated/wall,
 /area/security/vacantoffice)
-"bzu" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/crew_quarters/locker/locker_toilet)
 "bzv" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
@@ -41781,6 +41733,10 @@
 /area/crew_quarters/locker)
 "bzA" = (
 /obj/machinery/washing_machine,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -42000,7 +41956,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bzV" = (
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -42045,7 +42000,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "bAb" = (
-/obj/effect/decal/warning_stripes/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -42068,7 +42022,6 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "bAe" = (
-/obj/effect/decal/warning_stripes/southwestcorner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -42499,6 +42452,7 @@
 "bBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/robot,
+/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bBc" = (
@@ -43065,26 +43019,17 @@
 	},
 /area/crew_quarters/locker/locker_toilet)
 "bCn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bCo" = (
-/obj/item/latexballon,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"bCp" = (
-/obj/effect/landmark{
-	name = "blobstart"
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
 	},
-/obj/item/clothing/suit/ianshirt,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/crew_quarters/locker/locker_toilet)
 "bCq" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -43842,9 +43787,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/mob/living/simple_animal/mouse,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/wall,
+/area/crew_quarters/locker)
 "bDQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45094,10 +45038,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bGn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/warning_stripes/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5;
 	level = 1
@@ -45474,17 +45414,6 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/locker/locker_toilet)
-"bGX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "bGY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45514,6 +45443,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bHc" = (
@@ -45710,14 +45640,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/west)
-"bHv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "bHw" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor/wood,
@@ -46848,11 +46770,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bJx" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -46864,8 +46781,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/crew_quarters/locker)
 "bJz" = (
 /obj/structure/toilet{
 	dir = 8
@@ -47382,15 +47302,23 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/machinery/camera{
+	c_tag = "Locker Room Toilets";
+	dir = 8;
+	network = list("SS13")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/crew_quarters/locker/locker_toilet)
 "bKr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "bKs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -47400,13 +47328,15 @@
 "bKt" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "bKu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -47681,16 +47611,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/port)
-"bKX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96255,6 +96175,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"eGR" = (
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "eJO" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -96524,12 +96450,30 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"gVi" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "gVl" = (
 /turf/simulated/shuttle/wall{
 	dir = 4;
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/tsf)
+"gWh" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "hek" = (
 /obj/machinery/computer{
 	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
@@ -96576,6 +96520,11 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"hQN" = (
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "iaC" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -96610,6 +96559,18 @@
 	dir = 2
 	},
 /area/crew_quarters/kitchen)
+"ivG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/locker)
+"iye" = (
+/obj/item/bikehorn/rubberducky,
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "izn" = (
 /obj/machinery/atmospherics/unary/passive_vent{
 	dir = 1
@@ -96670,12 +96631,24 @@
 /area/toxins/launch{
 	name = "Toxins Launch Room"
 	})
+"iSe" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint2)
 "iWl" = (
 /obj/machinery/vending/medical,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"iYl" = (
+/obj/item/radio/intercom{
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "iZL" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
@@ -96939,6 +96912,10 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"lVq" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "mek" = (
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/floor{
@@ -96978,6 +96955,21 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"mjb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "mjt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/wood,
@@ -97139,6 +97131,10 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"nOc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall,
+/area/crew_quarters/locker/locker_toilet)
 "nRs" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/shuttle/floor{
@@ -97219,6 +97215,13 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"pcs" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/coatrack,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "puu" = (
 /obj/structure/bed/dogbed/garronte,
 /mob/living/simple_animal/friendly/owl,
@@ -97345,6 +97348,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"qCx" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "qIy" = (
 /turf/simulated/shuttle/wall{
 	icon_state = "wall3"
@@ -97356,6 +97368,11 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/tsf)
+"qNu" = (
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "qOQ" = (
 /obj/structure/barricade/wooden/crude,
 /turf/simulated/shuttle/floor{
@@ -97366,6 +97383,24 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
+"qXN" = (
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/obj/machinery/camera{
+	c_tag = "Locker Room Toilets";
+	dir = 8;
+	network = list("SS13")
+	},
+/obj/machinery/light/small{
+	tag = "icon-bulb1 (EAST)";
+	icon_state = "bulb1";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "qYi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -97395,6 +97430,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
+"rvO" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "ryD" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -97491,6 +97533,15 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"ssS" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/locker)
 "suH" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/vomit,
@@ -97613,6 +97664,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"tzQ" = (
+/obj/machinery/light,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "tAf" = (
 /obj/structure/table,
 /obj/item/kitchen/knife,
@@ -97623,6 +97678,15 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
+"tCt" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "tLk" = (
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock{
@@ -97709,6 +97773,20 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
+"uPj" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
+"uTN" = (
+/obj/machinery/camera{
+	c_tag = "Engineering West";
+	dir = 4;
+	network = list("SS13")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "freezerfloor"
+	},
+/area/crew_quarters/locker/locker_toilet)
 "viF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/remains/human{
@@ -97720,6 +97798,11 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"vjP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "vlW" = (
 /obj/item/mounted/mirror,
 /turf/simulated/shuttle/wall{
@@ -97781,6 +97864,11 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
+"vLg" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "vLs" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/barricade/wooden/crude,
@@ -97858,6 +97946,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"wvO" = (
+/obj/machinery/camera{
+	c_tag = "Brig Prison Hallway East";
+	dir = 4;
+	network = list("Prison","SS13")
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/crew_quarters/locker)
 "wCG" = (
 /obj/structure/ore_box,
 /turf/simulated/shuttle/floor{
@@ -111532,8 +111631,8 @@ aaa
 aaa
 aGn
 aHR
-aHS
-aJX
+iSe
+iSe
 aGn
 aKN
 aGn
@@ -113618,8 +113717,8 @@ btL
 bvq
 bvy
 bwZ
-bnK
-bnw
+lVq
+vjP
 blQ
 bIP
 bET
@@ -113875,7 +113974,7 @@ dnG
 bvr
 bwK
 bye
-bnK
+uPj
 bBb
 blQ
 bJw
@@ -114646,7 +114745,7 @@ blM
 bvs
 bwP
 bym
-bzu
+bwP
 bvs
 bwP
 bvs
@@ -115159,7 +115258,7 @@ bvk
 bnD
 bvs
 bBN
-byn
+uTN
 bEr
 bGk
 bCx
@@ -115668,8 +115767,8 @@ bki
 blM
 bnB
 bnD
-bqv
-bqv
+bqx
+bqx
 bvS
 bvs
 bvs
@@ -115677,7 +115776,7 @@ bvs
 bvs
 bvs
 bvs
-bym
+tCt
 bym
 bGW
 bDQ
@@ -115930,13 +116029,13 @@ bqx
 bvZ
 bzU
 bBQ
-bwT
+wvO
 bzz
 blM
 bCo
-blQ
+iye
 bKt
-bKX
+bGW
 bDQ
 blQ
 aaa
@@ -116182,18 +116281,18 @@ bkg
 bkx
 bnD
 bnD
-bqx
+bnD
 bsg
 bvW
 bnD
 bwT
-byp
+bwT
 bzy
 blM
-bCp
-blQ
+bCo
+qXN
 bKr
-bGX
+bGW
 bDQ
 bxb
 bKB
@@ -116439,18 +116538,18 @@ bpg
 bqh
 brv
 brv
-bug
-bvt
+brv
+brv
 bwb
-bnD
+eGR
 bBU
 bwT
 bzA
 blM
-bCo
-blQ
-bnw
-bHv
+bvs
+bvs
+nOc
+bGW
 bDQ
 bxb
 bPY
@@ -116696,16 +116795,16 @@ bkg
 blM
 bnF
 bpd
-bqv
-bqv
+bnD
+bqx
 bwa
-bng
+bnD
+pcs
+brN
+qNu
+hQN
+gWh
 blM
-blM
-blM
-blM
-blM
-blQ
 bKu
 bHb
 bMg
@@ -116954,14 +117053,14 @@ blM
 bnG
 bnD
 bnD
-bnD
-bwa
+vLg
+mjb
 bAb
 brN
 brN
 brN
 brN
-blM
+iYl
 bDP
 bKE
 bKY
@@ -117215,11 +117314,11 @@ bnD
 bwd
 bzV
 bst
-bst
-bst
+gVi
+ssS
 bua
-blM
-bCk
+qCx
+ivG
 bKy
 bxb
 bxb
@@ -117475,8 +117574,8 @@ bCn
 bCn
 bCn
 bGn
-blM
-bCk
+tzQ
+ivG
 bKy
 bxb
 bIV
@@ -117730,9 +117829,9 @@ btT
 bvx
 bwY
 bsk
-bnD
+rvO
 bBf
-bOn
+bCn
 bJy
 bKG
 bxb
@@ -117990,7 +118089,7 @@ blM
 blM
 blM
 blM
-bCk
+ivG
 bFd
 bxb
 bIY

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -37639,6 +37639,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"brg" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/portable_atmospherics/pump,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "brh" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -42452,7 +42457,6 @@
 "bBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/robot,
-/obj/machinery/portable_atmospherics/pump,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bBc" = (
@@ -96912,10 +96916,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
-"lVq" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/simulated/floor/plating,
-/area/maintenance/port)
 "mek" = (
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/floor{
@@ -97620,6 +97620,10 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/syndicate_sit)
+"sWy" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/simulated/floor/plating,
+/area/maintenance/fpmaint)
 "tjN" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -113717,7 +113721,7 @@ btL
 bvq
 bvy
 bwZ
-lVq
+uPj
 vjP
 blQ
 bIP
@@ -113974,7 +113978,7 @@ dnG
 bvr
 bwK
 bye
-uPj
+bnK
 bBb
 blQ
 bJw
@@ -124744,7 +124748,7 @@ aNJ
 aJc
 aPC
 aEl
-aPi
+sWy
 aVD
 aRw
 baj
@@ -126286,7 +126290,7 @@ aNP
 aBn
 aBn
 aEl
-aGb
+brg
 aVD
 aYh
 bal


### PR DESCRIPTION
## What Does This PR Do
Agrega camas, duchas y una puerta a la par que un medikit a la seccion de vestidores y baños de arrivals. Reposiciona la maquinaria para ingeniería que anteriormente estaba aquí a mantenimiento y la disminuye a 8.

## Why It's Good For The Game
Actualmente el mapa no cuenta con área propia o adecuada donde puedas tirarte SSD sin que tengas que preocuparte que el área donde estés sea totalmente segura. Decidí poner las camas para los SSD en este dormitorio de arrivals debido a que por experiencia esta área nunca suele verse afectada por actos de antagonistas a la par que a lo mucho únicamente suele sufrir daños por vines que no son controladas. A la par que sacamos la instrumentaría de ingeniería junto a las toolbox de este lugar para poder dejar claro que es un area para la crew de vestidores y por ultimo agregue las duchas por que actualmente los civiles tienen que desplazarse a maint o las duchas de un extremo aun sabiendo que tenemos una zona de baños aqui. 

## Images of changes

                                                Versión DM
![image](https://user-images.githubusercontent.com/46639834/77811764-3cf4bf00-7062-11ea-8764-6307b67d0857.png)

                                                 Versión de DS
![image](https://user-images.githubusercontent.com/46639834/77811769-48e08100-7062-11ea-846b-3980e818adfd.png)

                                    Reposicionamiento de Scrubbers y Air
![image](https://user-images.githubusercontent.com/46639834/77854689-f493e900-71a8-11ea-96f3-f17b2feee229.png)




## Changelog
:cl:
add: Camas y duchas a vestidores
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
