### PR TITLE
Cambia el revolver del detective

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -34,13 +34,13 @@
 /obj/item/projectile/bullet/weakbullet2  //detective revolver
 	name = "rubber bullet"
 	damage = 5
-	stamina = 35
+	weaken = 3
+	stamina = 20
 	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/weakbullet2/invisible //finger gun bullets
 	name = "invisible bullet"
 	damage = 0
-	weaken = 3
 	stamina = 60
 	icon_state = null
 	hitsound_wall = null


### PR DESCRIPTION
## What Does This PR Do
El revolver del detective vuelve a tener su stun pequeño, pero ahora solo da 20 de stamina.

## Why It's Good For The Game
Los cambios que hice al revolver en paradise era por problemas del validhunting y el detective, ya que siempre hay seguridad para hacer el trabajo de cazar antags. El problema es qué acá el detective comunmente es el unico miembro de seguridad, y el revolver triste no va a frenar a nadie. Ahora van a tener que salvar y apuntar bien para stamina-crit, pero un disparo lo hará más facil.

## Changelog
:cl:
tweak: El revolver del detective vuelve a stunnear, pero hace menos daño de stamina.
/:cl: