### PR TITLE
Miras para el Stun revolver y el Xray

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -120,6 +120,7 @@
 	icon_state = "xray"
 	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
+	zoomable = TRUE
 	zoom_amt = 3
 
 /obj/item/gun/energy/immolator

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -120,6 +120,7 @@
 	icon_state = "xray"
 	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
+	zoom_amt = 3
 
 /obj/item/gun/energy/immolator
 	name = "Immolator laser gun"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -21,6 +21,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/shock_revolver)
 	can_flashlight = 0
 	shaded_charge = 1
+	zoomable = TRUE
 	zoom_amt = 1
 
 /obj/item/gun/energy/gun/advtaser

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -21,6 +21,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/shock_revolver)
 	can_flashlight = 0
 	shaded_charge = 1
+	zoom_amt = 1
 
 /obj/item/gun/energy/gun/advtaser
 	name = "hybrid taser"


### PR DESCRIPTION
## What Does This PR Do
el stun revolver ahora tiene una mira que le permite hacer zoom 1 tile
el xray gun ahora tiene un zoom de 3.

## Why It's Good For The Game
el sutn revolver es un arma magnifica pero con su gran area de efecto es más una desventaja que una ventaja. basicamente es un arma cazabobos, entiendo lo poderosa que puede ser con una mira peroconsidero que con solo un zoom de 1 la hace un arma aceptable

El xray en vez de por balance como el caso del stun es más por consistencia, esto es basicamente un rifle laser deberia tener un zoom, además de que esto hace juego con su mecanica de traspasarlo todo.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
tweak: el stun revolver y el Xraygun ahora tienen miras.
/:cl:
