### PR TITLE
Cambia la edad mínima y restringe los jobs por edad

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -13,7 +13,7 @@
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
-#define AGE_MIN 18			//youngest a character can be
+#define AGE_MIN 15			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -80,6 +80,12 @@ SUBSYSTEM_DEF(jobs)
 			return 0
 		if(job.barred_by_disability(player.client))
 			return 0
+		if(job.age_restringed(player.client))
+			return 0
+		if(job.command_age_restringed(player.client))
+			return 0
+		if(job.captain_age_restringed(player.client))
+			return 0
 		if(!is_job_whitelisted(player, rank))
 			return 0
 
@@ -133,6 +139,15 @@ SUBSYSTEM_DEF(jobs)
 		if(job.barred_by_disability(player.client))
 			Debug("FOC player has disability rendering them ineligible for job, Player: [player]")
 			continue
+		if(job.age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+		if(job.command_age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+		if(job.captain_age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
 		if(flag && !(flag in player.client.prefs.be_special))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
@@ -176,6 +191,18 @@ SUBSYSTEM_DEF(jobs)
 
 		if(job.barred_by_disability(player.client))
 			Debug("GRJ player has disability rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.command_age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.captain_age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
 			continue
 
 		if(player.mind && (job.title in player.mind.restricted_roles))
@@ -353,6 +380,18 @@ SUBSYSTEM_DEF(jobs)
 
 				if(job.barred_by_disability(player.client))
 					Debug("DO player has disability rendering them ineligible for job, Player: [player], Job:[job.title]")
+					continue
+
+				if(job.age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					continue
+
+				if(job.command_age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					continue
+
+				if(job.captain_age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
 					continue
 
 				if(player.mind && (job.title in player.mind.restricted_roles))
@@ -568,6 +607,15 @@ SUBSYSTEM_DEF(jobs)
 				level6++
 				continue
 			if(job.barred_by_disability(player.client))
+				level7++
+				continue
+			if(job.age_restringed(player.client))
+				level7++
+				continue
+			if(job.command_age_restringed(player.client))
+				level7++
+				continue
+			if(job.captain_age_restringed(player.client))
 				level7++
 				continue
 			if(player.client.prefs.GetJobDepartment(job, 1) & job.flag)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -4,6 +4,9 @@
 	department_flag = JOBCAT_SUPPORT
 	total_positions = -1
 	spawn_positions = -1
+	minimal_character_age = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_engineering = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffeeaa"
@@ -55,6 +56,8 @@
 	total_positions = 5
 	spawn_positions = 5
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"
@@ -91,6 +94,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"
@@ -125,6 +130,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -46,6 +46,10 @@
 	//If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/minimal_player_age = 0
 
+	var/minimal_character_age = 0
+	var/minimal_command_character_age = 0
+	var/minimal_captain_character_age = 0
+
 	var/exp_requirements = 0
 	var/exp_type = ""
 
@@ -110,6 +114,30 @@
 		return 0
 
 	return max(0, minimal_player_age - C.player_age)
+
+/datum/job/proc/age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_character_age)
+		return 0
+	if(C.prefs.age < 18)
+		return 1
+
+/datum/job/proc/command_age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_command_character_age)
+		return 0
+	if(C.prefs.age < 25)
+		return 1
+
+/datum/job/proc/captain_age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_captain_character_age)
+		return 0
+	if(C.prefs.age < 30)
+		return 1
 
 /datum/job/proc/barred_by_disability(client/C)
 	if(!C)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffddf0"
@@ -48,6 +49,8 @@
 	total_positions = 5
 	spawn_positions = 3
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -83,6 +86,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -144,6 +149,8 @@
 	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -178,6 +185,8 @@
 	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -211,6 +220,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -246,6 +257,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -284,6 +297,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_science = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffddff"
@@ -54,6 +55,8 @@
 	total_positions = 4
 	spawn_positions = 6
 	is_science = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"
@@ -93,6 +96,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_science = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffdddd"
@@ -17,7 +18,6 @@
 			            ACCESS_FORENSICS_LOCKERS, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS, ACCESS_ALL_PERSONAL_LOCKERS,
 			            ACCESS_RESEARCH, ACCESS_ENGINE, ACCESS_MINING, ACCESS_MEDICAL, ACCESS_CONSTRUCTION, ACCESS_MAILSORTING,
 			            ACCESS_HEADS, ACCESS_HOS, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_PILOT, ACCESS_WEAPONS)
-	minimal_player_age = 21
 	exp_requirements = 2880
 	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed = 0
@@ -57,6 +57,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -101,6 +103,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -160,6 +164,8 @@
 	total_positions = 7
 	spawn_positions = 7
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -198,6 +204,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -229,6 +237,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -4,6 +4,9 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 0 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
 	spawn_positions = 1
+	minimal_character_age = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	department_head = list("Captain")
@@ -26,6 +29,9 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 1
 	spawn_positions = 1
+	minimal_character_age = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "your laws and the AI"	//Nodrak
 	department_head = list("AI")
 	selection_color = "#ddffdd"

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -5,6 +5,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 1
 	spawn_positions = 1
+	minimal_player_age = 30
 	supervisors = "Nanotrasen officials"
 	department_head = list("Nanotrasen Navy Officer")
 	selection_color = "#ccccff"
@@ -12,7 +13,6 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	is_command = 1
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
-	minimal_player_age = 30
 	exp_requirements = 4320
 	exp_type = EXP_TYPE_COMMAND
 	disabilities_allowed = 0
@@ -61,12 +61,13 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_SUPPORT
 	total_positions = 1
 	spawn_positions = 1
+	minimal_player_age = 25
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_command = 1
-	minimal_player_age = 21
+	minimal_captain_character_age = 1
 	exp_requirements = 1440
 	exp_type = EXP_TYPE_COMMAND
 	access = list(ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_CHANGE_IDS, ACCESS_EVA, ACCESS_HEADS,
@@ -111,7 +112,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	req_admin_notify = 1
 	is_command = 1
 	transfer_allowed = FALSE
-	minimal_player_age = 21
+	minimal_captain_character_age = 1
 	exp_requirements = 2880
 	exp_type = EXP_TYPE_COMMAND
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_COURT, ACCESS_FORENSICS_LOCKERS,
@@ -151,6 +152,8 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_KARMA
 	total_positions = 1
 	spawn_positions = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the Nanotrasen representative"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
@@ -197,6 +200,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_KARMA
 	total_positions = 1
 	spawn_positions = 1
+	minimal_captain_character_age = 1
 	supervisors = "the Nanotrasen Supreme Court"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
@@ -245,6 +249,8 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	total_positions = 2
 	spawn_positions = 2
 	is_legal = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the magistrate"
 	department_head = list("Captain")
 	selection_color = "#ddddff"

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -6,6 +6,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -47,6 +49,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -81,6 +85,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -118,6 +124,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -148,6 +156,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "Quartermaster"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -174,6 +184,8 @@
 	total_positions = 6
 	spawn_positions = 8
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "Quartermaster"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -244,6 +256,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -330,6 +344,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -382,6 +398,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -408,6 +426,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -437,6 +457,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -6,6 +6,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -26,7 +28,7 @@
 		/obj/item/camera/spooky = 1,
 		/obj/item/nullrod = 1
 	)
-	
+
 /datum/outfit/job/chaplain/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -653,6 +653,15 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 		if(job.barred_by_disability(user.client))
 			HTML += "<del>[rank]</del></td><td> \[ DISABILITY \]</td></tr>"
 			continue
+		if(job.age_restringed(user.client))
+			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			continue
+		if(job.command_age_restringed(user.client))
+			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			continue
+		if(job.captain_age_restringed(user.client))
+			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			continue
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)
 			HTML += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -314,6 +314,15 @@
 	if(thisjob.barred_by_disability(client))
 		to_chat(src, alert("[rank] is not available due to your character's disability. Please try another."))
 		return 0
+	if(thisjob.age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
+	if(thisjob.command_age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
+	if(thisjob.captain_age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
 
 	SSjobs.AssignRole(src, rank, 1)
 
@@ -483,7 +492,7 @@
 		"Supply" = list(jobs = list(), titles = GLOB.supply_positions, color = "#ead4ae"),
 		)
 	for(var/datum/job/job in SSjobs.occupations)
-		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client))
+		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client) && !job.age_restringed(client) && !job.command_age_restringed(client) && !job.captain_age_restringed(client))
 			num_jobs_available++
 			activePlayers[job] = 0
 			var/categorized = 0

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-secret
+extended


### PR DESCRIPTION

## What Does This PR Do
Cambia la edad mínima de 18 a 15, y coloca restricciones de edad para los jobs.
Capitán: +30 años
Comando: +25 años
Resto de jobs: +18
Civil: Sin restricción

## Why It's Good For The Game
Permite a los jugadores rolear diferentes edades, pero mantiene la consistencia de que en una estación espacial no contratarían menores de edad. También los puestos de alto mando son restringidos para personajes "con mas experiencia laboral", así no tendrás un RD de 20 años o un capitán de 18.

## Images of changes
![image](https://user-images.githubusercontent.com/47925856/95270233-7ed0a000-0811-11eb-8d9b-298cd98e7aa6.png)
![image](https://user-images.githubusercontent.com/47925856/95270241-842dea80-0811-11eb-8ac7-930dbc09c0bf.png)

![image](https://user-images.githubusercontent.com/47925856/95270261-8c862580-0811-11eb-8566-86b280f6446a.png)
![image](https://user-images.githubusercontent.com/47925856/95270276-927c0680-0811-11eb-969d-129260bc0883.png)

![image](https://user-images.githubusercontent.com/47925856/95270293-9dcf3200-0811-11eb-9bb2-5eacce143ca7.png)
![image](https://user-images.githubusercontent.com/47925856/95270310-a4f64000-0811-11eb-8472-f67db2baa410.png)

![image](https://user-images.githubusercontent.com/47925856/95270324-ad4e7b00-0811-11eb-8290-06ba07fed466.png)
![image](https://user-images.githubusercontent.com/47925856/95270347-b3dcf280-0811-11eb-8b91-ed5d14211964.png)


## Changelog
:cl:
tweak: Ajusta la edad mínima y restringe los jobs por edades
/:cl:

