### PR TITLE
[Map Change] Pequeñas reparaciones a la hispania.

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -5719,23 +5719,6 @@
 	dir = 1
 	},
 /area/security/seceqstorage)
-"amK" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
-"amL" = (
-/obj/machinery/shower{
-	tag = "icon-shower (WEST)";
-	icon_state = "shower";
-	dir = 8
-	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/plating,
-/area/maintenance/fsmaint)
 "amM" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "red";
@@ -23173,7 +23156,6 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "aUO" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
@@ -23480,7 +23462,6 @@
 	},
 /area/crew_quarters/dorms)
 "aVx" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
@@ -41364,9 +41345,7 @@
 	},
 /area/medical/reception)
 "bGf" = (
-/obj/structure/chair/comfy/teal{
-	dir = 1
-	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whiteblue";
 	icon_state = "whiteblue"
@@ -43338,6 +43317,7 @@
 	name = "station intercom (General)";
 	pixel_y = -28
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whiteblue (SOUTHEAST)";
 	icon_state = "whiteblue";
@@ -90193,6 +90173,14 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"eTM" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/space)
+"eUh" = (
+/obj/item/soap,
+/turf/simulated/floor/plating,
+/area/space)
 "eUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -92385,6 +92373,9 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"nTX" = (
+/turf/simulated/wall,
+/area/space)
 "nVM" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92481,6 +92472,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"oqN" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "ovc" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -94409,6 +94408,24 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"vBb" = (
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air{
+	filled = 0.1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
+"vEL" = (
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	tag = "icon-shower (WEST)"
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/plating,
+/area/space)
 "vEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -94428,6 +94445,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"vFe" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "vKM" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94566,6 +94593,13 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/storage/secure)
+"wnS" = (
+/obj/effect/spawner/random_barrier/possibly_welded_airlock,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint)
+"wqz" = (
+/turf/simulated/floor/plating,
+/area/space)
 "wqX" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/computer/atmos_alert,
@@ -94847,6 +94881,9 @@
 /obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"xko" = (
+/turf/space,
+/area/maintenance/fsmaint)
 "xms" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/machinery/camera{
@@ -133726,9 +133763,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+nTX
+nTX
+nTX
 awl
 awl
 awl
@@ -133983,11 +134020,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-awl
-amK
+nTX
+oqN
+wqz
+wnS
+atw
 atT
 auK
 bVQ
@@ -134240,11 +134277,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+nTX
+eTM
+eUh
 awl
-aCh
+vBb
 atG
 auA
 axg
@@ -134497,11 +134534,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+nTX
+vEL
+vFe
 awl
-amL
+awl
 atG
 axf
 dgk
@@ -134754,11 +134791,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+nTX
+nTX
+nTX
 awl
-awl
+xko
 awl
 azT
 azT

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -42622,12 +42622,8 @@
 /area/quartermaster/office)
 "bIH" = (
 /obj/machinery/door/window/eastleft{
-	base_state = "right";
 	dir = 2;
-	icon_state = "right";
-	layer = 3;
-	name = "interior door";
-	req_access_txt = "50"
+	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -41862,6 +41862,7 @@
 	input_dir = 1;
 	stack_amt = 10
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bHg" = (
@@ -42620,6 +42621,14 @@
 	},
 /area/quartermaster/office)
 "bIH" = (
+/obj/machinery/door/window/eastleft{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	layer = 3;
+	name = "interior door";
+	req_access_txt = "50"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
 "bII" = (
@@ -90173,14 +90182,10 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
-"eTM" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/space)
 "eUh" = (
 /obj/item/soap,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/fsmaint)
 "eUO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -92373,9 +92378,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
-"nTX" = (
-/turf/simulated/wall,
-/area/space)
 "nVM" = (
 /obj/effect/decal/warning_stripes/southwest,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92479,7 +92481,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/fsmaint)
 "ovc" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -94425,7 +94427,7 @@
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/fsmaint)
 "vEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -94454,7 +94456,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/maintenance/fsmaint)
 "vKM" = (
 /obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94597,9 +94599,6 @@
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
-"wqz" = (
-/turf/simulated/floor/plating,
-/area/space)
 "wqX" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/computer/atmos_alert,
@@ -133763,9 +133762,9 @@ aaa
 aaa
 aaa
 aaa
-nTX
-nTX
-nTX
+awl
+awl
+awl
 awl
 awl
 awl
@@ -134020,9 +134019,9 @@ aaa
 aaa
 aaa
 aaa
-nTX
+awl
 oqN
-wqz
+avq
 wnS
 atw
 atT
@@ -134277,8 +134276,8 @@ aaa
 aaa
 aaa
 aaa
-nTX
-eTM
+awl
+aCh
 eUh
 awl
 vBb
@@ -134534,7 +134533,7 @@ aaa
 aaa
 aaa
 aaa
-nTX
+awl
 vEL
 vFe
 awl
@@ -134791,9 +134790,9 @@ aaa
 aaa
 aaa
 aaa
-nTX
-nTX
-nTX
+awl
+awl
+awl
 awl
 xko
 awl


### PR DESCRIPTION
## What Does This PR Do
Reconfigura el sistema de salidas al espacio en el mantenimiento de seguridad y mueve de lugar dos plantas de medbay para evitar ser guardadas por los lockers frontales al inicio de cada ronda. Por ultimo pero no menos importante agrega una windoor en el triturador de basura.

## Why It's Good For The Game
Repara un error que deje en el mapa hace tiempo cuando agregamos diferentes holo-decks. Y evita que las plantas de medbay se metan en automático a los emergency closets. Con la windoor Samfun no terminara envuelto en esas capas de comida y basura que suelen llenar en las rondas largas. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116651379-b2f3e580-a948-11eb-96d5-6f03dc56df3b.png)
![image](https://user-images.githubusercontent.com/46639834/116651420-c8690f80-a948-11eb-874a-a1ca9a49602f.png)
![image](https://user-images.githubusercontent.com/46639834/116651928-d8cdba00-a949-11eb-9fbd-04c33eefd8d2.png)


## Changelog
:cl:
add: Reparaciones pequeñas y Windoors a Triturador
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
