### PR TITLE
fix - Los apc ahora no recargan instantaneamente las baterias nuevas

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1162,7 +1162,7 @@
 				cell.minorrecharging = TRUE
 				addtimer(CALLBACK(cell, /obj/item/stock_parts/cell/proc/minorrecharge), 20 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		if(newcell)
-			cell.charge = cell.charge/GLOB.CELLRATE
+			cell.charge = cell.charge * GLOB.CELLRATE
 			newcell = FALSE
 			cell.update_icon()
 	if(debug)


### PR DESCRIPTION
## What Does This PR Do
segun nuestro changelo las baterias nuevas  en los apc deberian descargarse  intantaneamente pero actualmente se recargan instantaneamente. 

## Changelog
:cl:
fix: los apc recargaban las baterias inicialmente, ya no.
/:cl: