### PR TITLE
Ka Experimental sprite repair

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -166,7 +166,7 @@
 	name = "experimental kinetic accelerator"
 	desc = "A modified version of the proto-kinetic accelerator, with twice the modkit space of the standard version."
 	icon_state = "kineticgun_h"
-	item_state = "kineticgun_h"
+	item_state = "kineticgun"
 	origin_tech = "combat=5;powerstorage=3;engineering=5"
 	max_mod_capacity = 200
 


### PR DESCRIPTION
## Why It's Good For The Game
Repara el bug que hace que el KA Experimental no se vea en la mano.

## Images of changes
Desde que salio Para ni los coders de ahi se calentaron en reparar este bug tan boludo, por fin ya esta reparado.

## Changelog
:cl:
fix: Kinetic Accelerator Experimental sprite arreglado
/:cl: