### PR TITLE
Tweak Advanced Medikits y HA

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -153,7 +153,7 @@
 	new /obj/item/stack/medical/ointment/advanced(src)
 	new /obj/item/stack/medical/ointment/advanced(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
-	//new /obj/item/healthanalyzer( src )
+	new /obj/item/healthanalyzer( src )  //Unicamente por ser un medikit especifico
 
 /obj/item/storage/firstaid/adv/empty
 	empty = 1


### PR DESCRIPTION
## What Does This PR Do
Regresa los HA a los Advanced Medikits (Medikits Rojos)

## Why It's Good For The Game
Como ya sabemos anteriormente se elimino los HA de los medikits y los otros lados donde fácilmente se podía conseguir uno, sin embargo esto dejo a que los doctores ahora dependan por completo de sus NanoMeds y los otros trabajos que inician con este no puedan acceder a un Health Analyzer de medios convencionales. Igualmente revisando el otro PR no veo ninguna linea justificando el borrarlos directamente a los Advanced Medikits.

Resuelve lo solicitado en https://github.com/Helixis/Paradise/issues/539

## Images of changes

                                     HA en Advanced Medikit
![image](https://user-images.githubusercontent.com/46639834/78197843-d0a00400-7443-11ea-92ba-57e4c74e1685.png)


## Changelog
:cl:
tweak: Health Analyzer en Advanced Medikit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
