### PR TITLE
Fix Sprite en decoración Lavaland Planet

### DIFF
--- a/code/game/objects/items/decorations.dm
+++ b/code/game/objects/items/decorations.dm
@@ -269,6 +269,6 @@
 /obj/structure/decorative_structures/flammable/lava_land_display
 	name = "lava land display"
 	desc = "The tomb of many a miner and possibly a home for much worse things."
-	icon_state = "lava_land_display"
+	icon_state = "Lava_land_display"
 
 


### PR DESCRIPTION
## What Does This PR Do
Repara un error de referencia a un sprite de decoración que genera un planeta de lavaland bastante bonito. 

## Why It's Good For The Game
Repara un error y evita tengamos estructuras invisibles. 

## Images of changes

                                               Sprite Funcional
![image](https://user-images.githubusercontent.com/46639834/78410477-abd59900-75c9-11ea-9408-e8074bc03279.png)


## Changelog
:cl:
fix: Lavaland Display Sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
