### PR TITLE
Fix ATM Machines

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -94860,10 +94860,6 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
-"dXr" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
 "dZD" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -94882,6 +94878,13 @@
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
+"ecp" = (
+/obj/item/radio/intercom{
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel,
+/area/bridge/meeting_room)
 "edh" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
@@ -95483,6 +95486,10 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/administration)
+"gRe" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "gSA" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
@@ -95548,10 +95555,6 @@
 	icon_state = "floor4"
 	},
 /area/shuttle/tsf)
-"hkf" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/plating,
-/area/bridge/meeting_room)
 "hmZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -97717,6 +97720,10 @@
 	dir = 4
 	},
 /area/shuttle/escape)
+"sPg" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "sQN" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/alt,
@@ -98288,6 +98295,12 @@
 /obj/structure/table,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"vza" = (
+/obj/machinery/computer/account_database{
+	anchored = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/bridge/meeting_room)
 "vAp" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human{
@@ -125252,8 +125265,8 @@ bCG
 bJH
 bFF
 bxl
-bMv
-bMv
+sPg
+gRe
 bMG
 bTc
 bUq
@@ -125509,8 +125522,8 @@ bCC
 bJH
 bFI
 bxl
-dXr
-hkf
+bxl
+bxl
 bMG
 bOC
 bQl
@@ -125766,8 +125779,8 @@ bBw
 bJH
 bKJ
 bxm
-bxl
-bxl
+vza
+ecp
 bQo
 bTd
 bUr


### PR DESCRIPTION
## What Does This PR Do
Agrega la maquina de fondos en la sala alterna del HoP para poder laborar sobre las cuentas de créditos de la tripulacion.

## Why It's Good For The Game
De esta forma todos los cajeros de la estación ya funcionan de forma correcta pues dependen de la existencia de esta maquina. 

## Images of changes

                                                 ¡Oh si! ¡A cobrar!
![image](https://user-images.githubusercontent.com/46639834/96398158-cac80100-1190-11eb-9e13-b7f589978291.png)

                                                  Lero lero descontado por baboso
![image](https://user-images.githubusercontent.com/46639834/96398263-08c52500-1191-11eb-9137-69b2707c83f7.png)

## Changelog
:cl:
fix: Missing ATM Control Machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
