### PR TITLE
Balance Bubblegum

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -147,7 +147,7 @@ Difficulty: Hard
 	charge(delay = 6)
 	charge(delay = 4)
 	charge(delay = 2)
-	SetRecoveryTime(15)
+	SetRecoveryTime(40)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge()
 	if(!BUBBLEGUM_SMASH || prob(33))


### PR DESCRIPTION
## What Does This PR Do
Sube el CD de la Triple Carga de Bubblegum pasa de 1.5s a 4.0s

## Why It's Good For The Game
Actualmente Bubblegum luego del rework por el cual paso en manos de McFurro es una bestia incapaz de ser asesinada por lo que hasta la fecha ningún minero puede asesinarle y es un avoid on sight bajo toda circunstancia creando un tope insuperable el cual no se puede pasar a no ser que tengas Mechas de combate. Con este cambio en el CD se proporciona al minero una ventana de oportunidad en la cual poder atacar y sigue siendo una bestia letal que al primer fallo causa tu muerte. 

Este problema ya era algo existente desde antes de el cambio a CEV Eris en el tiempo que estuvo disponible en lavaland nadie logro acabar con este monstruo asesino a no ser que contaran con equipamiento de alto calibre (admin spawn). 

## Images of changes

Adjunto este video de los cambios: <a href="https://www.youtube.com/watch?v=YAnNraB-AFw&ab_channel=Spircen"> Link </a>

## Changelog
:cl:
tweak: Bubblegum Triple Charge CD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
