### PR TITLE
Inducers refactor

### DIFF
--- a/code/HISPANIA/datums/supplypacks.dm
+++ b/code/HISPANIA/datums/supplypacks.dm
@@ -1,7 +1,7 @@
 /datum/supply_packs/engineering/inducers
 	name = "Inducers Crate"
 	cost = 60
-	contains = list(/obj/item/inducerapc, /obj/item/inducerapc)
+	contains = list(/obj/item/inducer/apc, /obj/item/inducer/apc)
 	containername = "inducer crate"
 	containertype = /obj/structure/closet/crate/secure/engineering
 	access = ACCESS_ENGINE

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -281,7 +281,7 @@
 	item_state = "inducer-engi"
 	origin_tech = "powerstorage=4;materials=3;engineering=3"
 	var/cell_type = /obj/item/stock_parts/cell/crap
-	ratio = 0.30 //<30%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
+	ratio = 0.25 //<30%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
 	coefficient_base = 1.1 //determina que porcentje de energia, del a bateria interna, se pierde al inducir, 10%
 	mintransfer = 50 //determina el valor minimo de la energia inducida
 	on = TRUE
@@ -332,7 +332,7 @@
 
 /obj/item/inducer/apc/afterattack(obj/machinery/power/apc/A as obj, mob/user as mob, flag, params)
 	if(!flag)
-		return
+		return FALSE
 
 	if(user.a_intent == INTENT_HARM)
 		return FALSE

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -154,8 +154,7 @@
 
 	if(istype(A, /obj))
 		if(istype(A, /obj/machinery/power/apc))
-			// power_use * coefficient = 20*100 > 1000 = CELLRATE -> los inducers no aumentan la cantidad de energia que hay en la estacion
-			coefficient = 1000
+			coefficient = 1000 * coefficient_base
 		O = A
 	if(C)
 		var/done_any = FALSE

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -280,8 +280,8 @@
 	icon_state = "inducer-engi"
 	item_state = "inducer-engi"
 	origin_tech = "powerstorage=4;materials=3;engineering=3"
-	var/cell_type = /obj/item/stock_parts/cell/crap
-	ratio = 0.25 //<30%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
+	var/cell_type = /obj/item/stock_parts/cell
+	ratio = 0.15 //<30%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
 	coefficient_base = 1.1 //determina que porcentje de energia, del a bateria interna, se pierde al inducir, 10%
 	mintransfer = 50 //determina el valor minimo de la energia inducida
 	on = TRUE
@@ -290,7 +290,9 @@
 	. = ..()
 	if(!cell && cell_type)
 		cell = new cell_type
+		cell.charge = 500
 	START_PROCESSING(SSobj, src)
+	cell.update_icon()
 	update_icon()
 
 /obj/item/inducer/apc/attack_self(mob/user)

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -9,27 +9,70 @@
 	origin_tech = "powerstorage=4;materials=4;engineering=4"
 	force = 7
 	flags =  CONDUCT
-	var/opened = TRUE
 	var/obj/item/stock_parts/cell/cell
 	var/powertransfer = null
-	var/ratio = 0.12 //determina que porcentaje de la bateria objetivo de la induccion es recargado, 12%
+	var/ratio = 0.15 //<15%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
 	var/coefficient_base = 1.1 //determina que porcentje de energia, del a bateria interna, se pierde al inducir, 10%
 	var/mintransfer = 250 //determina el valor minimo de la energia inducida
-	var/recharging = FALSE
 	var/on = FALSE
+	var/recharging = FALSE
+
+/obj/item/inducer/attack_obj(obj/O, mob/living/carbon/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(recharging)
+		return
+	if(afterattack(O, user))
+		return
+	return ..()
+
+/obj/item/inducer/emp_act(severity)
+	. = ..()
+	if(cell)
+		cell.emp_act(severity)
+
+/obj/item/inducer/proc/induce(obj/item/stock_parts/cell/target, coefficient)
+	var/promcharge = (target.maxcharge + cell.maxcharge)/2
+	powertransfer = max(mintransfer, (promcharge * ratio))
+	var/totransfer = min((cell.charge/coefficient), powertransfer)
+	var/transferred = target.give(totransfer)
+	cell.use(transferred * coefficient)
+	cell.update_icon()
+	target.update_icon()
+
+/obj/item/inducer/proc/invertinduce(obj/item/stock_parts/cell/target, coefficient)
+	var/promcharge = (target.maxcharge + cell.maxcharge)/2
+	powertransfer = max(mintransfer, (promcharge * ratio))
+	var/totransfer = min((target.charge/coefficient), powertransfer)
+	var/transferred = cell.give(totransfer)
+	target.use(transferred * coefficient)
+	cell.update_icon()
+	target.update_icon()
+
+/obj/item/inducer/attack(mob/M, mob/user)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(recharging)
+		return
+	if(afterattack(M, user))
+		return
+	return ..()
+
+/obj/item/inducer/sci
 	var/powered = FALSE
 	var/coeff = 17 //multiplica al consumo energetico de la estacion
+	var/opened = TRUE
 
-/obj/item/inducer/Initialize()
+/obj/item/inducer/sci/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj, src)
 	update_icon()
 
-/obj/item/inducer/Destroy()
+/obj/item/inducer/sci/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/inducer/process()
+/obj/item/inducer/sci/process()
 	if(!on)
 		return
 	if(opened)
@@ -60,23 +103,10 @@
 			cell.update_icon()
 	update_icon()
 
-/obj/item/inducer/proc/induce(obj/item/stock_parts/cell/target, coefficient)
-	powertransfer = max(mintransfer, (target.maxcharge * ratio))
-	var/totransfer = min((cell.charge/coefficient), powertransfer)
-	var/transferred = target.give(totransfer)
-	cell.use(transferred * coefficient)
-	cell.update_icon()
-	target.update_icon()
-
-/obj/item/inducer/get_cell()
+/obj/item/inducer/sci/get_cell()
 	return cell
 
-/obj/item/inducer/emp_act(severity)
-	. = ..()
-	if(cell)
-		cell.emp_act(severity)
-
-/obj/item/inducer/attackby(obj/item/W, mob/user)
+/obj/item/inducer/sci/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/screwdriver))
 		playsound(loc, W.usesound, 100, 1)
 		if(!opened)
@@ -108,7 +138,7 @@
 
 	return ..()
 
-/obj/item/inducer/afterattack(atom/movable/A as mob|obj, mob/user as mob, flag, params)
+/obj/item/inducer/sci/afterattack(atom/movable/A as mob|obj, mob/user as mob, flag, params)
 	if(user.a_intent == INTENT_HARM)
 		return FALSE
 
@@ -182,25 +212,7 @@
 		return TRUE
 	recharging = FALSE
 
-/obj/item/inducer/attack(mob/M, mob/user)
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	if(recharging)
-		return
-	if(afterattack(M, user))
-		return
-	return ..()
-
-/obj/item/inducer/attack_obj(obj/O, mob/living/carbon/user)
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	if(recharging)
-		return
-	if(afterattack(O, user))
-		return
-	return ..()
-
-/obj/item/inducer/attack_self(mob/user)
+/obj/item/inducer/sci/attack_self(mob/user)
 	if(!opened || (opened && !cell))
 		on = !on
 		if(on)
@@ -217,6 +229,10 @@
 			playsound(get_turf(user), 'sound/magic/lightningshock.ogg', 50, 1, -1)
 			new/obj/effect/temp_visual/revenant/cracks(user.loc)
 			to_chat(user, "<span class='warning'>[src] electrocutes you!</span>")
+			if(ishuman(user))
+				var/mob/living/carbon/human/H = user
+				if(H.get_int_organ(/obj/item/organ/internal/cell) && H.nutrition < 450)
+					H.set_nutrition(min(H.nutrition + 50, 450))
 			return
 	if(opened && cell)
 		user.visible_message("[user] removes [cell] from [src]!","<span class='notice'>You remove [cell].</span>")
@@ -225,7 +241,7 @@
 		cell = null
 		update_icon()
 
-/obj/item/inducer/examine(mob/living/M)
+/obj/item/inducer/sci/examine(mob/living/M)
 	..()
 	if(on)
 		to_chat(M,"<span class='notice'>the self charge is on.</span>")
@@ -238,7 +254,7 @@
 	if(opened)
 		to_chat(M,"<span class='notice'>Its battery compartment is open.</span>")
 
-/obj/item/inducer/update_icon()
+/obj/item/inducer/sci/update_icon()
 	cut_overlays()
 	if(!cell)
 		add_overlay("inducer-unpowered")
@@ -258,35 +274,26 @@
 		if(opened)
 			add_overlay("inducer-bat")
 
-/obj/item/inducerapc
+/obj/item/inducer/apc
 	name = "APC's inducer"
 	desc = "A tool for inductively charging APC's."
-	icon = 'icons/hispania/obj/tools.dmi'
 	icon_state = "inducer-engi"
 	item_state = "inducer-engi"
-	lefthand_file = 'icons/hispania/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/hispania/mob/inhands/equipment/tools_righthand.dmi'
 	origin_tech = "powerstorage=4;materials=3;engineering=3"
-	force = 7
-	flags =  CONDUCT
-	var/opened = FALSE
 	var/cell_type = /obj/item/stock_parts/cell/crap
-	var/obj/item/stock_parts/cell/cell
-	var/powertransfer = null
-	var/ratio = 0.25 //determina que porcentaje de la bateria objetivo de la induccion es recargado, 12%
-	var/coefficient_base = 1.1 //determina que porcentje de energia, del a bateria interna, se pierde al inducir, 10%
-	var/mintransfer = 50 //determina el valor minimo de la energia inducida
-	var/recharging = FALSE
-	var/on = TRUE
+	ratio = 0.30 //<30%> determina que porcentaje de la carga maxima promedio recargada (la mitad de la del objetivo entre la interna)
+	coefficient_base = 1.1 //determina que porcentje de energia, del a bateria interna, se pierde al inducir, 10%
+	mintransfer = 50 //determina el valor minimo de la energia inducida
+	on = TRUE
 
-/obj/item/inducerapc/Initialize()
+/obj/item/inducer/apc/Initialize()
 	. = ..()
 	if(!cell && cell_type)
 		cell = new cell_type
 	START_PROCESSING(SSobj, src)
 	update_icon()
 
-/obj/item/inducerapc/attack_self(mob/user)
+/obj/item/inducer/apc/attack_self(mob/user)
 	on = !on
 	if(on)
 		to_chat(user,"<span class='notice'>switched to emission mode.</span>")
@@ -294,7 +301,7 @@
 		to_chat(user,"<span class='notice'>switched to suction mode.</span>")
 	update_icon()
 
-/obj/item/inducerapc/update_icon()
+/obj/item/inducer/apc/update_icon()
 	cut_overlays()
 	if(on)
 		if(cell.percent() >= 100)
@@ -304,28 +311,10 @@
 	else
 		add_overlay("inducer-unpowered")
 
-/obj/item/inducerapc/attack(mob/M, mob/user)
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	if(recharging)
-		return
-	if(afterattack(M, user))
-		return
-	return ..()
+/obj/item/inducer/apc/proc/DisplayPower(powerused)
+	return "[powerused] kW"
 
-/obj/item/inducerapc/attack_obj(obj/O, mob/living/carbon/user)
-	if(user.a_intent == INTENT_HARM)
-		return ..()
-	if(recharging)
-		return
-	if(afterattack(O, user))
-		return
-	return ..()
-
-/obj/item/inducerapc/proc/DisplayPower(powerused)
-		return "[powerused] kW"
-
-/obj/item/inducerapc/examine(mob/living/M)
+/obj/item/inducer/apc/examine(mob/living/M)
 	..()
 	if(on)
 		to_chat(M,"<span class='notice'>Emission mode is activate.</span>")
@@ -336,34 +325,12 @@
 	else
 		to_chat(M,"<span class='notice'>Its display is dark.</span>")
 
-/obj/item/inducerapc/proc/induce(obj/item/stock_parts/cell/target, coefficient)
-	powertransfer = max(mintransfer, (cell.maxcharge * ratio))
-	var/totransfer = min((cell.charge/coefficient), powertransfer)
-	var/transferred = target.give(totransfer)
-	cell.use(transferred * coefficient)
-	cell.update_icon()
-	target.update_icon()
-
-/obj/item/inducerapc/proc/invertinduce(obj/item/stock_parts/cell/target, coefficient)
-	powertransfer = max(mintransfer, (cell.maxcharge * ratio))
-	var/totransfer = min((target.charge/coefficient), powertransfer)
-	var/transferred = cell.give(totransfer)
-	target.use(transferred * coefficient)
-	cell.update_icon()
-	target.update_icon()
-
-/obj/item/inducerapc/emp_act(severity)
-	. = ..()
-	if(cell)
-		cell.emp_act(severity)
-
-/obj/item/inducerapc/attackby(obj/item/W, mob/user)
+/obj/item/inducer/apc/attackby(obj/item/W, mob/user)
 	if(afterattack(W, user))
 		return
-
 	return ..()
 
-/obj/item/inducerapc/afterattack(obj/machinery/power/apc/A as obj, mob/user as mob, flag, params)
+/obj/item/inducer/apc/afterattack(obj/machinery/power/apc/A as obj, mob/user as mob, flag, params)
 	if(!flag)
 		return
 

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -154,7 +154,7 @@
 
 	if(istype(A, /obj))
 		if(istype(A, /obj/machinery/power/apc))
-			coefficient = 1000 * coefficient_base
+			coefficient = GLOB.CELLRATE * coefficient_base
 		O = A
 	if(C)
 		var/done_any = FALSE

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -184,7 +184,7 @@
 
 	if(istype(A, /obj))
 		if(istype(A, /obj/machinery/power/apc))
-			coefficient = GLOB.CELLRATE * coefficient_base
+			coefficient = coefficient_base/GLOB.CELLRATE
 		O = A
 	if(C)
 		var/done_any = FALSE

--- a/code/HISPANIA/game/objects/items/inducer.dm
+++ b/code/HISPANIA/game/objects/items/inducer.dm
@@ -312,7 +312,7 @@
 		add_overlay("inducer-unpowered")
 
 /obj/item/inducer/apc/proc/DisplayPower(powerused)
-	return "[powerused] kW"
+	return "[powerused/2] kW"
 
 /obj/item/inducer/apc/examine(mob/living/M)
 	..()

--- a/code/HISPANIA/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/HISPANIA/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,6 +1,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical/New()
 	..()
-	new /obj/item/inducerapc(src)
-	new /obj/item/inducerapc(src)
+	new /obj/item/inducer/apc(src)
+	new /obj/item/inducer/apc(src)
 	new/obj/item/clothing/glasses/meson/engine/tray(src)
 	new/obj/item/clothing/glasses/meson/engine/tray(src)

--- a/code/HISPANIA/modules/research/designs/power_designs.dm
+++ b/code/HISPANIA/modules/research/designs/power_designs.dm
@@ -5,7 +5,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	req_tech = list("powerstorage" = 5, "materials" = 5, "engineering" = 5)
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_SILVER=1000, MAT_GOLD = 1500)
-	build_path = /obj/item/inducer
+	build_path = /obj/item/inducer/sci
 	category = list("Misc","Power")
 
 /datum/design/xenobluecellmaker

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -140,7 +140,7 @@
 				R.heal_overall_damage(repairs, repairs)
 			if(R.cell)
 				var/transfered = R.cell.give(recharge_speed)
-				use_power(transfered * 12)
+				use_power(transfered * 1.6)
 		else if(ishuman(occupant))
 			var/mob/living/carbon/human/H = occupant
 			if(H.get_int_organ(/obj/item/organ/internal/cell) && H.nutrition < 450)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1162,7 +1162,7 @@
 				cell.minorrecharging = TRUE
 				addtimer(CALLBACK(cell, /obj/item/stock_parts/cell/proc/minorrecharge), 20 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		if(newcell)
-			cell.charge = cell.charge/GLOB.CELLRATE
+			cell.charge = cell.charge * GLOB.CELLRATE
 			newcell = FALSE
 			cell.update_icon()
 	if(debug)


### PR DESCRIPTION
## What Does This PR Do

fixea el gasto energetico del rechargestation y ahora los sci inducers recargan menos a los apc.

## Why It's Good For The Game
Ya que tenemos los engi inducers darle gastos energeticos aumentados a los rechargestation no tiene sentido.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: los sci inducers son aun peores para recargar apcs
tweak: los rechargestation consumen menos energia de los apcs.
tweak: los inducers ahora alimentan un poco a los ipc que se electrocutan al sacar la bateria
tweak: los apc inducers inician con una mejor bateria pero tienen la misma carga inicial.
fix: los apc ya no recargan las baterias que les incertas
/:cl:

