### PR TITLE
Fix Runtimes de Camaras en DD

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -34,8 +34,8 @@
 	var/in_use_lights = 0 // TO BE IMPLEMENTED
 	var/toggle_sound = 'sound/items/wirecutter.ogg'
 
-/obj/machinery/camera/Initialize()
-	. = ..()
+/obj/machinery/camera/New()
+	..()
 	wires = new(src)
 	assembly = new(src)
 	assembly.state = 4


### PR DESCRIPTION
## What Does This PR Do
Repara el spam de runtimes que generan las cámaras mejoradas al cargar el server en DreamDaemon, este es un PR provisional hasta que paradise ya sea decida dar el revert también o genere una solución. 

## Why It's Good For The Game
Evita que nuestro log de inicio se inunde de runtimes.

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/79057263-05bb0c00-7c25-11ea-956d-ca388635a8c4.png)


## Changelog
:cl:
fix: Runtime Camaras
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
