### PR TITLE
[Map Change] Re agregar nave de mineria

### DIFF
--- a/_maps/map_files/hispania/Lavaland.dmm
+++ b/_maps/map_files/hispania/Lavaland.dmm
@@ -2030,7 +2030,7 @@
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 3;
-	height = 5;
+	height = 7;
 	id = "mining";
 	name = "mining shuttle";
 	rebuildable = 1;
@@ -2041,7 +2041,7 @@
 	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 3;
-	height = 5;
+	height = 7;
 	id = "mining_away";
 	name = "lavaland mine";
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
@@ -4591,6 +4591,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"mG" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "mT" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower,
@@ -4640,6 +4645,13 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
+"sn" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "sS" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4739,10 +4751,6 @@
 "CO" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/siberia)
-"CW" = (
-/obj/structure/table,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
 "CY" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -4818,6 +4826,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"Is" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "It" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/simulated/floor/plasteel{
@@ -4858,12 +4879,6 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
-"Lq" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
 "NX" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/plasteel,
@@ -4872,6 +4887,30 @@
 /obj/structure/chair/sofa/left,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"Pl" = (
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
+"Pr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/shovel,
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 20
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "PB" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
@@ -4884,6 +4923,15 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = 30;
+	pixel_y = 0;
+	req_access_txt = "0"
+	},
+/obj/item/storage/pill_bottle/patch_pack,
+/obj/item/storage/pill_bottle/patch_pack,
+/obj/item/roller,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "Ru" = (
@@ -4904,6 +4952,10 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plasteel,
 /area/mine/living_quarters)
+"SM" = (
+/obj/structure/ore_box,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "Tn" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -4927,6 +4979,15 @@
 /obj/item/clothing/head/beanie/waldo,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ZK" = (
+/obj/structure/rack,
+/obj/item/pickaxe,
+/obj/item/shovel,
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 20
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 
 (1,1,1) = {"
 aa
@@ -16198,7 +16259,7 @@ cI
 cI
 cI
 cX
-cX
+cQ
 bp
 bp
 aD
@@ -16453,8 +16514,8 @@ cI
 cI
 cX
 cX
-cX
-cX
+cQ
+cQ
 bp
 bp
 bp
@@ -16708,12 +16769,12 @@ bp
 bp
 cX
 cX
-cX
-cX
+cQ
+cQ
 bp
 bp
 bp
-bp
+aD
 bp
 bp
 bp
@@ -16967,13 +17028,13 @@ bp
 bp
 bp
 bp
-bp
-bp
+aD
+aD
 aD
 bp
-bp
-bp
-bp
+aD
+aD
+aD
 bp
 bp
 aD
@@ -17223,15 +17284,15 @@ bp
 bp
 bp
 bp
-bp
-bp
-bp
 aD
-bp
+uR
+uR
+zi
+uR
+zi
+uR
+uR
 aD
-bp
-bp
-bp
 bp
 bp
 fs
@@ -17479,16 +17540,16 @@ bp
 bp
 bp
 bp
-bp
-bp
 aD
 aD
+uR
+Pr
+Pl
+sn
+Hr
+SM
+uR
 aD
-aD
-aD
-aD
-aD
-bp
 bp
 bp
 bp
@@ -17735,16 +17796,16 @@ aD
 bp
 bp
 bp
-bp
-bp
 aD
-uR
-uR
+aD
+aD
 zi
-uR
-zi
-uR
-uR
+ZK
+Cx
+Cx
+CY
+Is
+Hi
 aD
 bp
 bp
@@ -17996,10 +18057,10 @@ bp
 aD
 aD
 uR
-CW
+Jm
+CY
 Cx
-Lq
-Hr
+CY
 Xz
 uR
 aD
@@ -18253,10 +18314,10 @@ bp
 aD
 aD
 zi
-Jm
-CY
+mG
 Cx
-Hr
+Cx
+CY
 sS
 Hi
 aD
@@ -18511,7 +18572,7 @@ bp
 aD
 uR
 Re
-Cx
+Pl
 Cx
 Hr
 vm

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -58756,7 +58756,7 @@
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 3;
-	height = 5;
+	height = 7;
 	id = "mining_home";
 	name = "mining shuttle bay";
 	width = 7


### PR DESCRIPTION
## What Does This PR Do
Reagrega mi nave de minería la cual es mas grande y mas equipada.

## Why It's Good For The Game
Evita múltiples accidentes tanto como para la gente que se atora en cajas como los que salen volando de la shuttle debido al corto espacio para maniobrar.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116335459-88fdc000-a79c-11eb-9941-ba50e892cfbf.png)
![image](https://user-images.githubusercontent.com/46639834/116335563-b21e5080-a79c-11eb-8457-9e9d65f23105.png)
![image](https://user-images.githubusercontent.com/46639834/116335576-b8acc800-a79c-11eb-8034-050d54e9dc82.png)
![image](https://user-images.githubusercontent.com/46639834/116335595-bcd8e580-a79c-11eb-866b-e298d18568f9.png)

## Changelog
:cl:
add: Nave de Mineria
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
