### PR TITLE
quirks 3.0

### DIFF
--- a/code/HISPANIA/__DEFINES/traits.dm
+++ b/code/HISPANIA/__DEFINES/traits.dm
@@ -1,1 +1,0 @@
-#define TRAIT_AGEUSIA			"ageusia"

--- a/code/HISPANIA/modules/mob/living/status_procs.dm
+++ b/code/HISPANIA/modules/mob/living/status_procs.dm
@@ -20,3 +20,13 @@
 		if(Q.type == quirktype)
 			return TRUE
 	return FALSE
+
+/mob/living/proc/remove_all_quirks()
+	for(var/datum/quirk/Q in roundstart_quirks)
+		if(Q)
+			qdel(Q)
+			return TRUE
+	return FALSE
+
+/mob/living/proc/add_antag_quirks() //añade todos los quirks que un traidor necesita
+	return

--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -63,6 +63,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //mob traits
 #define TRAIT_PACIFISM			"pacifism"
 #define TRAIT_WATERBREATH       "waterbreathing"
+//hispatraits
+#define TRAIT_AGEUSIA			"ageusia"
+//finhispatraits
 
 // common trait sources
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -118,12 +118,16 @@
 		new_character.mind.current = null
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
+	if(ishuman(old_current))	//cambio hispano para tranferir quirks
+		old_current.transfer_trait_datums(current) //para transfererir quirks
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
-
+	if(special_role)	//para que los antagas tengan las todas las habilidades basicas
+		new_character.remove_all_quirks()
+		new_character.add_antag_quirks() //fin para que los antags tengan los quirks basicos
 	if(active)
 		new_character.key = key		//now transfer the key to link the client to our new body
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1167,7 +1167,6 @@
 #include "code\game\verbs\randomtip.dm"
 #include "code\game\verbs\suicide.dm"
 #include "code\game\verbs\who.dm"
-#include "code\HISPANIA\__DEFINES\traits.dm"
 #include "code\HISPANIA\__HELPERS\cmp.dm"
 #include "code\HISPANIA\__HELPERS\unsorted.dm"
 #include "code\HISPANIA\controllers\subsystem\processing\quirks.dm"


### PR DESCRIPTION
## What Does This PR Do
Trale los cambios más basicos del pr #659 para que pueda ser testeado y aprobado con más comodidad.

## Why It's Good For The Game
evita que un antag tenga quirks negativos al transferir su mente a un nuevo cuerpo y hace que los quirks perduren a la clonacion.

## Changelog
:cl:
tweak: elimina los quirks del jugador en caso de que le toque antag
tweak: los quirks trascienden a la muerte
/:cl:
