### PR TITLE
Fix Guardado de Quirks en DB

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -302,12 +302,11 @@
 	if(!organ_data) src.organ_data = list()
 	if(!rlimb_data) src.rlimb_data = list()
 	if(!loadout_gear) loadout_gear = list()
+	if(!all_quirks) all_quirks = list()
 
 	// Check if the current body accessory exists
 	if(!GLOB.body_accessory_by_name[body_accessory])
 		body_accessory = null
-
-	all_quirks = SANITIZE_LIST(all_quirks)
 	return 1
 
 /datum/preferences/proc/save_character(client/C)
@@ -315,6 +314,7 @@
 	var/rlimblist
 	var/playertitlelist
 	var/gearlist
+	var/quirklist
 
 	var/markingcolourslist = list2params(m_colours)
 	var/markingstyleslist = list2params(m_styles)
@@ -326,6 +326,8 @@
 		playertitlelist = list2params(player_alt_titles)
 	if(!isemptylist(loadout_gear))
 		gearlist = list2params(loadout_gear)
+	if(!isemptylist(all_quirks))
+		quirklist = list2params(all_quirks)
 
 	var/DBQuery/firstquery = GLOB.dbcon.NewQuery("SELECT slot FROM [format_table_name("characters")] WHERE ckey='[C.ckey]' ORDER BY slot")
 	firstquery.Execute()
@@ -383,7 +385,7 @@
 												body_accessory='[body_accessory]',
 												gear='[gearlist]',
 												autohiss='[autohiss_mode]',
-												all_quirks='[all_quirks]'
+												all_quirks='[quirklist]'
 												WHERE ckey='[C.ckey]'
 												AND slot='[default_slot]'"}
 												)
@@ -449,7 +451,7 @@
 											'[sanitizeSQL(gen_record)]',
 											'[playertitlelist]',
 											'[disabilities]', '[organlist]', '[rlimblist]', '[nanotrasen_relation]', '[speciesprefs]',
-											'[socks]', '[body_accessory]', '[gearlist]', '[autohiss_mode]', '[all_quirks]')
+											'[socks]', '[body_accessory]', '[gearlist]', '[autohiss_mode]', '[quirklist]')
 "}
 )
 


### PR DESCRIPTION
## What Does This PR Do
Modifica el como se hacen entradas a la DB para poder guardar los quirks de forma correcta en la tabla creada con ayuda de Hessica.

## Why It's Good For The Game
Evita múltiples Runtimes que suceden cada que un jugador entra al juego al cargar su personaje.

## Images of changes

                                            No se que poner aquí

![757881233337352233](https://user-images.githubusercontent.com/46639834/98200241-c91d6d80-1ef2-11eb-89e7-afc3867af566.gif)


## Changelog
:cl:
fix: SQL Quirks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
