### PR TITLE
Ultra Chad peste negra, Version 9000.

### DIFF
--- a/code/HISPANIA/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/HISPANIA/modules/reagents/chemistry/reagents/misc.dm
@@ -5,9 +5,9 @@
 	reagent_state = LIQUID
 	color = "#f80000"
 
-/datum/reagent/blackdeath_blood/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/blackdeath_blood/on_mob_life(mob/living/carbon/human/M)
 	if(volume > 2)
-		M.ForceContractDisease(new /datum/disease/black_death(0))
+		M.ForceContractDisease(new /datum/disease/black_death())
 	return ..()
 
 //Reagent for the drake steak//

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -45,7 +45,7 @@
 					antable = FALSE
 					desc += " It appears to be infested with ants. Yuck!"
 					reagents.add_reagent("ants", 1) // Don't eat things with ants in i you weirdo.
-					if(prob(5))
+					if(prob(1))
 						new /mob/living/simple_animal/hostile/poison/fleas(T)
 					if(ant_timer)
 						deltimer(ant_timer)

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -45,7 +45,7 @@
 					antable = FALSE
 					desc += " It appears to be infested with ants. Yuck!"
 					reagents.add_reagent("ants", 1) // Don't eat things with ants in i you weirdo.
-					if(prob(0.05))
+					if(prob(1))
 						new /mob/living/simple_animal/hostile/poison/fleas(T)
 					if(ant_timer)
 						deltimer(ant_timer)

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -45,7 +45,7 @@
 					antable = FALSE
 					desc += " It appears to be infested with ants. Yuck!"
 					reagents.add_reagent("ants", 1) // Don't eat things with ants in i you weirdo.
-					if(prob(1))
+					if(prob(5))
 						new /mob/living/simple_animal/hostile/poison/fleas(T)
 					if(ant_timer)
 						deltimer(ant_timer)

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -727,7 +727,7 @@
 	//spark for no reason
 	if(prob(5))
 		do_sparks(3, 1, src)
-		if(prob(0.2))
+		if(prob(0.5))
 			new /mob/living/simple_animal/hostile/poison/fleas/borg(T)
 
 /mob/living/simple_animal/pet/dog/corgi/borgi/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -727,7 +727,7 @@
 	//spark for no reason
 	if(prob(5))
 		do_sparks(3, 1, src)
-		if(prob(0.005))
+		if(prob(0.2))
 			new /mob/living/simple_animal/hostile/poison/fleas/borg(T)
 
 /mob/living/simple_animal/pet/dog/corgi/borgi/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -728,7 +728,8 @@
 	if(prob(5))
 		do_sparks(3, 1, src)
 		if(prob(0.5))
-			new /mob/living/simple_animal/hostile/poison/fleas/borg(T)
+			if(prob(10))
+				new /mob/living/simple_animal/hostile/poison/fleas/borg(T)
 
 /mob/living/simple_animal/pet/dog/corgi/borgi/handle_automated_action()
 	if(emagged && prob(25))


### PR DESCRIPTION
## What Does This PR Do
Aumenta la probabilidad de que aparezcan los fleas y soluciona un bug que hacia que los fleas no te pudieran infectar. Aunque recuerdo que antes, al testearlo, funcionaba.

## Why It's Good For The Game
Fijandome en la probabilidad del slot machine, los fleas estan casi como la probabilidad de ganar un millon de creditos, cosa que solo se veia cada 7 años, y ahora almenos tienen algo mas de probablidades de salir, para que no parezca adminspawn.
A nadie le gustan los bugs.

## Changelog
:cl:
tweak: Retoca la probabilidad de los fleas.
fix: Soluciona el error que hacia que los fleas no contagiaran.
/:cl: