### PR TITLE
New round mention

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -760,7 +760,7 @@
 				if("discord_webhooks_admin_role_id")
 					discord_admin_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
 				if("discord_webhooks_newround_role_id")
-					discord_newround_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
+					discord_newround_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers, esta es una variable de hispania
 				if("discord_webhooks_main_url")
 					discord_main_webhook_urls = splittext(value, "|")
 				if("discord_webhooks_admin_url")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -258,7 +258,7 @@
 	var/discord_admin_role_id = null // Intentional null usage
 
 	/// Role ID to be pinged for administrative events
-	var/discord_newround_role_id = null // Intentional null usage
+	var/discord_newround_role_id = null // Intentional null usage, toma el valor del archivo .config
 
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()
@@ -760,7 +760,7 @@
 				if("discord_webhooks_admin_role_id")
 					discord_admin_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
 				if("discord_webhooks_newround_role_id")
-					discord_newround_role_id = "[value]" // Este comentario no tiene ningun sentido pero, Hola, todo bien?
+					discord_newround_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
 				if("discord_webhooks_main_url")
 					discord_main_webhook_urls = splittext(value, "|")
 				if("discord_webhooks_admin_url")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -258,7 +258,7 @@
 	var/discord_admin_role_id = null // Intentional null usage
 
 	/// Role ID to be pinged for administrative events
-	var/discord_newround_role_id //toma el valor del archivo config.txt
+	var/discord_newround_role_id //toma el valor del archivo config.txt, esta es una variable de hispania
 
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -257,6 +257,9 @@
 	/// Role ID to be pinged for administrative events
 	var/discord_admin_role_id = null // Intentional null usage
 
+	/// Role ID to be pinged for administrative events
+	var/discord_newround_role_id = null // Intentional null usage
+
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()
 
@@ -756,6 +759,8 @@
 					discord_webhooks_enabled = TRUE
 				if("discord_webhooks_admin_role_id")
 					discord_admin_role_id = "[value]" // This MUST be a string because BYOND doesnt like massive integers
+				if("discord_webhooks_newround_role_id")
+					discord_newround_role_id = "[value]" // Este comentario no tiene ningun sentido pero, Hola, todo bien?
 				if("discord_webhooks_main_url")
 					discord_main_webhook_urls = splittext(value, "|")
 				if("discord_webhooks_admin_url")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -258,7 +258,7 @@
 	var/discord_admin_role_id = null // Intentional null usage
 
 	/// Role ID to be pinged for administrative events
-	var/discord_newround_role_id = null // Intentional null usage, toma el valor del archivo .config
+	var/discord_newround_role_id // Intentional null usage, toma el valor del archivo .config
 
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -258,7 +258,7 @@
 	var/discord_admin_role_id = null // Intentional null usage
 
 	/// Role ID to be pinged for administrative events
-	var/discord_newround_role_id // Intentional null usage, toma el valor del archivo .config
+	var/discord_newround_role_id //toma el valor del archivo config.txt
 
 	/// Webhook URLs for the main public webhook
 	var/list/discord_main_webhook_urls = list()

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -53,9 +53,9 @@ SUBSYSTEM_DEF(discord)
 
 	if(active_admins <= 0)
 		if(inactive_admins > 0)
-			alerttext = " | **ALL ADMINS AFK**"
+			alerttext = " | **TODOS LOS ADMINS ESTÁN AFK**"
 		else
-			alerttext = " | **NO ADMINS ONLINE**"
+			alerttext = " | **NO HAY ADMINS ONLINE**"
 	else
 		if(check_send_always && config.discord_forward_all_ahelps)
 			// If we are here, there are admins online. We want to forward everything, but obviously dont want to add a ping, so we do this

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -23,8 +23,6 @@ SUBSYSTEM_DEF(discord)
 			webhook_urls = config.discord_main_webhook_urls
 		if(DISCORD_WEBHOOK_MENTOR)
 			webhook_urls = config.discord_mentor_webhook_urls
-		if(DISCORD_WEBHOOK_NEWROUND)
-			webhook_urls = config.discord_newround_webhook_urls
 
 	var/datum/discord_webhook_payload/dwp = new()
 	dwp.webhook_content = content

--- a/code/controllers/subsystem/discord.dm
+++ b/code/controllers/subsystem/discord.dm
@@ -23,6 +23,8 @@ SUBSYSTEM_DEF(discord)
 			webhook_urls = config.discord_main_webhook_urls
 		if(DISCORD_WEBHOOK_MENTOR)
 			webhook_urls = config.discord_mentor_webhook_urls
+		if(DISCORD_WEBHOOK_NEWROUND)
+			webhook_urls = config.discord_newround_webhook_urls
 
 	var/datum/discord_webhook_payload/dwp = new()
 	dwp.webhook_content = content

--- a/code/datums/discord.dm
+++ b/code/datums/discord.dm
@@ -78,6 +78,8 @@
 	embed_timestamp = time_stamp() // 8601 is king
 	fields = list() // Initialize the list
 
+/datum/discord_embed/embed/new_round
+
 /**
   * Embed Serializer
   *

--- a/code/datums/discord.dm
+++ b/code/datums/discord.dm
@@ -78,8 +78,6 @@
 	embed_timestamp = time_stamp() // 8601 is king
 	fields = list() // Initialize the list
 
-/datum/discord_embed/embed/new_round
-
 /**
   * Embed Serializer
   *

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "A round of [name] has ended - [surviving_total] survivors, [ghosts] ghosts.")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&713556765576396820> ")
 	return 0
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&[713556765576396820]> ")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&[config.discord_newround_role_id]> ")
 	return 0
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -209,7 +209,7 @@
 	if(escaped_on_pod_5 > 0)
 		feedback_set("escaped_on_pod_5",escaped_on_pod_5)
 
-	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&713556765576396820> ")
+	SSdiscord.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "Una ronda en modo [name] acaba de terminar - [surviving_total] supervivientes, [ghosts] muertos. <@&[713556765576396820]> ")
 	return 0
 
 

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -126,6 +126,6 @@
 				modmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mods_online++
 
-	var/noadmins_info = "\n<span class='notice'><small>If no admins or mentors are online, make a ticket anyways. Adminhelps and mentorhelps will be relayed to discord, and staff will still be informed.<small></span>"
+	var/noadmins_info = "\n<span class='notice'><small>Si no hay administradores o mentors online, de igual forma haz un ticket. Los adminhelps y mentorhelps seran enviados a discord y el staff sera informado.<small></span>"
 	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b>Current Mentors ([num_mods_online]):</b>\n" + modmsg + noadmins_info
 	to_chat(src, msg)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -456,7 +456,7 @@ BYOND_ACCOUNT_AGE_THRESHOLD 7
 ## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
 #DISCORD_WEBHOOKS_ADMIN_ROLE_ID
 
-## ID del rol que el webhook menciona cuando termina , si no se modifica, la mencion estara desactivada
+## ID del rol que el webhook menciona cuando termina , si no se modifica, la mencion estara desactivada, esta es una variable de hispania
 ## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
 #DISCORD_WEBHOOKS_NEWROUND_ROLE_ID
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -456,6 +456,10 @@ BYOND_ACCOUNT_AGE_THRESHOLD 7
 ## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
 #DISCORD_WEBHOOKS_ADMIN_ROLE_ID
 
+## ID del rol que el webhook menciona cuando termina , si no se modifica, la mencion estara desactivada
+## IF YOU ARE DISABLING THIS COMMENT IT OUT ENTIRELY, DONT LEAVE IT BLANK
+#DISCORD_WEBHOOKS_NEWROUND_ROLE_ID
+
 ## Webhook URLs for the main discord webhook. Separate multiple URLs with a | (EG: https://url1|https://url2)
 #DISCORD_WEBHOOKS_MAIN_URL
 


### PR DESCRIPTION
## What Does This PR Do
El bot/La intergación de discord ahora menciona al rol new round (o el rol que pongas en config.txt) cuando termina una ronda

## Why It's Good For The Game
porque.... [esta es la razón](https://cdn.discordapp.com/attachments/387645048386486273/782314784325894164/image0-1.gif)

#changelog 
:cl:
add: Ahora el rol que menciona el bot (integración de discord) puede ser modificado desde config.txt
tweak: Traduce el texto de adminwho y el de no admins online, también cambia el texto que envía el bot (una integración de discord) al terminar una ronda
/:cl: