### PR TITLE
fix Welding experimental

### DIFF
--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -131,7 +131,7 @@
 
 /obj/item/weldingtool/proc/remove_fuel(amount) //NB: doesn't check if we have enough fuel, it just removes however much is left if there's not enough
 	reagents.remove_reagent("fuel", amount * requires_fuel)
-	if(!GET_FUEL)
+	if(GET_FUEL < 1)
 		toggle_welder(TRUE)
 
 /obj/item/weldingtool/refill(mob/user, atom/A, amount)

--- a/code/game/objects/items/tools/welder.dm
+++ b/code/game/objects/items/tools/welder.dm
@@ -36,7 +36,7 @@
 	create_reagents(maximum_fuel)
 	reagents.add_reagent("fuel", maximum_fuel)
 	if(refills_over_time)
-		reagents.reagents_generated_per_cycle += list("fuel" = 1)
+		reagents.reagents_generated_per_cycle += list("fuel" = 0.2)
 	update_icon()
 
 /obj/item/weldingtool/examine(mob/user)
@@ -61,7 +61,7 @@
 		to_chat(user, "<span class='notice'>You switch off [src].</span>")
 		toggle_welder()
 		return
-	else if(GET_FUEL) //The welder is off, but we need to check if there is fuel in the tank
+	else if(GET_FUEL > 1) //The welder is off, but we need to check if there is fuel in the tank
 		to_chat(user, "<span class='notice'>You switch on [src].</span>")
 		toggle_welder()
 	else //The welder is off and unfuelled


### PR DESCRIPTION
## What Does This PR Do
si un wlding tool tiene menos de uno de fuel se apaga.

## Why It's Good For The Game
si un wlding tool tiene menos de 1 de fuel entonces no deberia funcionar.



## Changelog
:cl:
tweak: los welding tool se apagan si tienen menos de 1 de fuel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
