### PR TITLE
Fix Kois Runtime

### DIFF
--- a/code/HISPANIA/modules/mob/living/simple_animal/hostile/retaliate/fish.dm
+++ b/code/HISPANIA/modules/mob/living/simple_animal/hostile/retaliate/fish.dm
@@ -1,18 +1,15 @@
 /mob/living/simple_animal/hostile/retaliate/carp/koi/handle_automated_action()
-	var/obj/structure/cable/C = locate() in loc
-	var/turf/simulated/floor/F = get_turf(src)
-	if(istype(F))
-		///Evitar que los kois coman cables dentro de la estacion y debajo de tiles
-	else
-		if(prob(10))
-			if(C.avail())
-				visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
-				playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
-				C.deconstruct()
-				toast()
-			else
-				C.deconstruct()
-				visible_message("<span class='warning'>[src] chews through [C].</span>")
+	var/turf/space/S = get_turf(src)
+	var/obj/structure/cable/C = locate() in S //Las catwalk son estructuras sobre turf/space
+	if(C && prob(30)) //Solo pueden comer cables del espacio
+		if(C.avail())
+			visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
+			playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
+			C.deconstruct()
+			toast()
+		else
+			C.deconstruct()
+			visible_message("<span class='warning'>[src] chews through [C].</span>")
 	..()
 
 /mob/living/simple_animal/hostile/retaliate/carp/koi/proc/toast()


### PR DESCRIPTION
## What Does This PR Do
Repara el Runtime de los kois, antes intentaba comer cables inexistentes, ahora come cables de catwalk unicamente y sube su probabilidad, desde que lo implementamos nunca escuche a un koi morder un cable.

## Why It's Good For The Game
Repara un runtime y esperemos los ingenieros recuerden que esos grilles alrededor de solares no están de adorno. 

## Images of changes

                                          ¡Hola mama!
![image](https://user-images.githubusercontent.com/46639834/79406234-20aaba80-7f5c-11ea-9d54-78f131787f11.png)


## Changelog
:cl:
fix: Koi Runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
