### PR TITLE
[Map Changes] Arrivals and Arrivals Public Places (Cyberiad)

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -16368,9 +16368,8 @@
 /turf/space,
 /area/space/nearstation)
 "aBy" = (
-/obj/effect/landmark/damageturf,
 /turf/simulated/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/fpmaint2)
 "aBz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -16577,11 +16576,6 @@
 	icon_state = "dark"
 	},
 /area/security/execution)
-"aBT" = (
-/obj/item/paper/crumpled,
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel/airless,
-/area/space/nearstation)
 "aBU" = (
 /obj/machinery/light_construct/small{
 	dir = 8
@@ -16625,10 +16619,6 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"aBZ" = (
-/obj/effect/landmark/damageturf,
-/turf/simulated/floor/plasteel/airless,
-/area/space/nearstation)
 "aCa" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -19157,7 +19147,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aHa" = (
-/obj/machinery/vending/coffee,
+/obj/structure/closet/lasertag/red,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aHb" = (
@@ -19739,6 +19729,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/closet/lasertag/red,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aIv" = (
@@ -20240,11 +20231,11 @@
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aJA" = (
-/obj/structure/closet/lasertag/red,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/structure/closet/lasertag/blue,
 /turf/simulated/floor/carpet/arcade,
 /area/crew_quarters/arcade)
 "aJB" = (
@@ -22743,11 +22734,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint2)
-"aOX" = (
-/obj/structure/lattice,
-/obj/structure/closet,
-/turf/space,
-/area/space/nearstation)
 "aOY" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -24633,7 +24619,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -24786,26 +24772,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/starboard/east)
-"aSW" = (
-/obj/structure/chair/comfy/beige,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
-"aSX" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
 "aSY" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/item/radio/intercom{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aSZ" = (
 /obj/item/radio/intercom{
@@ -25049,7 +25020,7 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25067,7 +25038,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/item/seeds/ricinus,
+/obj/item/seeds/poppy,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25075,7 +25048,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25450,10 +25424,8 @@
 	c_tag = "Arrivals North";
 	dir = 1
 	},
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
 /obj/effect/decal/warning_stripes/south,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "aUo" = (
@@ -25487,7 +25459,7 @@
 /area/hallway/primary/fore)
 "aUr" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25496,7 +25468,8 @@
 	pixel_x = -5;
 	pixel_y = 30
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25517,7 +25490,7 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25535,7 +25508,7 @@
 /area/crew_quarters/dorms)
 "aUx" = (
 /obj/machinery/seed_extractor,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25558,7 +25531,7 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25798,7 +25771,8 @@
 	},
 /area/hallway/secondary/entry)
 "aVe" = (
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -25832,7 +25806,8 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -26246,7 +26221,7 @@
 /area/maintenance/fpmaint2)
 "aVM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -26319,12 +26294,9 @@
 /turf/simulated/floor/wood,
 /area/clownoffice)
 "aVV" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f6";
-	icon_state = "swall_f6";
-	dir = 2
-	},
+/obj/structure/window/full/shuttle,
+/obj/structure/grille,
+/turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aVW" = (
 /turf/space,
@@ -26466,7 +26438,7 @@
 /area/storage/primary)
 "aWj" = (
 /obj/machinery/biogenerator,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -27008,10 +26980,11 @@
 /turf/simulated/floor/plating,
 /area/chapel/main)
 "aXm" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "swall11";
-	dir = 2
-	},
+/obj/structure/table/reinforced,
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/item/reagent_containers/food/snacks/chips,
+/obj/item/reagent_containers/food/drinks/cans/cola,
+/turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aXn" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -27059,42 +27032,37 @@
 	},
 /area/hallway/secondary/entry)
 "aXr" = (
-/obj/effect/landmark{
-	name = "HONKsquad"
-	},
-/obj/structure/closet/walllocker/emerglocker/north,
+/obj/structure/closet/firecloset,
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aXs" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aXt" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aXu" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
-"aXv" = (
-/obj/structure/closet/wardrobe/xenos,
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
-"aXw" = (
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aXx" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
-"aXy" = (
-/obj/structure/closet/walllocker/emerglocker/north,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 28;
+	req_access_txt = "0"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
@@ -27179,7 +27147,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -27190,13 +27158,17 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
 "aXI" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/plasteel,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -27208,7 +27180,7 @@
 	pixel_x = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -27849,16 +27821,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"aYL" = (
-/obj/machinery/light{
-	dir = 1;
-	on = 1
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
 "aYM" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
@@ -27867,10 +27829,13 @@
 	},
 /area/shuttle/arrival/station)
 "aYN" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "swall3";
-	dir = 2
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
+/obj/effect/landmark{
+	name = "HONKsquad"
+	},
+/turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "aYO" = (
 /obj/structure/disposalpipe/segment{
@@ -28006,7 +27971,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -28042,6 +28007,7 @@
 	},
 /obj/item/stack/tape_roll,
 /obj/item/stack/tape_roll,
+/obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "aZf" = (
@@ -28087,7 +28053,7 @@
 /obj/item/crowbar,
 /obj/item/plant_analyzer,
 /obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -28122,7 +28088,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -28434,7 +28400,7 @@
 	c_tag = "Garden";
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -28451,7 +28417,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -28883,11 +28849,6 @@
 	icon_state = "swallc3"
 	},
 /area/shuttle/escape)
-"baZ" = (
-/obj/structure/window/full/shuttle,
-/obj/structure/grille,
-/turf/simulated/shuttle/plating,
-/area/shuttle/arrival/station)
 "bba" = (
 /obj/effect/landmark{
 	name = "Observer-Start"
@@ -29063,7 +29024,6 @@
 /turf/simulated/floor/plasteel,
 /area/storage/primary)
 "bbm" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start{
 	name = "Civilian"
 	},
@@ -29682,13 +29642,6 @@
 	icon_state = "grimy"
 	},
 /area/chapel/office)
-"bcr" = (
-/turf/simulated/shuttle/floor,
-/turf/simulated/shuttle/wall{
-	icon_state = "swall_f10";
-	dir = 2
-	},
-/area/shuttle/arrival/station)
 "bcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29885,13 +29838,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
-"bcN" = (
-/obj/machinery/light,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
 "bcO" = (
 /obj/item/radio/intercom{
 	frequency = 1459;
@@ -29932,10 +29878,7 @@
 	name = "station intercom (General)";
 	pixel_x = 28
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
-	},
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -30217,10 +30160,7 @@
 /area/mimeoffice)
 "bdu" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
-	},
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -30258,10 +30198,7 @@
 	icon_state = "tube1";
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 4
-	},
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -30366,7 +30303,7 @@
 /obj/effect/landmark/start{
 	name = "Civilian"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -30746,14 +30683,6 @@
 	icon_state = "dark"
 	},
 /area/ai_monitored/storage/eva)
-"beh" = (
-/turf/space,
-/turf/simulated/shuttle/wall{
-	tag = "icon-swall_f5";
-	icon_state = "swall_f5";
-	dir = 2
-	},
-/area/shuttle/arrival/station)
 "bei" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -30821,13 +30750,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/chapel/office)
-"bes" = (
-/obj/item/radio/intercom{
-	name = "station intercom (General)";
-	pixel_y = -28
-	},
-/turf/simulated/shuttle/floor,
-/area/shuttle/arrival/station)
 "bet" = (
 /obj/structure/chair{
 	dir = 4
@@ -30876,6 +30798,9 @@
 	department = "Arrival Shuttle";
 	name = "Arrival Shuttle Requests Console";
 	pixel_y = -30
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
@@ -30938,7 +30863,13 @@
 	},
 /area/crew_quarters/toilet)
 "beG" = (
-/obj/machinery/light,
+/obj/item/radio/intercom{
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/arrival/station)
 "beH" = (
@@ -31037,7 +30968,7 @@
 /area/hallway/primary/port)
 "beP" = (
 /obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -31046,7 +30977,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -31895,10 +31826,8 @@
 	},
 /area/chapel/main)
 "bgj" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/item/reagent_containers/food/drinks/cans/cola,
-/turf/simulated/floor/carpet,
+/obj/structure/flora/rock/icy,
+/turf/simulated/floor/plating/asteroid/snow/temperature,
 /area/hallway/secondary/entry)
 "bgk" = (
 /obj/machinery/door/firedoor,
@@ -32005,11 +31934,8 @@
 	},
 /area/storage/office)
 "bgt" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards,
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/structure/snowman/built,
+/turf/simulated/floor/plating/asteroid/snow/temperature,
 /area/hallway/secondary/entry)
 "bgu" = (
 /obj/structure/cable{
@@ -32029,11 +31955,6 @@
 	},
 /area/hallway/secondary/entry)
 "bgw" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "station intercom (General)";
-	pixel_y = 25
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -32124,11 +32045,11 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgI" = (
-/obj/item/radio/beacon,
 /obj/machinery/camera{
 	c_tag = "Arrivals South"
 	},
 /obj/effect/decal/warning_stripes/north,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bgJ" = (
@@ -32187,10 +32108,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "green";
-	dir = 8
-	},
+/turf/simulated/floor/grass,
 /area/hallway/secondary/construction{
 	name = "\improper Garden"
 	})
@@ -32410,7 +32328,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bhm" = (
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/plating/asteroid/snow/temperature,
 /area/hallway/secondary/entry)
 "bhn" = (
 /obj/item/stack/sheet/metal{
@@ -32495,12 +32413,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bhv" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/plasteel,
 /area/hallway/secondary/entry)
 "bhw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -32582,6 +32498,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Arrivals"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralcorner";
@@ -33793,10 +33713,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/hydroponics)
-"bjO" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet,
-/area/hallway/secondary/entry)
 "bjP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33925,17 +33841,8 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/port)
 "bkc" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes{
-	pixel_y = 2
-	},
-/obj/item/lighter{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
+/obj/structure/flora/tree/dead,
+/turf/simulated/floor/plating/asteroid/snow/temperature,
 /area/hallway/secondary/entry)
 "bkd" = (
 /obj/machinery/vending/cola,
@@ -35136,14 +35043,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
-"bmo" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "grimy"
-	},
-/area/hallway/secondary/entry)
 "bmp" = (
 /obj/structure/chair/stool,
 /turf/simulated/floor/plasteel{
@@ -35744,6 +35643,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/item/flashlight/flare,
+/obj/item/tank/emergency_oxygen/engi,
+/obj/item/tank/emergency_oxygen/engi,
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
 "bny" = (
@@ -35751,7 +35653,6 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnz" = (
-/obj/item/flashlight/flare,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -35762,6 +35663,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/warning_stripes/white/hollow,
 /turf/simulated/floor/plating,
 /area/storage/emergency2)
 "bnA" = (
@@ -35772,7 +35675,7 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnB" = (
-/obj/machinery/vending/cola,
+/obj/machinery/vending/cart,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bnC" = (
@@ -37132,11 +37035,6 @@
 	dir = 8
 	},
 /obj/structure/closet/wardrobe/white,
-/turf/simulated/floor/plasteel,
-/area/crew_quarters/locker)
-"bqw" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bqx" = (
@@ -39282,6 +39180,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvq" = (
@@ -39304,9 +39203,7 @@
 /area/crew_quarters/locker)
 "bvv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/landmark/start{
-	name = "Civilian"
-	},
+/obj/structure/chair/stool,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bvw" = (
@@ -39639,8 +39536,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey,
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "bwb" = (
@@ -39686,6 +39582,9 @@
 	dir = 10;
 	initialize_directions = 10;
 	level = 1
+	},
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
@@ -42668,10 +42567,7 @@
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
 "bBU" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/dresser,
+/obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -53809,15 +53705,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/quartermaster/office)
-"bVt" = (
-/obj/machinery/vending/cart,
-/obj/effect/turf_decal/tile/brown,
-/turf/simulated/floor/plasteel{
-	tag = "icon-browncorner (EAST)";
-	icon_state = "browncorner";
-	dir = 4
-	},
 /area/quartermaster/office)
 "bVu" = (
 /obj/structure/closet/secure_closet/hop2,
@@ -96339,6 +96226,18 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
+"eST" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "eVK" = (
 /obj/structure/rack,
 /obj/item/storage/box/handcuffs,
@@ -96523,6 +96422,13 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"gpy" = (
+/obj/structure/noticeboard{
+	pixel_x = 32;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "grm" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/vomit,
@@ -96700,6 +96606,13 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/storage)
+"hrq" = (
+/obj/structure/closet/crate/medical,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/tank/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "hsy" = (
 /obj/machinery/atmospherics/pipe/simple/insulated{
 	dir = 4
@@ -96800,6 +96713,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"isZ" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/head/welding,
+/turf/simulated/floor/plasteel,
+/area/storage/primary)
 "itF" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -96998,6 +96917,14 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"jqG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Arrivals"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "juV" = (
 /obj/machinery/vending/cigarette{
 	pixel_x = 0;
@@ -97005,6 +96932,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"jve" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "jyr" = (
 /obj/structure/sign/directions/engineering,
 /turf/simulated/shuttle/wall{
@@ -97091,6 +97024,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"ken" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/item/storage/toolbox/emergency,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "khN" = (
 /obj/structure/sign/greencross,
 /turf/simulated/shuttle/wall{
@@ -97144,6 +97083,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/armoury)
+"kKm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1;
+	on = 1
+	},
+/obj/item/storage/firstaid/regular,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "kMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -97187,6 +97135,16 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"lcj" = (
+/obj/machinery/computer{
+	desc = "You have no idea what all the numbers on the screen means.";
+	name = "Advanced Shuttle System"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "leC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97262,6 +97220,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/qm)
+"lHi" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/primary/port)
+"lKP" = (
+/obj/structure/table,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "lLC" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -97365,6 +97336,7 @@
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/cola,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "mjt" = (
@@ -97374,6 +97346,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"mkE" = (
+/obj/item/radio/beacon,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "mow" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -97419,6 +97395,18 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"myd" = (
+/obj/machinery/hydroponics/soil,
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 0;
+	pixel_y = 28;
+	req_access_txt = "0"
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "mMw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -97481,6 +97469,11 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/tsf)
+"ncq" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/plasteel,
+/area/storage/primary)
 "neF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -97533,6 +97526,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"nuo" = (
+/obj/effect/landmark{
+	name = "JoinLate"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "nCu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -97656,6 +97655,18 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"oBJ" = (
+/obj/effect/landmark{
+	name = "JoinLate"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "oDW" = (
 /obj/structure/sign/restroom,
 /turf/simulated/shuttle/wall{
@@ -97675,6 +97686,14 @@
 	icon_state = "floorgrime"
 	},
 /area/security/armoury)
+"oSU" = (
+/turf/simulated/shuttle/floor,
+/turf/simulated/shuttle/wall{
+	tag = "icon-swall_f10";
+	icon_state = "swall_f10";
+	dir = 2
+	},
+/area/shuttle/arrival/station)
 "oXt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -97756,6 +97775,17 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"pJn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "pNG" = (
 /obj/machinery/computer/shuttle/tsf,
 /turf/simulated/shuttle/floor{
@@ -97781,6 +97811,12 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"pWq" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "pZO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -97918,6 +97954,12 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space/nearstation)
+"qWu" = (
+/obj/effect/landmark/start{
+	name = "Civilian"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "qXN" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -97967,6 +98009,12 @@
 "rgm" = (
 /turf/simulated/floor/carpet,
 /area/maintenance/port)
+"rjZ" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f6";
+	dir = 2
+	},
+/area/shuttle/arrival/station)
 "rvv" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -97976,6 +98024,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
+"rwC" = (
+/obj/structure/chair/sofa/right,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "ryD" = (
@@ -98048,6 +98100,13 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"rPQ" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/turf/simulated/floor/plasteel,
+/area/storage/primary)
 "rSv" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8;
@@ -98056,6 +98115,12 @@
 	},
 /turf/space,
 /area/shuttle/administration)
+"rUV" = (
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
+	dir = 2
+	},
+/area/shuttle/arrival/station)
 "rUY" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98116,6 +98181,16 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/tsf)
+"sqz" = (
+/obj/effect/landmark{
+	name = "HONKsquad"
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
 "ssA" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/shuttle/floor{
@@ -98159,6 +98234,10 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"szE" = (
+/obj/structure/chair/sofa/corner,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "sAy" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
@@ -98204,6 +98283,18 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
+"sEp" = (
+/obj/structure/rack,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plasteel,
+/area/storage/primary)
 "sFt" = (
 /obj/structure/rack{
 	dir = 8;
@@ -98267,6 +98358,12 @@
 	icon_state = "floorgrime"
 	},
 /area/security/armoury)
+"sUF" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/hallway/primary/port)
 "sUK" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -98279,6 +98376,12 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
+"teU" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "tiJ" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plasteel,
@@ -98417,6 +98520,28 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
+"unU" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/walllocker/emerglocker/north{
+	pixel_y = -32
+	},
+/obj/item/camera,
+/turf/simulated/shuttle/floor,
+/area/shuttle/arrival/station)
+"uqw" = (
+/obj/structure/grille,
+/obj/structure/window/full/shuttle{
+	icon_state = "window4"
+	},
+/turf/simulated/shuttle/plating,
+/area/shuttle/arrival/station)
+"uqM" = (
+/turf/space,
+/turf/simulated/shuttle/wall{
+	icon_state = "swall_f5";
+	dir = 2
+	},
+/area/shuttle/arrival/station)
 "urN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -98532,6 +98657,11 @@
 	icon_state = "browncorner"
 	},
 /area/quartermaster/storage)
+"vaf" = (
+/turf/simulated/floor/grass,
+/area/hallway/secondary/construction{
+	name = "\improper Garden"
+	})
 "vgm" = (
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 30
@@ -98632,9 +98762,15 @@
 	tag = "icon-cafeteria (NORTHEAST)"
 	},
 /area/crew_quarters/kitchen)
+"vKZ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Vacant Office"
+	},
+/turf/simulated/floor/wood,
+/area/security/vacantoffice)
 "vLg" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/machinery/computer/security/telescreen/entertainment,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/locker)
 "vLr" = (
@@ -98685,6 +98821,10 @@
 	icon_state = "floor2"
 	},
 /area/shuttle/constructionsite)
+"vVh" = (
+/obj/structure/chair/sofa,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "weQ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -98832,6 +98972,10 @@
 	icon_state = "wall3"
 	},
 /area/shuttle/tsf)
+"xgz" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/locker)
 "xjj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -106826,9 +106970,9 @@ arh
 apr
 aaa
 aaa
-aaa
-aaa
-aaa
+rjZ
+aVV
+rUV
 aaa
 aaa
 aaa
@@ -107082,11 +107226,11 @@ dhh
 arY
 apu
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+rjZ
+aYM
+lcj
+oSU
+rUV
 aaa
 aaa
 aaa
@@ -107340,10 +107484,10 @@ apx
 asK
 aaa
 aVV
-aXp
-baZ
-aXp
-beh
+hrq
+aXu
+hrq
+aVV
 aaa
 aaa
 aab
@@ -107595,13 +107739,13 @@ aZP
 aab
 aab
 aaa
-aaa
-aWa
+rjZ
 aYM
 aXs
-bcr
-bej
-aaa
+aXs
+aXs
+oSU
+uqM
 aaa
 aab
 aab
@@ -107852,13 +107996,13 @@ aSd
 aab
 aLd
 aaa
-aaa
 aVS
-aYL
+kKm
+aXu
 aXs
-bcN
+aXu
+ken
 aVS
-aaa
 aaa
 bjQ
 aab
@@ -108109,13 +108253,13 @@ aSd
 aMs
 aLd
 aaa
-aVV
+aVS
 aXm
 aYN
-aVX
+aXs
 aYN
-aXm
-beh
+unU
+aVS
 aaa
 aLd
 aMs
@@ -108371,7 +108515,7 @@ aXr
 aXz
 aXz
 aXz
-aXz
+aXr
 aVS
 aSd
 aSd
@@ -108625,9 +108769,9 @@ aOQ
 aRU
 aVX
 aXs
-aYZ
-aYZ
-aYZ
+nuo
+nuo
+nuo
 aXs
 aVX
 bgy
@@ -108882,9 +109026,9 @@ aSd
 aSd
 aVS
 aXt
-aXs
-aXs
-aXs
+aXu
+mkE
+aXu
 beG
 aVS
 aSd
@@ -109137,13 +109281,13 @@ aME
 aTo
 aUl
 aSd
-aVS
+aVY
 aXu
+oBJ
+nuo
 aYZ
-aYZ
-aYZ
-bes
-aVS
+aXu
+uqw
 aSd
 bid
 aTo
@@ -109391,11 +109535,11 @@ aOP
 aMs
 aPJ
 aSf
-aSf
+qWu
 aUk
 aSd
 aVY
-aXv
+aXs
 aXs
 bba
 aXs
@@ -109652,11 +109796,11 @@ aSf
 aUn
 aSd
 aVZ
-aXw
+aXu
 aYZ
+nuo
 aYZ
-aYZ
-aXs
+aXu
 aVZ
 aSd
 bjT
@@ -109910,9 +110054,9 @@ aUm
 aSd
 aVS
 aXx
+aXu
 aXs
-aXs
-aXs
+aXu
 bex
 aVS
 aSd
@@ -110166,11 +110310,11 @@ aSd
 aSd
 aSd
 aVS
-aXy
-aYZ
-aYZ
-aYZ
-beG
+aXs
+nuo
+nuo
+nuo
+aXs
 aVS
 aSd
 aSd
@@ -110423,11 +110567,11 @@ aRU
 aOQ
 aRU
 aVX
+sqz
 aXz
 aXz
 aXz
-aXz
-aXz
+sqz
 aVX
 bgy
 aOQ
@@ -111975,7 +112119,7 @@ aSd
 aSd
 aSd
 bre
-bgG
+jqG
 bqr
 bqr
 bqr
@@ -112227,10 +112371,10 @@ aZY
 aVc
 bgw
 bhN
-aSW
+aSd
 bgt
 bkc
-bmo
+aSd
 brk
 bwx
 bqr
@@ -112484,10 +112628,10 @@ aZW
 bcX
 bgu
 bhL
-aSW
+aSd
 bgj
-bjO
-bmo
+bgt
+aSd
 brk
 aSf
 bqr
@@ -112741,10 +112885,10 @@ aZf
 aUt
 aNu
 bhN
-aSX
+aSd
 bhm
-bhm
-aSX
+bkc
+aSd
 brk
 bpF
 bqr
@@ -112998,13 +113142,13 @@ aZa
 aIz
 aNu
 bhN
-aSW
-bhm
-bhm
-bmo
+aSd
+aSd
+aSd
+aSd
 brl
 bss
-bqr
+vKZ
 brU
 brU
 bvn
@@ -113257,8 +113401,8 @@ bgB
 bhO
 aSY
 bhv
-bhv
-aSY
+gpy
+aSf
 brk
 boT
 bqr
@@ -114018,7 +114162,7 @@ aGn
 aPc
 aGn
 aTu
-aUu
+myd
 aUu
 aUu
 aXI
@@ -114277,8 +114421,8 @@ aRA
 aTu
 aUv
 aVe
-aVe
-aVe
+vaf
+jve
 aUr
 aTu
 bgD
@@ -114783,8 +114927,8 @@ aGn
 aKd
 aLm
 aGn
-aBy
-afO
+aHS
+aHS
 aBy
 aGn
 aRB
@@ -114793,11 +114937,11 @@ aUx
 aTA
 aWj
 aXH
-aVe
+teU
 bdu
 bgM
 beP
-bfc
+lHi
 blF
 bfc
 blK
@@ -115040,21 +115184,21 @@ aGn
 aLt
 aMN
 aGn
-afO
-aOX
-aab
+aHS
+aHS
+aHS
 aGn
 aRB
 aTu
 aUs
 aZn
-aVe
-aXH
-aVe
-aVe
-aVe
+vaf
+eST
+vaf
+vaf
+vaf
 beQ
-bgz
+sUF
 bly
 bgz
 blK
@@ -115297,9 +115441,9 @@ aGn
 aLv
 aMP
 aGn
-aBT
-aBy
-aBZ
+aHS
+aHS
+aHS
 aGn
 aRB
 aTu
@@ -115311,7 +115455,7 @@ bae
 bdH
 aVe
 beP
-bgz
+sUF
 bse
 bvd
 bNP
@@ -115563,7 +115707,7 @@ aTu
 aUu
 aUu
 aUu
-aXH
+pJn
 bab
 bdx
 bcQ
@@ -116088,7 +116232,7 @@ bkg
 blM
 bnr
 bnD
-bnD
+eGR
 bvk
 bnD
 bvs
@@ -116602,8 +116746,8 @@ bki
 blM
 bnB
 bnD
-bqx
-bqx
+xgz
+lKP
 bvS
 bvs
 bvs
@@ -116849,7 +116993,7 @@ aUy
 aVi
 aWn
 aXM
-aXQ
+rPQ
 aXQ
 bde
 aVi
@@ -116859,7 +117003,7 @@ bkb
 blM
 bnC
 bnD
-bqw
+xgz
 bqx
 bvZ
 bzU
@@ -117106,7 +117250,7 @@ aUy
 aVi
 aWm
 aXM
-aXQ
+isZ
 aXQ
 bcT
 aVi
@@ -117363,7 +117507,7 @@ aUy
 aVi
 aWo
 aXM
-aXQ
+ncq
 bbm
 bdg
 aVi
@@ -117620,7 +117764,7 @@ aUy
 aVi
 aWq
 aXM
-aXQ
+sEp
 aXQ
 bdh
 aVi
@@ -117630,7 +117774,7 @@ bkg
 blM
 bnF
 bpd
-bnD
+rwC
 bqx
 bwa
 bnD
@@ -117887,7 +118031,7 @@ bkf
 blM
 bnG
 bnD
-bnD
+vVh
 vLg
 mjb
 bAb
@@ -118144,8 +118288,8 @@ bkg
 blM
 bnH
 bnD
-bnD
-bnD
+szE
+pWq
 bwd
 bzV
 bst
@@ -123046,7 +123190,7 @@ bSQ
 bUp
 bUX
 bTv
-bVt
+bTv
 bWU
 bYM
 cat

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -42567,7 +42567,10 @@
 /turf/simulated/shuttle/floor4,
 /area/shuttle/escape)
 "bBU" = (
-/obj/effect/spawner/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "barber"
@@ -109539,11 +109542,11 @@ qWu
 aUk
 aSd
 aVY
-aXs
-aXs
+aXu
+aXu
 bba
-aXs
-aXs
+aXu
+aXu
 aVY
 aSd
 bgI
@@ -110310,11 +110313,11 @@ aSd
 aSd
 aSd
 aVS
-aXs
+aXu
+aYZ
 nuo
-nuo
-nuo
-aXs
+aYZ
+aXu
 aVS
 aSd
 aSd


### PR DESCRIPTION
## What Does This PR Do
Modifica la shuttle de arrivals para poder hacerlo un lugar mas amplio y elimina antiguos lockers y una maquina de arcade que venia dentro de este lugar, agrega una tabla de noticias a arrivals a la par que una zona de exposición donde la temática de este mes es el invierno, da otra puerta a la oficina vacante y agrega pasto al jardín publico a la par que agrega dos nuevas semillas a las publicas, poopy y ricinus. 

En la zona de herramientas publicas agrega unos cuantos minerales básicos y una mascara de soldar, dentro del almacen frente al vault agrega un canister de oxigeno y un par de extended canister, en la zona de lockers agrega un sofá y una consola de entretenimiento. 

Agrega otro par de kits para jugar a laser tag con todos tus compañeros. 

## Why It's Good For The Game
Vuelve a Arrivals en una zona mas interesante con múltiples cosas y detalles que hacen sentir la estación mas viva, proporciona un orden mas agradable a esta zona y nos da una nueva área la cual podemos rotar cada tanto para poder ambientar en base al mes o las festividades. 

Vuelve la shuttle de arrivals un lugar mas seguro para el personal que va llegando y la hace sentir mas como una nave que un simple punto de spawn. 

## Images of changes

                                  Con suerte la calidad no es mala
![image](https://user-images.githubusercontent.com/46639834/79962102-439e0880-844d-11ea-884a-60968a717e77.png)

                                     Fun with Friends
![image](https://user-images.githubusercontent.com/46639834/79962152-544e7e80-844d-11ea-8a92-1696e589904b.png)

                                                   Semillas Gratis
![image](https://user-images.githubusercontent.com/46639834/79961375-3f252000-844c-11ea-91ce-c583fbed215e.png)


## Changelog
:cl:
tweak: Arrivals Shuttle
tweak: Arrivals Garden
tweak: Arrivals Lockers
/:cl:
