### PR TITLE
Cambia la edad mínima y restringe los jobs por edades

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -13,7 +13,7 @@
 #define DROPLIMB_BLUNT 1
 #define DROPLIMB_BURN 2
 
-#define AGE_MIN 18			//youngest a character can be
+#define AGE_MIN 15			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -81,11 +81,11 @@ SUBSYSTEM_DEF(jobs)
 			return 0
 		if(job.barred_by_disability(player.client))
 			return 0
-		if(job.age_restringed(player.client))
+		if(job.age_restringed(player.client))//Restriccion de edad
 			return 0
-		if(job.command_age_restringed(player.client))
+		if(job.command_age_restringed(player.client))//Restriccion de edad
 			return 0
-		if(job.captain_age_restringed(player.client))
+		if(job.captain_age_restringed(player.client))//Restriccion de edad
 			return 0
 		if(!is_job_whitelisted(player, rank))
 			return 0
@@ -141,13 +141,13 @@ SUBSYSTEM_DEF(jobs)
 			Debug("FOC player has disability rendering them ineligible for job, Player: [player]")
 			continue
 		if(job.age_restringed(player.client))
-			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 		if(job.command_age_restringed(player.client))
-			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 		if(job.captain_age_restringed(player.client))
-			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 		if(flag && !(flag in player.client.prefs.be_special))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
@@ -195,15 +195,15 @@ SUBSYSTEM_DEF(jobs)
 			continue
 
 		if(job.age_restringed(player.client))
-			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 
 		if(job.command_age_restringed(player.client))
-			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 
 		if(job.captain_age_restringed(player.client))
-			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 			continue
 
 		if(player.mind && (job.title in player.mind.restricted_roles))
@@ -384,15 +384,15 @@ SUBSYSTEM_DEF(jobs)
 					continue
 
 				if(job.age_restringed(player.client))
-					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 					continue
 
 				if(job.command_age_restringed(player.client))
-					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 					continue
 
 				if(job.captain_age_restringed(player.client))
-					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")//Restriccion de edad
 					continue
 
 				if(player.mind && (job.title in player.mind.restricted_roles))

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -81,6 +81,12 @@ SUBSYSTEM_DEF(jobs)
 			return 0
 		if(job.barred_by_disability(player.client))
 			return 0
+		if(job.age_restringed(player.client))
+			return 0
+		if(job.command_age_restringed(player.client))
+			return 0
+		if(job.captain_age_restringed(player.client))
+			return 0
 		if(!is_job_whitelisted(player, rank))
 			return 0
 
@@ -134,6 +140,15 @@ SUBSYSTEM_DEF(jobs)
 		if(job.barred_by_disability(player.client))
 			Debug("FOC player has disability rendering them ineligible for job, Player: [player]")
 			continue
+		if(job.age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+		if(job.command_age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+		if(job.captain_age_restringed(player.client))
+			Debug("FOC player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
 		if(flag && !(flag in player.client.prefs.be_special))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
@@ -177,6 +192,18 @@ SUBSYSTEM_DEF(jobs)
 
 		if(job.barred_by_disability(player.client))
 			Debug("GRJ player has disability rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.command_age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
+			continue
+
+		if(job.captain_age_restringed(player.client))
+			Debug("GRJ player's character is underage rendering them ineligible for job, Player: [player]")
 			continue
 
 		if(player.mind && (job.title in player.mind.restricted_roles))
@@ -354,6 +381,18 @@ SUBSYSTEM_DEF(jobs)
 
 				if(job.barred_by_disability(player.client))
 					Debug("DO player has disability rendering them ineligible for job, Player: [player], Job:[job.title]")
+					continue
+
+				if(job.age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					continue
+
+				if(job.command_age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
+					continue
+
+				if(job.captain_age_restringed(player.client))
+					Debug("DO player's character is underage rendering them ineligible for job, Player: [player]")
 					continue
 
 				if(player.mind && (job.title in player.mind.restricted_roles))
@@ -570,6 +609,15 @@ SUBSYSTEM_DEF(jobs)
 				level6++
 				continue
 			if(job.barred_by_disability(player.client))
+				level7++
+				continue
+			if(job.age_restringed(player.client))
+				level7++
+				continue
+			if(job.command_age_restringed(player.client))
+				level7++
+				continue
+			if(job.captain_age_restringed(player.client))
 				level7++
 				continue
 			if(player.client.prefs.GetJobDepartment(job, 1) & job.flag)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -4,6 +4,9 @@
 	department_flag = JOBCAT_SUPPORT
 	total_positions = -1
 	spawn_positions = -1
+	minimal_character_age = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_engineering = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffeeaa"
@@ -55,6 +56,8 @@
 	total_positions = 5
 	spawn_positions = 5
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"
@@ -91,6 +94,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"
@@ -125,6 +130,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_engineering = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief engineer"
 	department_head = list("Chief Engineer")
 	selection_color = "#fff5cc"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -49,6 +49,10 @@
 	var/exp_requirements = 0
 	var/exp_type = ""
 
+	var/minimal_character_age = 0
+	var/minimal_command_character_age = 0
+	var/minimal_captain_character_age = 0
+
 	var/disabilities_allowed = 1
 	var/transfer_allowed = TRUE // If false, ID computer will always discourage transfers to this job, even if player is eligible
 	var/hidden_from_job_prefs = FALSE // if true, job preferences screen never shows this job.
@@ -111,6 +115,30 @@
 		return 0
 
 	return max(0, minimal_player_age - C.player_age)
+
+/datum/job/proc/age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_character_age)
+		return 0
+	if(C.prefs.age < 18)
+		return 1
+
+/datum/job/proc/command_age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_command_character_age)
+		return 0
+	if(C.prefs.age < 25)
+		return 1
+
+/datum/job/proc/captain_age_restringed(client/C)
+	if(!C)
+		return 0
+	if(minimal_captain_character_age)
+		return 0
+	if(C.prefs.age < 30)
+		return 1
 
 /datum/job/proc/barred_by_disability(client/C)
 	if(!C)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -49,9 +49,11 @@
 	var/exp_requirements = 0
 	var/exp_type = ""
 
+///Restriccion de edad
 	var/minimal_character_age = 0
 	var/minimal_command_character_age = 0
 	var/minimal_captain_character_age = 0
+///Fin restriccion de edad
 
 	var/disabilities_allowed = 1
 	var/transfer_allowed = TRUE // If false, ID computer will always discourage transfers to this job, even if player is eligible
@@ -116,6 +118,7 @@
 
 	return max(0, minimal_player_age - C.player_age)
 
+///Restriccion de edad
 /datum/job/proc/age_restringed(client/C)
 	if(!C)
 		return 0
@@ -139,6 +142,7 @@
 		return 0
 	if(C.prefs.age < 30)
 		return 1
+///Fin restriccion de edad
 
 /datum/job/proc/barred_by_disability(client/C)
 	if(!C)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffddf0"
@@ -48,6 +49,8 @@
 	total_positions = 5
 	spawn_positions = 3
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -83,6 +86,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -144,6 +149,8 @@
 	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -178,6 +185,8 @@
 	total_positions = 1
 	spawn_positions = 2
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -211,6 +220,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -246,6 +257,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
@@ -284,6 +297,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_medical = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the chief medical officer"
 	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_science = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffddff"
@@ -54,6 +55,8 @@
 	total_positions = 4
 	spawn_positions = 6
 	is_science = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"
@@ -93,6 +96,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_science = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -5,6 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ffdddd"
@@ -57,6 +58,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -101,6 +104,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -160,6 +165,8 @@
 	total_positions = 7
 	spawn_positions = 7
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -198,6 +205,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
@@ -229,6 +238,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_security = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -4,6 +4,9 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 0 // Not used for AI, see is_position_available below and modules/mob/living/silicon/ai/latejoin.dm
 	spawn_positions = 1
+	minimal_character_age = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	department_head = list("Captain")
@@ -26,6 +29,9 @@
 	department_flag = JOBCAT_ENGSEC
 	total_positions = 2
 	spawn_positions = 2
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
+	minimal_character_age = 1
 	supervisors = "your laws and the AI"	//Nodrak
 	department_head = list("AI")
 	selection_color = "#ddffdd"

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -61,6 +61,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_SUPPORT
 	total_positions = 1
 	spawn_positions = 1
+	minimal_captain_character_age = 1
 	supervisors = "the captain"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
@@ -105,6 +106,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_KARMA
 	total_positions = 1
 	spawn_positions = 1
+	minimal_captain_character_age = 1
 	supervisors = "the command staff"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
@@ -151,6 +153,8 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	department_flag = JOBCAT_KARMA
 	total_positions = 1
 	spawn_positions = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the Nanotrasen representative"
 	department_head = list("Captain")
 	selection_color = "#ddddff"
@@ -202,6 +206,7 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	selection_color = "#ddddff"
 	req_admin_notify = 1
 	is_legal = 1
+	minimal_captain_character_age = 1
 	transfer_allowed = FALSE
 	minimal_player_age = 30
 	exp_requirements = 2880
@@ -245,6 +250,8 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	total_positions = 2
 	spawn_positions = 2
 	is_legal = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the magistrate"
 	department_head = list("Captain")
 	selection_color = "#ddddff"

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -6,6 +6,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -47,6 +49,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -81,6 +85,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -118,6 +124,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -148,6 +156,8 @@
 	total_positions = 2
 	spawn_positions = 2
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "Quartermaster"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -174,6 +184,8 @@
 	total_positions = 6
 	spawn_positions = 8
 	is_supply = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "Quartermaster"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -244,6 +256,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -329,6 +343,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -381,6 +397,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -407,6 +425,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -436,6 +456,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
@@ -462,6 +484,8 @@
 	department_flag = JOBCAT_SUPPORT
 	total_positions = 0
 	spawn_positions = 0
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -6,6 +6,8 @@
 	total_positions = 1
 	spawn_positions = 1
 	is_service = 1
+	minimal_command_character_age = 1
+	minimal_captain_character_age = 1
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -651,6 +651,15 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 		if(job.barred_by_disability(user.client))
 			HTML += "<del>[rank]</del></td><td> \[ DISABILITY \]</td></tr>"
 			continue
+		if(job.age_restringed(user.client))
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
+			continue
+		if(job.command_age_restringed(user.client))
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
+			continue
+		if(job.captain_age_restringed(user.client))
+			HTML += "<del><font color=red>[rank]</font></del></td><td><font color=red> \[ AGE RESTRINGED \]</font></td></tr>"
+			continue
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)
 			HTML += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -328,6 +328,7 @@
 	if(thisjob.barred_by_disability(client))
 		to_chat(src, alert("[rank] is not available due to your character's disability. Please try another."))
 		return 0
+	///Restricciones de edad
 	if(thisjob.age_restringed(client))
 		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
 		return 0
@@ -337,6 +338,7 @@
 	if(thisjob.captain_age_restringed(client))
 		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
 		return 0
+	///Fin restricciones de edad
 	SSjobs.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
@@ -505,7 +507,7 @@
 		"Supply" = list(jobs = list(), titles = GLOB.supply_positions, color = "#ead4ae"),
 		)
 	for(var/datum/job/job in SSjobs.occupations)
-		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client) && !job.age_restringed(client) && !job.command_age_restringed(client) && !job.captain_age_restringed(client))
+		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client) && !job.age_restringed(client) && !job.command_age_restringed(client) && !job.captain_age_restringed(client))///Restricción de edad
 			num_jobs_available++
 			activePlayers[job] = 0
 			var/categorized = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -315,6 +315,7 @@
 /mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
 	if(src != usr)
 		return 0
+
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 		return 0
@@ -328,7 +329,15 @@
 	if(thisjob.barred_by_disability(client))
 		to_chat(src, alert("[rank] is not available due to your character's disability. Please try another."))
 		return 0
-
+	if(thisjob.age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
+	if(thisjob.command_age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
+	if(thisjob.captain_age_restringed(client))
+		to_chat(src, alert("[rank] is not available due to your character's age. Please try another."))
+		return 0
 	SSjobs.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
@@ -497,7 +506,7 @@
 		"Supply" = list(jobs = list(), titles = GLOB.supply_positions, color = "#ead4ae"),
 		)
 	for(var/datum/job/job in SSjobs.occupations)
-		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client))
+		if(job && IsJobAvailable(job.title) && !job.barred_by_disability(client) && !job.age_restringed(client) && !job.command_age_restringed(client) && !job.captain_age_restringed(client))
 			num_jobs_available++
 			activePlayers[job] = 0
 			var/categorized = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -315,7 +315,6 @@
 /mob/new_player/proc/AttemptLateSpawn(rank,var/spawning_at)
 	if(src != usr)
 		return 0
-
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "<span class='warning'>The round is either not ready, or has already finished...</span>")
 		return 0


### PR DESCRIPTION

## What Does This PR Do
Cambia la edad mínima de 18 a 15, y restringe los jobs según la edad del personaje.
Capitán: +30 años
Comando: +25 años
Resto de jobs: +18 años
Civil: Sin restricción

## Why It's Good For The Game
Ahora puedes tener tu personaje snowflake de menor de edad visitando una estación espacial, pero no tendrás un HoS de 17 años o un CE de 20 en comando, ni un CMO de 15 en el quirófano.

## Changelog
:cl:
tweak: Cambia la edad mínima y restringe los jobs por edades
/:cl:


