### PR TITLE
Balance MouthCover(?) -> Cant eat or drink

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1025,7 +1025,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 		var/covered = 0
 		var/snowflek = 0
 		if(wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH))
-			if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman) || istype(head, /obj/item/clothing/mask/breath/vox)) //Asi los plamaman y vox no mueren de hambre
+			if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman) || istype(wear_mask, /obj/item/clothing/mask/breath/vox)) //Asi los plamaman y vox no mueren de hambre
 				snowflek = 1
 			else
 				covered = 1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1017,6 +1017,31 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 /mob/living/carbon/proc/eat(var/obj/item/reagent_containers/food/toEat, mob/user, var/bitesize_override)
 	if(!istype(toEat))
 		return 0
+	///Validacion de mascara INICIO by Spircen
+	var/skip_check = 0
+	if(istype(toEat, /obj/item/reagent_containers/food/pill/patch)) //Permite aplicar parches, por alguna razon son comida
+		skip_check = 1
+	if(!skip_check)
+		var/covered = 0
+		var/snowflek = 0
+		if(wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH))
+			if(istype(head, /obj/item/clothing/head/helmet/space/plasmaman) || istype(head, /obj/item/clothing/mask/breath/vox)) //Asi los plamaman y vox no mueren de hambre
+				snowflek = 1
+			else
+				covered = 1
+		if(wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH) && !wear_mask.mask_adjusted)
+			if(snowflek)
+				if(!istype(wear_mask, /obj/item/clothing/mask/breath))
+					covered = 1
+			else
+				covered = 1
+		if(covered)
+			if(user == src)
+				to_chat(user, "<span class='warning'>Your mouth is covered, preventing you from ingesting [toEat]!</span>")
+			else
+				visible_message("<span class='warning'>[user] pushes [toEat] into the face of [src], but their mouth is covered!</span>")
+			return 0
+	////Validacion de mascara FINAL by Spircen
 	var/fullness = nutrition + 10
 	if(istype(toEat, /obj/item/reagent_containers/food/snacks))
 		for(var/datum/reagent/consumable/C in reagents.reagent_list) //we add the nutrition value of what we're currently digesting

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1021,6 +1021,9 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, list(/obj/machinery/atmospherics/unary/ven
 	var/skip_check = 0
 	if(istype(toEat, /obj/item/reagent_containers/food/pill/patch)) //Permite aplicar parches, por alguna razon son comida
 		skip_check = 1
+	if(istype(toEat, /obj/item/reagent_containers/food/pill)) //Permite aplicar pildoras pero envia un mensaje
+		to_chat(user, "<span class='notice'>You push the pill through a small place between the mask and the mouth.</span>")
+		skip_check = 1
 	if(!skip_check)
 		var/covered = 0
 		var/snowflek = 0


### PR DESCRIPTION
## What Does This PR Do
Agrega una validación en la cual si tu boca esta cubierta no puedes comer o beber. Esto no aplica para vox o plasmaman por razones de balance a la par que los parches tampoco son afectados. 

## Why It's Good For The Game
Me parece un balance considerablemente justo, esto se hace a partir del uso de las FLAGS que posee la ropa esto quiere decir que si desajustas una mascara obviamente te dejara comer en cuanto la retirar de tu rostro. Haciendo que esa funcionalidad tenga algo de uso. No, esto no quiere decir que si tienes un cigarro en la boca no puedes comer. 

Referente a la pregunta de ¿Y los spacesuits por que no entran? Pues es facil, aqui hay todo un archivo entero de una mision de [Apollo 15](https://www.hq.nasa.gov/alsj/alsj-DrinkFood.html) donde muestra un hardsuit no bloquea la capacidad de beber o comer.

## Images of changes

               Vox y Plasmaman pueden comer sin problemas y ser alimentados
![image](https://user-images.githubusercontent.com/46639834/79677758-256caa00-81ba-11ea-8c21-dd47b866e650.png)

                                                         Sad Boy
![image](https://user-images.githubusercontent.com/46639834/79677772-43d2a580-81ba-11ea-9a7a-6233b219396c.png)


## Changelog
:cl:
tweak: MouthCover -> Cant eat or drink
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
