### PR TITLE
Tweak Chem Dispensers Gasto Energetico

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -11,7 +11,7 @@
 	var/cell_type = /obj/item/stock_parts/cell/high
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1
-	var/amount = 15
+	var/amount = 10
 	var/recharge_amount = 5
 	var/recharge_counter = 0
 	var/hackedcheck = FALSE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -11,7 +11,7 @@
 	var/cell_type = /obj/item/stock_parts/cell/high
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1
-	var/amount = 10
+	var/amount = 50
 	var/recharge_amount = 20
 	var/recharge_counter = 0
 	var/hackedcheck = FALSE

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -5,14 +5,14 @@
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "dispenser"
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 40
+	idle_power_usage = 150
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/ui_title = "Chem Dispenser 5000"
 	var/cell_type = /obj/item/stock_parts/cell/high
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1
-	var/amount = 10
-	var/recharge_amount = 100
+	var/amount = 15
+	var/recharge_amount = 5
 	var/recharge_counter = 0
 	var/hackedcheck = FALSE
 	var/obj/item/reagent_containers/beaker = null

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -12,7 +12,7 @@
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1
 	var/amount = 10
-	var/recharge_amount = 5
+	var/recharge_amount = 20
 	var/recharge_counter = 0
 	var/hackedcheck = FALSE
 	var/obj/item/reagent_containers/beaker = null


### PR DESCRIPTION
## What Does This PR Do
Modifica la cantidad de poder que recupera el Chem-Dispenser de 10 a 2 por unidad de tiempo y su consumo de poder base es de 140. 

## Why It's Good For The Game
Actualmente esta maquina tiene una recuperación de recursos demasiado alta para la cantidad de recursos que puede permitir recordemos es una maquina de recursos químicos no una cargadora especializada de baterías. 

## Images of changes

                                     Recupera 2 por tiempo
![image](https://user-images.githubusercontent.com/46639834/78458362-f0b30b80-766d-11ea-9df2-e255a63a65d5.png)



## Changelog
:cl:
tweak: Valores energéticos Chem Dispenser
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
