### PR TITLE
Tweak Jackboot Sound

### DIFF
--- a/code/hispania/modules/clothing/shoes/miscellaneous.dm
+++ b/code/hispania/modules/clothing/shoes/miscellaneous.dm
@@ -1,0 +1,30 @@
+/obj/item/clothing/shoes/jackboots/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/stack/tape_roll))
+		var/obj/item/stack/tape_roll/TR = I
+		if(TR.use(4))
+			to_chat(user, "You tape the soles of [src] to silence your footsteps.")
+			if(istype(src, /obj/item/clothing/shoes/jackboots/jacksandals))
+				new /obj/item/clothing/shoes/jackboots_silent/jacksandals_silent(get_turf(user))
+			else
+				new /obj/item/clothing/shoes/jackboots_silent(get_turf(user))
+			qdel(src)
+	else
+		return ..()
+
+/obj/item/clothing/shoes/jackboots_silent
+	name = "jackboots"
+	desc = "Nanotrasen-issue Security combat boots for combat scenarios or combat situations. All combat, all the time."
+	can_cut_open = 1
+	icon_state = "jackboots"
+	item_state = "jackboots"
+	item_color = "hosred"
+	strip_delay = 50
+	put_on_delay = 50
+	resistance_flags = NONE
+
+/obj/item/clothing/shoes/jackboots_silent/jacksandals_silent
+	name = "jacksandals"
+	desc = "Nanotrasen-issue Security combat sandals for combat scenarios. They're jacksandals, however that works."
+	can_cut_open = 0
+	icon_state = "jacksandal"
+	item_color = "jacksandal"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1236,6 +1236,7 @@
 #include "code\hispania\modules\clothing\head\helmets.dm"
 #include "code\hispania\modules\clothing\head\jobs.dm"
 #include "code\hispania\modules\clothing\head\misc.dm"
+#include "code\hispania\modules\clothing\shoes\miscellaneous.dm"
 #include "code\hispania\modules\clothing\suits\armor.dm"
 #include "code\hispania\modules\clothing\suits\labcoat.dm"
 #include "code\hispania\modules\clothing\suits\miscellaneous.dm"


### PR DESCRIPTION
## What Does This PR Do
Vuelve a agregar la capacidad de silenciar las Jackboots con Tape.

## Why It's Good For The Game
Actualmente múltiple personal de seguridad se a quejado de la incapacidad de poder silenciarlas como anteriormente se podía, revisando el tema vi que se realizo un rework completo del sistema de audio de sonido pero eliminaron este sonido en Paradise oficial. Considero que esta bien continuar conservandolo pero se perdió esta importante función de silenciar las botas. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116867056-03ca3f00-abd2-11eb-865e-d90c5fbe8ee9.png)


## Changelog
:cl:
tweak: Jackboots Sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
