### PR TITLE
Tweak Rotación de Razas y Lock de Personajes en Data Base asociadas.

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -222,6 +222,7 @@
 /obj/machinery/door/airlock/tranquillite
 	name = "tranquillite airlock"
 	icon = 'icons/obj/doors/airlocks/station/freezer.dmi'
+	assemblytype = /obj/structure/door_assembly/door_assembly_tranquillite
 	doorOpen = null // it's silent!
 	doorClose = null
 	doorDeni = null


### PR DESCRIPTION
## What Does This PR Do
Elimina de rotación las razas de Tajaran, Unathi, Skrell, Slime People, Diona, Grey, Kidan dentro de la lista de razas que se pueden seleccionar al crear un personaje, a la par para poder tener concordancia y nada de favoritismos, hace que los personajes de estas razas que ya están asociados a ciertas CKEY queden como bloqueados por el momento.  Las razas seleccionadas cambiaran cada mes en base a lo que los Devs decidamos.

## Why It's Good For The Game
Como tal dejamos parte de las otras razas que ya existen y son bastante exclusivas de SS13 como los IPC, Vox y Plasmaman dejando de lado las razas que actualmente no aportan mucho al juego en cuanto a su lore y sus mecánicas de jugabilidad. Si bien sabemos que es algo que molestara a una parte de la comunidad es con el fin de poder generar una rotación e importancia a cada raza ya existente.

## Images of changes

                                             Furry No More
![image](https://user-images.githubusercontent.com/46639834/78097195-df7dac80-7398-11ea-9821-af04659b0de3.png)


## Changelog
:cl:
fix: Tranquilite Doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
