### PR TITLE
Quirk Terminator

### DIFF
--- a/code/HISPANIA/datums/traits/neutral.dm
+++ b/code/HISPANIA/datums/traits/neutral.dm
@@ -6,3 +6,16 @@
 	gain_text = "<span class='notice'>You can't taste anything!</span>"
 	lose_text = "<span class='notice'>You can taste again!</span>"
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
+
+//IPC
+/datum/quirk/terminator
+	name = "Terminator"
+	desc = "Eres un IPC que has sido usado para la guerra. Eres resistente, pero tosco y lento."
+	value = 0
+	gain_text = "<span class='notice'>Te sientes resistente, pero lento.</span>"
+	lose_text = "<span class='notice'>Tu cuerpo se aligera, pero te sientes fragil.</span>"
+/datum/quirk/terminator/add()
+	if(ismachineperson(quirk_holder))
+		quirk_holder.dna.species.brute_mod = 1.2
+		quirk_holder.dna.species.burn_mod = 1.2
+		quirk_holder.dna.species.speed_mod = 2

--- a/code/HISPANIA/datums/traits/neutral.dm
+++ b/code/HISPANIA/datums/traits/neutral.dm
@@ -10,10 +10,11 @@
 //IPC
 /datum/quirk/terminator
 	name = "Terminator"
-	desc = "Eres un IPC que has sido usado para la guerra. Eres resistente, pero tosco y lento."
+	desc = "Eres un IPC que has sido usado para la guerra. Eres resistente, pero tosco y lento. (Solo IPC)"
 	value = 0
 	gain_text = "<span class='notice'>Te sientes resistente, pero lento.</span>"
 	lose_text = "<span class='notice'>Tu cuerpo se aligera, pero te sientes fragil.</span>"
+
 /datum/quirk/terminator/add()
 	if(ismachineperson(quirk_holder))
 		quirk_holder.dna.species.brute_mod = 1.2


### PR DESCRIPTION
Se añade el quirk terminator, para los IPC

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Añade un quirk, el cual cambia la resistencia de los IPC pero los vuelve mas lentos. 

Ahora si el quirk esta activo, la resistencia al daño bruto y de quemaduras sera de 0.8. EL movement delay pasa a ser de 2.

## Why It's Good For The Game
Les da una segunda opción a los IPC, ser mas resistentes a costa de su velocidad.

## Images of changes
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Quirk Terminator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
