### PR TITLE
Fix menciones innecesarias

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -279,7 +279,7 @@ SUBSYSTEM_DEF(ticker)
 	//start_events() //handles random events and space dust.
 	//new random event system is handled from the MC.
 
-	SSdiscord.send2discord_simple("**\[Info]** Round has started")
+	SSdiscord.send2discord_simple("**\[Info]** Round has started") //El _noadmins al final de SSdiscord.send2discord_simple hacia que mencione a los admins cada vez que comenzaba una ronda, lo cual era innecesario
 	auto_toggle_ooc(0) // Turn it off
 	round_start_time = world.time
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -279,7 +279,7 @@ SUBSYSTEM_DEF(ticker)
 	//start_events() //handles random events and space dust.
 	//new random event system is handled from the MC.
 
-	SSdiscord.send2discord_simple_noadmins("**\[Info]** Round has started")
+	SSdiscord.send2discord_simple("**\[Info]** Round has started")
 	auto_toggle_ooc(0) // Turn it off
 	round_start_time = world.time
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&[713556765576396820]> ")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "A round of [name] has ended - [surviving_total] survivors, [ghosts] ghosts.")
 	return 0
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "A round of [name] has ended - [surviving_total] survivors, [ghosts] ghosts.")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&713556765576396820> ")
 	return 0
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&713556765576396820> ")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&[713556765576396820]> ")
 	return 0
 
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -560,7 +560,7 @@
 	var/watchreason = check_watchlist(ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
-		SSdiscord.send2discord_simple_noadmins("**\[Watchlist]** [key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+		SSdiscord.send2discord_simple("**\[Watchlist]** [key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
 
 
 	//Just the standard check to see if it's actually a number
@@ -772,7 +772,7 @@
 			if(cidcheck_failedckeys[ckey])
 				// Atonement
 				message_admins("<span class='adminnotice'>[key_name_admin(src)] has been allowed to connect after showing they removed their cid randomizer</span>")
-				SSdiscord.send2discord_simple_noadmins("**\[Info]** [key_name(src)] has been allowed to connect after showing they removed their cid randomizer.")
+				SSdiscord.send2discord_simple("**\[Info]** [key_name(src)] has been allowed to connect after showing they removed their cid randomizer.")
 				cidcheck_failedckeys -= ckey
 			if (cidcheck_spoofckeys[ckey])
 				message_admins("<span class='adminnotice'>[key_name_admin(src)] has been allowed to connect after appearing to have attempted to spoof a cid randomizer check because it <i>appears</i> they aren't spoofing one this time</span>")

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -126,7 +126,7 @@
 	if(status >= min_status)
 		if(!current_state)
 			log_and_message_admins(message)
-			SSdiscord.send2discord_simple_noadmins(message)
+			SSdiscord.send2discord_simple(message)
 		return TRUE
 	else
 		return FALSE


### PR DESCRIPTION
## What Does This PR Do
Quita algunos mentions innecesarios en mensajes del bot/la integración

## Why It's Good For The Game
Evita que el bot (la integración de discord) nos torture mandando 15 mentions por segundo

#changelog 
:cl:
tweak: Borro una parte en algunos mensajes del bot/la integración de discord para evitar que mencione al hispa staff en mensajes que no era necesario
/:cl: