### PR TITLE
Tweak Starting Founds

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -583,7 +583,7 @@ SUBSYSTEM_DEF(jobs)
 
 
 /datum/controller/subsystem/jobs/proc/CreateMoneyAccount(mob/living/H, rank, datum/job/job)
-	var/datum/money_account/M = create_account(H.real_name, rand(50,500)*10, null)
+	var/datum/money_account/M = create_account(H.real_name, rand(150,400)*10, null)
 	var/remembered_info = ""
 
 	remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"


### PR DESCRIPTION
## What Does This PR Do
Aumenta la cantidad de dinero base con la que puedes aparecer. En el peor de los casos 1500 en el mejor de los casos 4000.

## Why It's Good For The Game
Desde que hicimos los cambios en las vending donde ahora por vestir mejor cuesta dinero hay casos en los cuales únicamente por comprar ciertos objetos te quedas sin dineros para futuras transacciones ya sea en el bar o en ciencias. Esperemos que con esto la gente pueda gastar mas dinero en servicios. 

## Images of changes

                                   Ya puedo ser guapo
![image](https://user-images.githubusercontent.com/46639834/80291658-2bf8a580-8715-11ea-9399-ecf82e3b318d.png)

## Changelog
:cl:
tweak: Dinero de inicio aumenta base
/:cl:
