### PR TITLE
Eliminacion del multiplicador de daño

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,7 +15,7 @@
 
 	eyes = "blank_eyes"
 	brute_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
-	burn_mod = 2.28
+	burn_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,8 +14,6 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
-	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,7 +15,7 @@
 
 	eyes = "blank_eyes"
 	brute_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
-	burn_mod = 2.28 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
+	burn_mod = 2.28
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,6 +14,7 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
+	brute_mod = 1.5 // 100% * 1.5 * 0.66 (robolimbs) ~= 100%
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,7 +15,7 @@
 
 	eyes = "blank_eyes"
 	brute_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
-	burn_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
+	burn_mod = 2.28 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,7 +14,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1.5 // 100% * 1.5 * 0.66 (robolimbs) ~= 100%
+	brute_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
+	burn_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
 	tox_mod = 0
 	clone_mod = 0
 	death_message = "gives a short series of shrill beeps, their chassis shuddering before falling limp, nonfunctional."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Se elimina el multiplicador de daño bruto y daño por quemaduras de los IPC.

## Why It's Good For The Game
Los IPC ahora recibiran el mismo daño que los seres humanos, y por ende no serán tan fáciles de desmabrar y matar. 


## Changelog
:cl:
del: Se eliminan los multiplicadores de daño.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
