### PR TITLE
El lanzallamas es grande

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -12,7 +12,7 @@
 	throwforce = 10
 	throw_speed = 1
 	throw_range = 5
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	materials = list(MAT_METAL=500)
 	resistance_flags = FIRE_PROOF
 	origin_tech = "combat=1;plasmatech=2;engineering=2"


### PR DESCRIPTION
## What Does This PR Do
Cambia el tamaño del lanzallamas para que no quepa en una mochila.

## Why It's Good For The Game
Un lanzallamas es muy grande para que quepa en una mochila y últimamente se está usando demasiado. No es un item stealth y la verdad es que hace más friendly fire que ayudar.

## Changelog
:cl: DanaDririon
tweak: Agranda el peso del lanzallamas
/:cl: