### PR TITLE
Tweak Binocular a Belts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -53,6 +53,7 @@
 	pickup_sound = 'sound/items/handling/toolbelt_pickup.ogg'
 	can_hold = list(
 		/obj/item/taperoll,
+		/obj/item/device/binoculars,
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -219,6 +220,7 @@
 	use_item_overlays = TRUE
 	can_hold = list(
 		/obj/item/taperoll,
+		/obj/item/device/binoculars,
 		/obj/item/grenade/flashbang,
 		/obj/item/grenade/chem_grenade/teargas,
 		/obj/item/reagent_containers/spray/pepper,
@@ -743,6 +745,7 @@
 	use_item_overlays = FALSE
 	can_hold = list(
 		/obj/item/crowbar,
+		/obj/item/device/binoculars,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,


### PR DESCRIPTION
## What Does This PR Do
Agrega la posibilidad de meter bionoculares en belts de ingeniería, minería y seguridad.

## Why It's Good For The Game
Actualmente el donde guardar esta herramienta es un problema cuando si o si tiene que ir dentro de la mochila, con esto lo hace viable para llenar uno de tus espacios. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116364468-d8a6b080-a7c9-11eb-9f41-123c51d949d2.png)
![image](https://user-images.githubusercontent.com/46639834/116364482-d9d7dd80-a7c9-11eb-809d-f1f5901af199.png)
![image](https://user-images.githubusercontent.com/46639834/116364491-dba1a100-a7c9-11eb-8b3d-ffaaf6f333bb.png)


## Changelog
:cl:
tweak: Binoculares a Belts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
