### PR TITLE
Tweak Palabras Clave de Traitor

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -129,6 +129,7 @@ GLOBAL_VAR(syndicate_code_response) //Code response for traitors.
 	/N
 	*/
 
+/* Quitar si no usan frases en espanol
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
 	var/code_phrase = ""//What is returned when the proc finishes.
@@ -187,6 +188,7 @@ GLOBAL_VAR(syndicate_code_response) //Code response for traitors.
 			code_phrase += ", "
 
 	return code_phrase
+*/
 
 /proc/GenerateKey()
 	var/newKey

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR(syndicate_code_response) //Code response for traitors.
 	/N
 	*/
 
-/* Quitar si no usan frases en espanol
+/* Quitar si no usan frases en español
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
 	var/code_phrase = ""//What is returned when the proc finishes.

--- a/code/hispania/__HELPERS/names.dm
+++ b/code/hispania/__HELPERS/names.dm
@@ -1,0 +1,14 @@
+/proc/generate_code_phrase()//Proc da palabras en espanol
+	var/code_phrase = ""
+	var/words = 4 //Numero de palabras para Antag
+	var/nouns[] = list("amor","odio","enojo","paz","orgullo","simpatia","valentia","lealtad","honestidad","integridad","compasion","caridad","éxito","coraje","amable","habilidad","belleza","brillantez","dolor","miseria","creencias","atrevido","justicia","verdad","fe","libertad","conocimiento","pensamiento","informacion","cultura","confianza","dedicacion","progreso","educacion","hospitalidad","ocio","problema","amistades", "relajacion")
+	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","irish coffee"," manly dwarf","Irish cream","doctor's delight","beepksy smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white russian","vodka martini","martini","cuba libre","kahlua","vodka","wine","moonshine")
+	for(words,words>0,words--)
+		switch(rand(1,2))
+			if(1)
+				code_phrase += pick(nouns)
+				code_phrase += " - "
+			if(2)
+				code_phrase += pick(drinks)
+				code_phrase += " - "
+	return code_phrase

--- a/code/hispania/__HELPERS/names.dm
+++ b/code/hispania/__HELPERS/names.dm
@@ -1,8 +1,8 @@
-/proc/generate_code_phrase()//Proc da palabras en espanol
+/proc/generate_code_phrase()//Proc da palabras en español
 	var/code_phrase = ""
 	var/words = 4 //Numero de palabras para Antag
 	var/nouns[] = list("amor","odio","enojo","paz","orgullo","simpatia","valentia","lealtad","honestidad","integridad","compasion","caridad","éxito","coraje","amable","habilidad","belleza","brillantez","dolor","miseria","creencias","atrevido","justicia","verdad","fe","libertad","conocimiento","pensamiento","informacion","cultura","confianza","dedicacion","progreso","educacion","hospitalidad","ocio","problema","amistades", "relajacion")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","irish coffee"," manly dwarf","Irish cream","doctor's delight","beepksy smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white russian","vodka martini","martini","cuba libre","kahlua","vodka","wine","moonshine")
+	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","cafe"," manly dwarf","crema irlandesa","doctor's delight","beepksy smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white russian","vodka martini","martini","cuba libre","kahlua","vodka","vino","moonshine")
 	for(words,words>0,words--)
 		switch(rand(1,2))
 			if(1)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1139,6 +1139,7 @@
 #include "code\game\verbs\who.dm"
 #include "code\hispania\__DEFINES\monkey.dm"
 #include "code\hispania\__HELPERS\cmp.dm"
+#include "code\hispania\__HELPERS\names.dm"
 #include "code\hispania\__HELPERS\unsorted.dm"
 #include "code\hispania\controllers\subsystem\processing\quirks.dm"
 #include "code\hispania\datums\autofiresystem.dm"


### PR DESCRIPTION
## What Does This PR Do
Cambia el proceso que genera las palabras clave por ronda a una simple toma aleatoria de cuatro objetos dentro de dos arreglos con múltiples opciones, bebidas en nombres originales y palabras en español. Si gustan alguna palabra se cambie sin problemas puedo anexarla a la lista.

## Why It's Good For The Game
Anteriormente el proceso tomaba un numero aleatorio de palabras no mayor a seis de una lista generada por nombres, localizaciones, adjetivos, palabras y verbos en ingles. Todos estos causaban que las palabras clave fueran bastante difíciles de usar en una conversación casual. Espero que con este cambio las puedan usar nuevamente por el uso de palabras mas casuales y en español.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116359793-d726b980-a7c4-11eb-953f-85098cc9c3f2.png)

## Changelog
:cl:
tweak: Proc Palabras Traitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
