### PR TITLE
Add Trait Freeruner

### DIFF
--- a/code/__HELPERS/traits.dm
+++ b/code/__HELPERS/traits.dm
@@ -141,6 +141,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //hispatraits
 #define TRAIT_AGEUSIA			"ageusia"
 #define TRAIT_NOSLIPWATER		"noslip_water"
+#define TRAIT_FREERUNNING			"freerunning"
 //finhispatraits
 
 #define TRAIT_DWARF				"dwarf"

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -93,7 +93,11 @@
 	for(var/mob/living/M in get_turf(src))
 
 		if(M.lying) return //No spamming this on people.
-
+		//HISPATRAITS START
+		if(HAS_TRAIT(M, TRAIT_FREERUNNING))
+			to_chat(M, "<span class='warning'>You land on your feet like a boss!</span>")
+			return
+		//HISPATRAITS END
 		M.Weaken(5)
 		to_chat(M, "<span class='warning'>You topple as \the [src] moves under you!</span>")
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -96,6 +96,7 @@
 		//HISPATRAITS START
 		if(HAS_TRAIT(M, TRAIT_FREERUNNING))
 			to_chat(M, "<span class='warning'>You land on your feet like a boss!</span>")
+			to_chat(viewers(loc), "<span class='warning'>[M] lands on hes feet like a boss!</span>")
 			return
 		//HISPATRAITS END
 		M.Weaken(5)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -72,7 +72,7 @@
 	//HISPATRAITS START
 	var/escala = 50
 	if(HAS_TRAIT(user, TRAIT_FREERUNNING))
-		escala = 25
+		escala /= 2
 	//HISPATRAITS END
 	if(!do_after(user, escala, target = src))
 		climber = null

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -69,7 +69,12 @@
 
 	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
 	climber = user
-	if(!do_after(user, 50, target = src))
+	//HISPATRAITS START
+	var/escala = 50
+	if(HAS_TRAIT(user, TRAIT_FREERUNNING))
+		escala = 25
+	//HISPATRAITS END
+	if(!do_after(user, escala, target = src))
 		climber = null
 		return
 

--- a/code/hispania/datums/traits/positive.dm
+++ b/code/hispania/datums/traits/positive.dm
@@ -1,0 +1,8 @@
+/datum/quirk/freerunning
+	name = "Freerunning"
+	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls."
+	value = 2
+	mob_trait = TRAIT_FREERUNNING
+	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"
+	lose_text = "<span class='danger'>You feel clumsy again.</span>"
+	medical_record_text = "Patient scored highly on cardio tests."

--- a/paradise.dme
+++ b/paradise.dme
@@ -1151,6 +1151,7 @@
 #include "code\hispania\datums\traits\_quirk.dm"
 #include "code\hispania\datums\traits\negative.dm"
 #include "code\hispania\datums\traits\neutral.dm"
+#include "code\hispania\datums\traits\positive.dm"
 #include "code\hispania\defines\procs\discord.dm"
 #include "code\hispania\defines\procs\newsounds.dm"
 #include "code\hispania\game\data_huds.dm"


### PR DESCRIPTION
## What Does This PR Do
Añade el trait positivo de Freeruner con un costo de 2 puntos el cual disminuye a la mitad cualquier acción para escalar y evita recibas daño por caída.  

## Why It's Good For The Game
Añade una posibilidad para gastar esos dos puntos extras que te da el ser pacifico y ayuda con la diversidad en Traits.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116636129-2e906b00-a926-11eb-8eb6-28f047c8b63f.png)
![image](https://user-images.githubusercontent.com/46639834/116636134-305a2e80-a926-11eb-822c-61e0fb98f9dc.png)
![zKxZPy](https://user-images.githubusercontent.com/46639834/116636154-3fd97780-a926-11eb-9ca0-08309f1f3743.gif)
![image](https://user-images.githubusercontent.com/46639834/116636900-10c40580-a928-11eb-9f92-a623cae58b8c.png)

## Changelog
:cl:
add: Freeruner Trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
