### PR TITLE
Fix Alarmas de Anomalias

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -25,13 +25,6 @@
 
 /obj/effect/anomaly/Initialize(mapload, new_lifespan, _drops_core = TRUE)
 	. = ..()
-	set_light(initial(luminosity))
-	aSignal = new(src)
-	aSignal.code = rand(1,100)
-	aSignal.anomaly_type = type
-
-	var/new_frequency = sanitize_frequency(rand(PUBLIC_LOW_FREQ, PUBLIC_HIGH_FREQ))
-	aSignal.set_frequency(new_frequency)
 	GLOB.poi_list |= src
 	START_PROCESSING(SSobj, src)
 	impact_area = get_area(src)


### PR DESCRIPTION
## What Does This PR Do
Elimina líneas de código que quedaron tras los cambios realizados a las anomalias, estas causaban se generara un Runtime en el servidor lo cual detonaba en automatico las anomalias apenas existir. Ahora los anuncios funcionan con los tiempos previos respectivos para dar tiempo al equipo de ciencias de responder a ellas. 
 
## Why It's Good For The Game
Repara un Runtime el cual volvía en muertes casi instantáneas para el personal de la estación pues las anomalías detonaban apenas existir.  

## Images of changes

    Runtime que generaba error. 
![image](https://user-images.githubusercontent.com/46639834/116675698-b6e52f00-a96b-11eb-90b6-274f5cc97da0.png)

    Pruebas de diferentes anomalias
![image](https://user-images.githubusercontent.com/46639834/116675717-bea4d380-a96b-11eb-824b-48e0957537b0.png)
![image](https://user-images.githubusercontent.com/46639834/116675733-c4021e00-a96b-11eb-8fc8-a603a6bb7415.png)
![image](https://user-images.githubusercontent.com/46639834/116675752-c8c6d200-a96b-11eb-8f96-7e7cc32cdc4b.png)
![image](https://user-images.githubusercontent.com/46639834/116675766-ccf2ef80-a96b-11eb-9f41-5029c2b021a2.png)

## Changelog
:cl:
fix: Runtime de Anomalias
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
