### PR TITLE
Sube el tiempo limite de defrib a 5 minutos

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -345,7 +345,7 @@
 #define MOUSE_OPACITY_OPAQUE 2
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 120
+#define DEFIB_TIME_LIMIT 300
 #define DEFIB_TIME_LOSS 60
 
 //different types of atom colorations


### PR DESCRIPTION
## What Does This PR Do
Sube el tiempo limite de defribilación de 2 minutos  a 5 minutos. Esto significa que tienes 5 minutos cuando un paciente muere antes de que no sea más defribilable.

## Why It's Good For The Game
Copiado de https://github.com/ParadiseSS13/Paradise/pull/13006 y propuesto aquí en #514 . De esta manera los médicos tienen más tiempo para trabajar en el paciente, antes de que no se le puede defribilar. Así, los médicos que si quieren tratar tienen más oportunidades, en vez de apretar 3 botones y clonarlo.

## Changelog
:cl: DanaDririon
tweak: Sube el tiempo de defrib a 5 minutos
/:cl:
