### PR TITLE
Cambia color del texto "AGE RESTRINGED"

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -654,13 +654,13 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			HTML += "<del>[rank]</del></td><td> \[ DISABILITY \]</td></tr>"
 			continue
 		if(job.age_restringed(user.client))
-			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
 			continue
 		if(job.command_age_restringed(user.client))
-			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
 			continue
 		if(job.captain_age_restringed(user.client))
-			HTML += "<del>[rank]</del></td><td> \[ AGE RESTRINGED \]</td></tr>"
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
 			continue
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)


### PR DESCRIPTION


## What Does This PR Do
Cambia el color del texto en la configuración del job (Cuando no puedes elegirlo porque tu personaje no cumple la edad requerida) de blanco a rojo. De esta manera se lee mucho mejor.

## Why It's Good For The Game
No te rompe los ojos intentando leer que dice ahí.

## Images of changes
Antes
![image](https://user-images.githubusercontent.com/47925856/95278550-d1688700-0826-11eb-9c18-df8a0ebda783.png)


Después
![image](https://user-images.githubusercontent.com/47925856/95278288-3f607e80-0826-11eb-99c5-4836d162cad1.png)


## Changelog
:cl:
tweak: Cambia el color de un texto de la config de jobs, de blanco a rojo.
/:cl:

