### PR TITLE
Revert "Eliminacion del multiplicador de daño"

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -14,8 +14,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 1.51 // 100% * 1.51 * 0.66 (robolimbs) ~= 100%
-	burn_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
+	brute_mod = 2.28 // 100% * 2.28 * 0.66 (robolimbs) ~= 150%
+	burn_mod = 2.28  // So they take 50% extra damage from brute/burn overall
 	tox_mod = 0
 	clone_mod = 0
 	hunger_drain = 0.14


### PR DESCRIPTION
se supone habiamos codeado un quirk para darle una alternativa a los ipc, por qué necesitamos esto?
Reverts Helixis/Paradise#844