### PR TITLE
Quita un ordeanor sobrante de robotica

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -47817,12 +47817,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/assembly/chargebay)
-"bLn" = (
-/obj/machinery/computer/cryopod/robot{
-	pixel_x = -32
-	},
-/turf/simulated/floor/mech_bay_recharge_floor,
-/area/assembly/chargebay)
 "bLo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -140357,7 +140351,7 @@ bLN
 bNg
 bOZ
 bQK
-bLn
+bLE
 bLE
 bWi
 bWi


### PR DESCRIPTION
## What Does This PR Do
Quita el ordenador del cryo de robotica que estaba mal posicionado y que no funcionaba.

## Why It's Good For The Game
Se me olvido quitarlo en el PR del bug con cryo de robotica, y es totalmente inutil.

## Images of changes
### `ANTES`
![imagen](https://user-images.githubusercontent.com/58746682/77812341-e78bd280-70a0-11ea-80e9-ea0889ab1733.png)
### `DESPUES`
![imagen](https://user-images.githubusercontent.com/58746682/77812329-dfcc2e00-70a0-11ea-85bf-83211bf5311f.png)

## Changelog
:cl:
del: Quita un ordenador sobrante de ciencias.
/:cl: