### PR TITLE
Balance a las machines

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,8 +15,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
-	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
+	brute_mod = 1.3 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
+	burn_mod = 1.3  // So they take 50% extra damage from brute/burn overall
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,8 +15,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1.3 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
-	burn_mod = 1.3  // So they take 50% extra damage from brute/burn overall
+	brute_mod = 1.3 //+30% burn and brute damage
+	burn_mod = 1.3
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -647,8 +647,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 	..()
 	//robot limbs take reduced damage
 	if(!make_tough)
-		brute_mod = 0.66
-		burn_mod = 0.66
 		dismember_at_max_damage = TRUE
 	else
 		tough = TRUE


### PR DESCRIPTION
## What Does This PR Do
Cambia las stats de los IPC a algo mas entendible y los deja un poco mas fuertes comparados a la basura cosmica que son actualmente. Ademas de balancear un poco mas las extremidades roboticas que en manos de un ipc son basura pero en manos de otra raza son items supremos. fox why?

## Why It's Good For The Game
Los IPC son actualmente basura espacial, no sirven para roles que contengan un mínimo peligro y se les puede ganar de un batazo bien puesto. 

## Changelog
:cl:
tweak: Las modificaciones de daño de los ipc pasan de ser a 50% a 30%
del: Las extremidades roboticas pasan de tener un brute y burn mod de 0.66 a tener 1 de default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
