### PR TITLE
Maint drones pueden volver a entender el lenguaje universal

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -57,7 +57,7 @@
 	remove_language("Galactic Common")
 	add_language("Drone Talk", TRUE)
 	add_language("Drone", TRUE)
-	universal_understand = 0
+	universal_understand = 1
 
 	// Disable the microphone wire on Drones
 	if(radio)


### PR DESCRIPTION
## What Does This PR Do
Es cáncer jugar de maint drone y escuchar "blah blah blah" por la radio todo el tiempo, por ello se le devuelve el poder entender a la tripulación. Las personas seguirán sin entender a los drones, pero ellos podrán saber de brechas y anuncios importantes.

## Why It's Good For The Game
Jugar dronde no va a ser tan aburrido

## Changelog
:cl:
add: Los drones de mantenimiento ahora pueden entender a los tripulantes.

/:cl: