### PR TITLE
Fix Path de Billeteras Xtra

### DIFF
--- a/code/HISPANIA/game/machinery/vending.dm
+++ b/code/HISPANIA/game/machinery/vending.dm
@@ -132,7 +132,7 @@ deberan tener una linea de codigo demas para que funcionen "hispania_icon = TRUE
 	density = TRUE
 	vend_delay = 12
 
-	products = list(		/obj/item/storage/wallet/random = 15,
+	products = list(		/obj/item/storage/wallet = 15,
 					/obj/item/clothing/glasses/monocle = 5,
 					/obj/item/clothing/glasses/regular = 5,
 					/obj/item/clothing/ears/headphones = 5,
@@ -156,7 +156,7 @@ deberan tener una linea de codigo demas para que funcionen "hispania_icon = TRUE
     				/obj/item/stack/sheet/animalhide/monkey = 5,
     				/obj/item/stack/sheet/animalhide/lizard = 5)
 	contraband = list(		/obj/item/stack/sheet/animalhide/human = 5)
-	prices = list(			/obj/item/storage/wallet/random = 300,
+	prices = list(			/obj/item/storage/wallet = 300,
 					/obj/item/clothing/glasses/monocle = 400,
 					/obj/item/clothing/glasses/regular = 400,
 					/obj/item/clothing/ears/headphones = 450,


### PR DESCRIPTION
## What Does This PR Do
Mueve el tipo de objeto que vende la billetera anteriormente vendia la random que se genera con dinero y una moneda gratis, esto evita eso.

## Why It's Good For The Game
Evita dinero gratis del xtra

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/80265483-5424cd80-865d-11ea-84a4-c9984ac9f306.png)


## Changelog
:cl:
fix: Path Billeteras Xtra
/:cl:
