### PR TITLE
Wishgranter hoy siempre.

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -31,6 +31,7 @@
 	description = "Nothing good can come from this. Learn from their mistakes and turn around."
 	suffix = "lavaland_surface_cube.dmm"
 	cost = 10
+	always_place = TRUE
 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/seed_vault


### PR DESCRIPTION
## What Does This PR Do
Permite al Whisgranter spawnear siempre en algún lugar aleatorio de lavaland.

## Why It's Good For The Game
Antes tenia sentido que el wish no saliera casi nunca ya que la recompensa que daba era demasiado poderosa y un antag gratis, actualmente las recompensas del wish aunque interesantes no son la gran cosa por lo que no hay mucho problema en que salga uno siempre en algún lugar de lavaland.

## Changelog
:cl:
tweak: Un Wishgrante saldrá en todas las partidas.
/:cl: