### PR TITLE
Mini-Buff al Resonator y Upgraded Resonator

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -41,10 +41,11 @@
 		new /obj/effect/temp_visual/resonance(T, user, src, burst_time)
 		user.changeNext_move(CLICK_CD_MELEE)
 
-/obj/item/resonator/pre_attackby(atom/target, mob/user, params)
-	if(check_allowed_items(target, 1))
+/obj/item/resonator/afterattack(atom/target, mob/user, proximity, params)
+	var/distance = 0
+	distance = get_dist(user, target)
+	if(check_allowed_items(target, 1) && distance <= 2)
 		CreateResonance(target, user)
-	return TRUE
 
 //resonance field, crushes rock, damages mobs
 /obj/effect/temp_visual/resonance


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! --> Hace que puedas aplicar y detonar fields de resonator a un tile de distancia.

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> El resonator es absoluta basura actualmente y no trae ningún beneficio el usarlo, este cambio intenta que el resonator sea un punto medio entre el KA y el KC siendo de media distancia y daño mas alto que los otros dos, en cambio no tiene mejoras.

## Changelog
:cl:
**Tweak:** Reemplazado el pre_attackby del resonator por un afterattack que le permite atacar a una distancia media.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
