### PR TITLE
Tweak Dropper and Syringe Dump

### DIFF
--- a/code/hispania/modules/reagents/reagent_containers/dropper.dm
+++ b/code/hispania/modules/reagents/reagent_containers/dropper.dm
@@ -1,8 +1,5 @@
 /obj/item/reagent_containers/dropper/proc/dropperdump(atom/target, mob/user)
 	if(isfloorturf(target))
-		if(!reagents.total_volume)
-			to_chat(user, "<span class='notice'>[src] is empty.</span>")
-			return
 		if(user.a_intent == INTENT_HARM)
 			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
 							"<span class='notice'>You splash the contents of [src] onto [target].</span>")

--- a/code/hispania/modules/reagents/reagent_containers/dropper.dm
+++ b/code/hispania/modules/reagents/reagent_containers/dropper.dm
@@ -1,4 +1,4 @@
-/obj/item/reagent_containers/syringe/proc/syringedump(atom/target, mob/user)
+/obj/item/reagent_containers/dropper/proc/dropperdump(atom/target, mob/user)
 	if(isfloorturf(target))
 		if(!reagents.total_volume)
 			to_chat(user, "<span class='notice'>[src] is empty.</span>")

--- a/code/hispania/modules/reagents/reagent_containers/syringes.dm
+++ b/code/hispania/modules/reagents/reagent_containers/syringes.dm
@@ -1,0 +1,13 @@
+/obj/item/reagent_containers/syringe/proc/syringedump(atom/target, mob/user)
+	if(isfloorturf(target))
+		if(!reagents.total_volume)
+			to_chat(user, "<span class='notice'>[src] is empty.</span>")
+			return
+		if(user.a_intent == INTENT_HARM)
+			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
+							"<span class='notice'>You splash the contents of [src] onto [target].</span>")
+			reagents.reaction(target, REAGENT_TOUCH)
+			reagents.clear_reagents()
+		if(user.a_intent == INTENT_HELP)
+			user.visible_message("<span class='danger'>[user] almost splash the contents of [src] onto [target]!</span>")
+	return

--- a/code/hispania/modules/reagents/reagent_containers/syringes.dm
+++ b/code/hispania/modules/reagents/reagent_containers/syringes.dm
@@ -1,8 +1,5 @@
 /obj/item/reagent_containers/syringe/proc/syringedump(atom/target, mob/user)
 	if(isfloorturf(target))
-		if(!reagents.total_volume)
-			to_chat(user, "<span class='notice'>[src] is empty.</span>")
-			return
 		if(user.a_intent == INTENT_HARM)
 			user.visible_message("<span class='danger'>[user] splashes the contents of [src] onto [target]!</span>", \
 							"<span class='notice'>You splash the contents of [src] onto [target].</span>")

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -23,6 +23,7 @@
 /obj/item/reagent_containers/dropper/afterattack(atom/target, mob/user, proximity)
 	if(!proximity)
 		return
+	dropperdump(target, user) //Hispania Dropperdump
 	var/to_transfer = 0
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -56,6 +56,7 @@
 /obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user , proximity)
 	if(!proximity)
 		return
+	syringedump(target, user) //Hispania Syrengdump
 	if(!target.reagents)
 		return
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1337,6 +1337,7 @@
 #include "code\hispania\modules\reagents\chemistry\recipes\drinks.dm"
 #include "code\hispania\modules\reagents\chemistry\recipes\slime_extracts.dm"
 #include "code\hispania\modules\reagents\reagent_containers\glass_containers.dm"
+#include "code\hispania\modules\reagents\reagent_containers\syringes.dm"
 #include "code\hispania\modules\research\circuitprinter.dm"
 #include "code\hispania\modules\research\rdconsole.dm"
 #include "code\hispania\modules\research\designs\autolathe_designs.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1336,6 +1336,7 @@
 #include "code\hispania\modules\reagents\chemistry\reagents\toxins.dm"
 #include "code\hispania\modules\reagents\chemistry\recipes\drinks.dm"
 #include "code\hispania\modules\reagents\chemistry\recipes\slime_extracts.dm"
+#include "code\hispania\modules\reagents\reagent_containers\dropper.dm"
 #include "code\hispania\modules\reagents\reagent_containers\glass_containers.dm"
 #include "code\hispania\modules\reagents\reagent_containers\syringes.dm"
 #include "code\hispania\modules\research\circuitprinter.dm"


### PR DESCRIPTION
## What Does This PR Do
Permite tirar el contenido de las jeringas y droppers en el suelo al estar en HARM y apuntar al suelo.

## Why It's Good For The Game
Múltiples veces me han comentado que es molesto siempre tener que llegar a usar un beaker para tirar el contenido de una jeringa y no simplemente poder tirarla al suelo como sucede con los beakers. Esto debería ayudar a mejorar los tiempos de acción para múltiples tratamientos. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116831268-d6e73f00-ab73-11eb-8c34-c040cf85308e.png)


## Changelog
:cl:
tweak: Syringe Dump
tweak: Dropper Dump
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
