### PR TITLE
Add Videcamaras Autolathe

### DIFF
--- a/code/HISPANIA/modules/research/designs/autolathe_designs.dm
+++ b/code/HISPANIA/modules/research/designs/autolathe_designs.dm
@@ -5,3 +5,11 @@
 	materials = list(MAT_METAL = 750, MAT_GLASS = 400)
 	build_path = /obj/item/device/binoculars
 	category = list("initial","Tools")
+
+/datum/design/videocam
+	name = "Video Camera"
+	id = "videocam"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 120, MAT_GLASS = 60)
+	build_path = /obj/item/videocam
+	category = list("initial", "Miscellaneous")


### PR DESCRIPTION
## What Does This PR Do
Re agrega las Video Camaras al Autolathe

## Why It's Good For The Game
En Paradise fueron eliminadas debido a que la gente las ocupaba para hacer powergaming y otros motivos respecto a balance por su player base tan amplia.

## Images of changes

                                       ¡Vuelve!
![image](https://user-images.githubusercontent.com/46639834/78844219-c6917e80-79ca-11ea-86ad-285e401a0c28.png)


## Changelog
:cl:
add: Videocamara Design Autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
