### PR TITLE
Resaltar items por los que pases por encima en la UI

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -116,6 +116,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 
 	//variables hispania
 	var/hispania_icon = FALSE
+	var/outline_filter
 
 	//Tooltip vars
 	var/in_inventory = FALSE //is this item equipped into an inventory slot or hand of a mob?
@@ -688,13 +689,39 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 
 /obj/item/MouseEntered(location, control, params)
 	if(in_inventory)
-		var/timedelay = 8
-		var/user = usr
-		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)
+		var/mob/living/L = usr
+		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, usr), 8, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
+		if(usr.client?.prefs.itemoutline_pref)
+			if(istype(L) && L.incapacitated())
+				apply_outline(COLOR_RED_GRAY) //if they're dead or handcuffed, let's show the outline as red to indicate that they can't interact with that right now
+			else
+				apply_outline() //if the player's alive and well we send the command with no color set, so it uses the theme's color
+
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	remove_outline()
 
 /obj/item/MouseExited()
 	deltimer(tip_timer) //delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
+	remove_outline()
+
+/obj/item/proc/apply_outline(outline_color = null)
+	if(!in_inventory || QDELETED(src) || isobserver(usr)) //cancel if the item isn't in an inventory, is being deleted, or if the person hovering is a ghost (so that people spectating you don't randomly make your items glow)
+		return
+	if(!outline_color) //if we weren't provided with a color, take the theme's color
+		outline_color = usr.client?.prefs.UI_style_color
+	if(color)
+		outline_color = COLOR_WHITE //if the item is recolored then the outline will be too, let's make the outline white so it becomes the same color instead of some ugly mix of the theme and the tint
+	if(outline_filter)
+		filters -= outline_filter
+	outline_filter = filter(type="outline", size=1, color=outline_color)
+	filters += outline_filter
+
+/obj/item/proc/remove_outline()
+	if(outline_filter)
+		filters -= outline_filter
+		outline_filter = null
 
 /obj/item/MouseDrop_T(obj/item/I, mob/user)
 	if(!user || user.incapacitated(ignore_lying = TRUE) || src == I)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -706,23 +706,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 	closeToolTip(usr)
 	remove_outline()
 
-/obj/item/proc/apply_outline(outline_color = null)
-	if(!in_inventory || QDELETED(src) || isobserver(usr)) //cancel if the item isn't in an inventory, is being deleted, or if the person hovering is a ghost (so that people spectating you don't randomly make your items glow)
-		return
-	if(!outline_color) //if we weren't provided with a color, take the theme's color
-		outline_color = usr.client?.prefs.UI_style_color
-	if(color)
-		outline_color = COLOR_WHITE //if the item is recolored then the outline will be too, let's make the outline white so it becomes the same color instead of some ugly mix of the theme and the tint
-	if(outline_filter)
-		filters -= outline_filter
-	outline_filter = filter(type="outline", size=1, color=outline_color)
-	filters += outline_filter
-
-/obj/item/proc/remove_outline()
-	if(outline_filter)
-		filters -= outline_filter
-		outline_filter = null
-
 /obj/item/MouseDrop_T(obj/item/I, mob/user)
 	if(!user || user.incapacitated(ignore_lying = TRUE) || src == I)
 		return

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -697,10 +697,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /image, image("icon" = 'icons/goonstation/effect
 			else
 				apply_outline() //if the player's alive and well we send the command with no color set, so it uses the theme's color
 
-/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	. = ..()
-	remove_outline()
-
 /obj/item/MouseExited()
 	deltimer(tip_timer) //delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)

--- a/code/hispania/game/objects/items.dm
+++ b/code/hispania/game/objects/items.dm
@@ -14,3 +14,7 @@
 	if(outline_filter)
 		filters -= outline_filter
 		outline_filter = null
+
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	remove_outline()

--- a/code/hispania/game/objects/items.dm
+++ b/code/hispania/game/objects/items.dm
@@ -1,0 +1,16 @@
+/obj/item/proc/apply_outline(outline_color = null)
+	if(!in_inventory || QDELETED(src) || isobserver(usr)) //cancel if the item isn't in an inventory, is being deleted, or if the person hovering is a ghost (so that people spectating you don't randomly make your items glow)
+		return
+	if(!outline_color) //if we weren't provided with a color, take the theme's color
+		outline_color = usr.client?.prefs.UI_style_color
+	if(color)
+		outline_color = COLOR_WHITE //if the item is recolored then the outline will be too, let's make the outline white so it becomes the same color instead of some ugly mix of the theme and the tint
+	if(outline_filter)
+		filters -= outline_filter
+	outline_filter = filter(type="outline", size=1, color=outline_color)
+	filters += outline_filter
+
+/obj/item/proc/remove_outline()
+	if(outline_filter)
+		filters -= outline_filter
+		outline_filter = null

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -82,6 +82,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 	var/ooccolor = "#b82e00"
 	var/list/be_special = list()				//Special role selection
 	var/UI_style = "Midnight"
+	var/itemoutline_pref = TRUE // HISPANIA
 	var/toggles = TOGGLES_DEFAULT
 	var/toggles2 = TOGGLES_2_DEFAULT // Created because 1 column has a bitflag limit of 24 (BYOND limitation not MySQL)
 	var/sound = SOUND_DEFAULT
@@ -466,6 +467,7 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 			dat += " - <b>Alpha (transparency):</b> <a href='?_src_=prefs;preference=UIalpha'><b>[UI_style_alpha]</b></a><br>"
 			dat += " - <b>Color:</b> <a href='?_src_=prefs;preference=UIcolor'><b>[UI_style_color]</b></a> <span style='border: 1px solid #161616; background-color: [UI_style_color];'>&nbsp;&nbsp;&nbsp;</span><br>"
 			dat += " - <b>UI Style:</b> <a href='?_src_=prefs;preference=ui'><b>[UI_style]</b></a><br>"
+			dat += " - <b>Item Hover Outlines:</b> <a href='?_src_=prefs;preference=itemoutline_pref'>[itemoutline_pref ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Deadchat Anonymity:</b> <a href='?_src_=prefs;preference=ghost_anonsay'><b>[toggles2 & PREFTOGGLE_2_ANONDCHAT ? "Anonymous" : "Not Anonymous"]</b></a><br>"
 			if(user.client.donator_level > 0)
 				dat += "<b>Donator Publicity:</b> <a href='?_src_=prefs;preference=donor_public'><b>[(toggles & PREFTOGGLE_DONATOR_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
@@ -2055,6 +2057,9 @@ GLOBAL_LIST_INIT(special_role_times, list( //minimum age (in days) for accounts 
 					if(ishuman(usr)) //mid-round preference changes, for aesthetics
 						var/mob/living/carbon/human/H = usr
 						H.remake_hud()
+
+				if("itemoutline_pref")
+					itemoutline_pref = !itemoutline_pref
 
 				if("tgui")
 					toggles2 ^= PREFTOGGLE_2_FANCYUI

--- a/paradise.dme
+++ b/paradise.dme
@@ -1170,6 +1170,7 @@
 #include "code\hispania\game\mecha\mecha_control_console.dm"
 #include "code\hispania\game\mecha\paintkits.dm"
 #include "code\hispania\game\mecha\equipament\tools\medical_tools.dm"
+#include "code\hispania\game\objects\items.dm"
 #include "code\hispania\game\objects\items\folding.dm"
 #include "code\hispania\game\objects\items\inducer.dm"
 #include "code\hispania\game\objects\items\policetape.dm"


### PR DESCRIPTION
Port de TG || Al pasar el mouse por encima de objetos en tu inventario estos se resaltaran con el color de tu `ui_style_color`, que es seleccionable por el jugador en el menu de preferencias.

## Why It's Good For The Game
Mas feedback en el menu, todo cambio que quiera mejorar la interectividad de jugador con UI es inmediatamente
 positiva.

## Images of changes
![Screenshot_1](https://user-images.githubusercontent.com/55407528/111319585-8b68e800-863c-11eb-933d-40fdbc624a73.png)
![Screenshot_2](https://user-images.githubusercontent.com/55407528/111319599-8e63d880-863c-11eb-87bb-3d1fec587e7b.png)

                      Al estar incapacitado el color del hover se vuelve grisaseo

![Screenshot_3](https://user-images.githubusercontent.com/55407528/111319655-9face500-863c-11eb-9ca7-4f5c3d05682e.png)



## Changelog
:cl:
add: Resaltar objetos por los que pases por encima en el inventario.
/:cl: