### PR TITLE
Fix a sonido al point_to con un arma de fuego

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -253,7 +253,7 @@
 			return TRUE
 		A.visible_message("<span class='danger'>[src] points [hand_item] at [A]!</span>",
 											"<span class='userdanger'>[src] points [hand_item] at you!</span>")
-		A << 'sound/weapons/targeton.ogg'
+		playsound(src, 'sound/weapons/targeton.ogg', 75, 1, -1)
 		return TRUE
 	visible_message("<b>[src]</b> points to [A]")
 	return TRUE


### PR DESCRIPTION
Una feature que ya andaba en paradise pero se volvió obsoleta con el tiempo, aquí se arregla.

## Why It's Good For The Game
Mas feedback a la hora de apuntar con armas y da mas chicha para roleo por que es mas fácil de saber cuando te están apuntando con una.

## Changelog
:cl:
fix: Las armas ahora al apuntar objetos tienen un sonido, intended feature.
/:cl:
