### PR TITLE
Funcionamiento original de la duct tape

### DIFF
--- a/code/datums/components/ducttape.dm
+++ b/code/datums/components/ducttape.dm
@@ -49,8 +49,9 @@
 		return
 	var/turf/source_turf = get_turf(I)
 	var/turf/target_turf = target
-	var/x_offset
-	var/y_offset
+	var/list/clickparams = params2list(params)
+	var/x_offset = text2num(clickparams["icon-x"]) - 16
+	var/y_offset = text2num(clickparams["icon-y"]) - 16
 	if(target_turf != get_turf(I)) //Trying to stick it on a wall, don't move it to the actual wall or you can move the item through it. Instead set the pixels as appropriate
 		var/target_direction = get_dir(source_turf, target_turf)//The direction we clicked
 		// Snowflake diagonal handling
@@ -58,17 +59,13 @@
 			to_chat(user, "<span class='warning'>You cant reach [target_turf].</span>")
 			return
 		if(target_direction & EAST)
-			x_offset = 16
-			y_offset = rand(-12, 12)
+			x_offset += 32
 		else if(target_direction & WEST)
-			x_offset = -16
-			y_offset = rand(-12, 12)
+			x_offset -= 32
 		else if(target_direction & NORTH)
-			x_offset = rand(-12, 12)
-			y_offset = 16
+			y_offset += 32
 		else if(target_direction & SOUTH)
-			x_offset = rand(-12, 12)
-			y_offset = -16
+			y_offset -= 32
 	if(!user.unEquip(I))
 		return
 	to_chat(user, "<span class='notice'>You stick [I] to [target_turf].</span>")


### PR DESCRIPTION
Los duct tapes vuelven a pegarse en las paredes como antes, por offset de la posición del mouse en vez de una posición al azar en la pared.

## Why It's Good For The Game
Es lo que hacia especial a la duct tape, esto debe ser considerado un buff muy necesario.

## Images of changes
`Antes`

![Screenshot_1](https://user-images.githubusercontent.com/55407528/111157656-8426d900-856d-11eb-9e38-d424c9bd02cd.png)

`AHORA`
                                    
![image](https://user-images.githubusercontent.com/55407528/111157630-7c673480-856d-11eb-80c5-5b218fea1be5.png)


## Changelog
:cl:
tweak: duct tape buff
/:cl: