### PR TITLE
Tweak Shaft Miner Base Limit

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -171,7 +171,7 @@
 	title = "Shaft Miner"
 	flag = JOB_MINER
 	department_flag = JOBCAT_SUPPORT
-	total_positions = 6
+	total_positions = 4
 	spawn_positions = 8
 	is_supply = 1
 	supervisors = "the quartermaster"


### PR DESCRIPTION
## What Does This PR Do
Baja el limite de mineros de 6 a 4

## Why It's Good For The Game
Actualmente hay rondas donde cargo esta repleto y con nuestra playerbase no nos podemos dar el privilegio de poder llenar cargo con tanto personal, esto puede hacer que el QM preste mas atención y cuide a sus cuatro mineros.  Igualmente un Capitán o HoP siempre puede ampliar la cantidad de personal en este departamento.

## Images of changes

                               Spoopy Stuff
![image](https://user-images.githubusercontent.com/46639834/79733956-8af48f80-82bb-11ea-91e9-2f2ab216e60a.png)


## Changelog
:cl:
tweak: Shaft Miner Limit
/:cl:
