### PR TITLE
Lavaland modkit designs

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -133,6 +133,7 @@
 	name = "Kinetic Accelerator Offensive Mining Explosion Mod"
 	desc = "A device which causes kinetic accelerators to fire AoE blasts that destroy rock and damage creatures."
 	id = "hyperaoemod"
+	req_tech = list("materials" = 7, "powerstorage" = 6, "engineering" = 5, "magnets" = 8, "combat" = 5)
 	materials = list(MAT_METAL = 7000, MAT_GLASS = 3000, MAT_SILVER= 3000, MAT_GOLD = 3000, MAT_DIAMOND = 4000)
 	build_path = /obj/item/borg/upgrade/modkit/aoe/turfs/andmobs
 	category = list("Mining", "Cyborg Upgrade Modules")
@@ -141,6 +142,7 @@
 	name = "Kinetic Accelerator Rapid Repeater Mod"
 	desc = "A device which greatly reduces a kinetic accelerator's cooldown on striking a living target or rock, but greatly increases its base cooldown."
 	id = "repeatermod"
+	req_tech = list("materials" = 7, "powerstorage" = 6, "engineering" = 5, "magnets" = 8, "combat" = 5)
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_URANIUM = 8000, MAT_BLUESPACE = 2000)
 	build_path = /obj/item/borg/upgrade/modkit/cooldown/repeater
 	category = list("Mining", "Cyborg Upgrade Modules")
@@ -149,6 +151,7 @@
 	name = "Kinetic Accelerator Resonator Blast Mod"
 	desc = "A device which causes kinetic accelerators to fire shots that leave and detonate resonator blasts."
 	id = "resonatormod"
+	req_tech = list("materials" = 7, "powerstorage" = 6, "engineering" = 5, "magnets" = 8, "combat" = 5)
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 5000, MAT_SILVER= 5000, MAT_URANIUM = 5000)
 	build_path = /obj/item/borg/upgrade/modkit/resonator_blasts
 	category = list("Mining", "Cyborg Upgrade Modules")
@@ -157,6 +160,7 @@
 	name = "Kinetic Accelerator Death Syphon Mod"
 	desc = "A device which causes kinetic accelerators to permanently gain damage against creature types killed with it."
 	id = "bountymod"
+	req_tech = list("materials" = 7, "powerstorage" = 6, "engineering" = 5, "magnets" = 8, "combat" = 5)
 	materials = list(MAT_METAL = 4000, MAT_SILVER = 4000, MAT_GOLD = 4000, MAT_BLUESPACE = 4000)
 	reagents_list = list("blood" = 40)
 	build_path = /obj/item/borg/upgrade/modkit/bounty


### PR DESCRIPTION
## What Does This PR Do
ahora los diseños de los modkits de lavaland no se pueden encontrar normalemtne en rnd a menos que  se llegue a tecnologia 8 en electromagnetismo. Esto evita que se creen esos modkits especiales todas las partidas. La unica forma de verlos serán si los traen de lavaland o mediante el uso de anomaly cores para rnd.

## Changelog
:cl:
tweak: ahora los diseños de los modkits de lavaland requieren tecnologia 8 para ser desbloeados en el protolathe (antes estaban desde el inicio)
/:cl:

