### PR TITLE
Fix Pancakes

### DIFF
--- a/code/hispania/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/hispania/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -306,8 +306,8 @@
 	filling_color = "#EFD8A7"
 
 ///        Pancakes    (Coughthanksumeandevancough) ///
-/obj/item/reagent_containers/food/snacks/pancake
-    name = "pancake"
+/obj/item/reagent_containers/food/snacks/pancake_sal
+    name = "fluffy pancake"
     desc = "A fluffy pancake. The softer, superior relative of the waffle. This time with a top of butter."
     icon = 'icons/hispania/obj/food/food.dmi'
     icon_state = "pancake_1"
@@ -318,33 +318,33 @@
     var/list/pancakes = list()// If the pancakes are stacked, they come here
     tastes = list("soft dough" = 10, "butter" = 10)
 
-/obj/item/reagent_containers/food/snacks/pancake/update_icon()
+/obj/item/reagent_containers/food/snacks/pancake_sal/update_icon()
     overlays = list()
     if(pancakes.len > 0)
         desc = "A pile of delicious pancakes. There appears to be [pancakes.len+1] pancakes in the pile. All fully loaded of butter."
     icon_state = "pancake_[pancakes.len+1]"
 
-/obj/item/reagent_containers/food/snacks/pancake/attackby(obj/item/reagent_containers/food/snacks/pancake/I, mob/user, params)
-    if(istype(I, /obj/item/reagent_containers/food/snacks/pancake/))
-        var/obj/item/reagent_containers/food/snacks/pancake = I
+/obj/item/reagent_containers/food/snacks/pancake_sal/attackby(obj/item/reagent_containers/food/snacks/pancake_sal/I, mob/user, params)
+    if(istype(I, /obj/item/reagent_containers/food/snacks/pancake_sal/))
+        var/obj/item/reagent_containers/food/snacks/pancake_sal = I
 
         var/list/pancakestoadd = list()
-        pancakestoadd += pancake
-        for(var/obj/item/reagent_containers/food/snacks/pancake/i in I.pancakes)
+        pancakestoadd += pancake_sal
+        for(var/obj/item/reagent_containers/food/snacks/pancake_sal/i in I.pancakes)
             pancakestoadd += i
         if((pancakes.len) + pancakestoadd.len <= 2)
             user.drop_item()
-            pancake.loc = src
+            pancake_sal.loc = src
             pancakes.Add(pancakestoadd)
-            pancake.update_icon()
+            pancake_sal.update_icon()
             update_icon()
-            to_chat(user, "<span class='warning'>You put the [pancake] ontop of the [src]!</span>")
+            to_chat(user, "<span class='warning'>You put the [pancake_sal] ontop of the [src]!</span>")
         else
             to_chat(user, "<span class='warning'>The stack is too high!</span>")
 
 ///        Pancakes de mermelada ñom ñom ///
 /obj/item/reagent_containers/food/snacks/pancake_mermelada
-    name = "pancake"
+    name = "fluffy berry pancake"
     desc = "A fluffy pancake. The softer, superior relative of the waffle. This time with a top of a jelly made of nispero and berries."
     icon = 'icons/hispania/obj/food/food.dmi'
     icon_state = "pancake_mermelada_1"

--- a/code/hispania/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/hispania/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -28,12 +28,12 @@
     result = /obj/item/reagent_containers/food/snacks/sliceable/honeybread
 
 //Pancake by Nothing (Con ayuda de Ume, gracias!)
-/datum/recipe/oven/pancake
+/datum/recipe/oven/pancake_sal
     reagents = list("sugar" = 5, "sodiumchloride" = 1)
     items = list(
         /obj/item/reagent_containers/food/snacks/sliceable/flatdough,
     )
-    result = /obj/item/reagent_containers/food/snacks/pancake
+    result = /obj/item/reagent_containers/food/snacks/pancake_sal
 
 //Peachmeat//
 /datum/recipe/oven/peachmeat

--- a/code/hispania/modules/hydroponics/grown/avocado.dm
+++ b/code/hispania/modules/hydroponics/grown/avocado.dm
@@ -35,7 +35,7 @@
 /obj/item/reagent_containers/food/snacks/grown/avocado/attackby(obj/item/W, mob/user, params)
 	if(is_sharp(W))
 		var/mob/living/carbon/human/H = user
-		if(prob(5))
+		if(prob(20))
 			var/picked_hand = pick("l_hand", "r_hand")
 			var/obj/item/organ/external/M = H.get_organ(picked_hand)
 			if (prob(99))

--- a/code/hispania/modules/hydroponics/grown/avocado.dm
+++ b/code/hispania/modules/hydroponics/grown/avocado.dm
@@ -35,7 +35,7 @@
 /obj/item/reagent_containers/food/snacks/grown/avocado/attackby(obj/item/W, mob/user, params)
 	if(is_sharp(W))
 		var/mob/living/carbon/human/H = user
-		if(prob(20))
+		if(prob(5))
 			var/picked_hand = pick("l_hand", "r_hand")
 			var/obj/item/organ/external/M = H.get_organ(picked_hand)
 			if (prob(99))


### PR DESCRIPTION
## What Does This PR Do
Repara una definicion en los pancakes que causaba el sprite no funcionara debido a que el objeto existia declarado dos veces bajo el mismo nombre, cambia el nombre de los pancakes creados por N0thing para denotar la diferencia entre ellos.

## Why It's Good For The Game
Repara los sprites y las recetas de pancakes.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116423276-280ad200-a806-11eb-8c3c-bf2c3cbc4368.png)


## Changelog
:cl:
fix: Pancakes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
