### PR TITLE
RnD rebalance v2

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -79189,8 +79189,6 @@
 	},
 /obj/item/stack/sheet/metal{
 	amount = 13;
-	step_x = 0;
-	step_y = 0
 	},
 /obj/item/stack/sheet/glass{
 	amount = 13

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -27348,6 +27348,12 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
+/obj/item/stack/sheet/metal{
+	amount = 38
+	},
+/obj/item/stack/sheet/glass{
+	amount = 13
+	},
 /obj/item/multitool,
 /obj/item/multitool,
 /turf/simulated/floor/plasteel,
@@ -45980,7 +45986,6 @@
 /obj/item/stack/sheet/metal{
 	amount = 50
 	},
-/obj/item/clothing/glasses/welding,
 /obj/machinery/door_control{
 	id = "rdlab";
 	name = "Research and Development Lab Shutters Control";
@@ -45988,6 +45993,15 @@
 	pixel_y = 0;
 	req_access_txt = "47"
 	},
+/obj/item/stack/sheet/glass{
+	amount = 13;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 13
+	},
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
@@ -79172,6 +79186,14 @@
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
+	},
+/obj/item/stack/sheet/metal{
+	amount = 13;
+	step_x = 0;
+	step_y = 0
+	},
+/obj/item/stack/sheet/glass{
+	amount = 13
 	},
 /obj/item/pod_paint_bucket,
 /turf/simulated/floor/plasteel,

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -65,6 +65,7 @@
 #define MAT_PLASTIC			"$plastic"
 //The amount of materials you get from a sheet of mineral like iron/diamond/glass etc
 #define MINERAL_MATERIAL_AMOUNT 1500
+
 //The maximum size of a stack object.
 #define MAX_STACK_SIZE 50
 //maximum amount of cable in a coil

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -64,7 +64,7 @@
 #define MAT_BIOMASS			"$biomass"
 #define MAT_PLASTIC			"$plastic"
 //The amount of materials you get from a sheet of mineral like iron/diamond/glass etc
-#define MINERAL_MATERIAL_AMOUNT 2000
+#define MINERAL_MATERIAL_AMOUNT 1500
 //The maximum size of a stack object.
 #define MAX_STACK_SIZE 50
 //maximum amount of cable in a coil

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -32,13 +32,13 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 // Who likes #defines?
 // I don't!
 // but I gotta add 'em anyways because we have a bias against /const statements for some reason
-#define TECH_UPDATE_DELAY 50
-#define DESIGN_UPDATE_DELAY 50
+#define TECH_UPDATE_DELAY 40
+#define DESIGN_UPDATE_DELAY 40
 #define PROTOLATHE_CONSTRUCT_DELAY 32
-#define SYNC_RESEARCH_DELAY 30
+#define SYNC_RESEARCH_DELAY 25
 #define DECONSTRUCT_DELAY 24
-#define SYNC_DEVICE_DELAY 20
-#define RESET_RESEARCH_DELAY 20
+#define SYNC_DEVICE_DELAY 15
+#define RESET_RESEARCH_DELAY 15
 #define IMPRINTER_DELAY 16
 
 /obj/machinery/computer/rdconsole

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-secret
+extended

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+secret


### PR DESCRIPTION
## What Does This PR Do
1. Reduce la cantidad de materiales por shett en un 25%
3. Aumentará la cantidad de materiales iniciales en robotica mecainica y rnd para que el inicio de la ronda permanezca igual.
2. cambios varios para compensar esta perdida con otra cosa, por ejemplo reducir los tiempos muertos de las consolas de RnD.

## Why It's Good For The Game
Porque siempre me dicen que un solo minero da abasto para cubrir todas las necesidades de materiales de la estcion, Esto ayudará a justificar la gran cantidad de mineros que tenemos, y hará que todos tengan que pensarlo dos veces antes de imprimir cosas inecesarias.


## Changelog
:cl:
tweak: se obtiene menos cantidad de minerales por shett
tweak: las consolas de rnd son más rapidas
tweak: aumenta la cantidad de minerales iniciales en mecanica, rnd y robotica
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
