### PR TITLE
Tweak Discord UI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 
 #ignore other, specific files and folers
 *.before
-data/
+data/*
 /_maps/map_files/backup/*
 /_maps/map_files/**/backup/*
 *.dmm.backup

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 
 #ignore other, specific files and folers
 *.before
-data/*
+data/
 /_maps/map_files/backup/*
 /_maps/map_files/**/backup/*
 *.dmm.backup

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -676,7 +676,6 @@ proc/dd_sortedObjectList(list/incoming)
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
 
 #define LAZYINITLIST(L) if (!L) L = list()
-#define SANITIZE_LIST(L) (islist(L) ? L : list()) //HISPANIA
 #define UNSETEMPTY(L) if (L && !L.len) L = null
 #define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -342,6 +342,18 @@ window "rpane"
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
+	elem "discordb"
+		type = BUTTON
+		pos = 487,7
+		size = 60x16
+		anchor1 = none
+		anchor2 = none
+		font-style = "bold"
+		text-color = #ffffff
+		background-color = #7289da
+		saved-params = "is-checked"
+		text = "Discord"
+		command = "discord"
 	elem "rulesb"
 		type = BUTTON
 		pos = 357,7


### PR DESCRIPTION
## What Does This PR Do
Re agrega el botón de Discord a la UI para que los usuarios nuevos puedan entrar de forma sencilla a nuestro discord. Ademas elimina una variable que no se ocupa mas. 

## Why It's Good For The Game
Mas de una vez ya escuche las preguntas de "¿Tienen el discord?" en OOC, con esto espero que los visitantes repentinos que tenemos al server directo puedan conectar directo con nosotros en Discord.

## Images of changes

![image](https://user-images.githubusercontent.com/46639834/98268027-a5d5db00-1f51-11eb-8335-ee5056b0f97d.png)

## Changelog
:cl:
tweak: Discord UI Button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
