### PR TITLE
Balance VTEC Cyborg Upgrade

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1047,7 +1047,7 @@
 	id = "borg_upgrade_vtec"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/vtec
-	req_tech = list("engineering" = 4, "materials" = 5, "programming" = 4)
+	req_tech = list("engineering" = 6, "materials" = 6, "programming" = 4) //Balance Hispania
 	materials = list(MAT_METAL=80000 , MAT_GLASS=6000 , MAT_URANIUM= 5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")


### PR DESCRIPTION
## What Does This PR Do
Sube los valores que requiere para poder ser ensamblada a Ingenieria 6 y Materiales 6. 

## Why It's Good For The Game
Atrasa un poco mas el tiempo para poder conseguir esta mejora la cual otorga una mejora considerablemente poderosa en poco tiempo y sin mucha intervención de otro departamento para conseguir, aparte de minerales para ensamblarla. 

## Images of changes
N/A

## Changelog
:cl:
tweak: Valores de VTEC Upgrade
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
