### PR TITLE
Tweak Holy Water 

### DIFF
--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -238,6 +238,10 @@
 /datum/reagent/holywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	M.AdjustJitter(-5)
+	//HEAL CHAP STARTS HERE
+	if(ishuman(M) && M.mind.isholy)
+		update_flags |= M.adjustToxLoss(-1.5*REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	//HEAL CHAP ENDS HERE
 	if(current_cycle >= 30)		// 12 units, 60 seconds @ metabolism 0.4 units & tick rate 2.0 sec
 		M.AdjustStuttering(4, bound_lower = 0, bound_upper = 20)
 		M.Dizzy(5)


### PR DESCRIPTION
## What Does This PR Do
Causa que el agua bendita pueda tratar toxinas si el usuario tiene la mente bendita con la propiedad de isholy, esto usualmente solo aplica para ERT Paranormal o Chaplain. El Chap seguira sufriendo de los debuffos comunes si bebe demasiada agua bendita. 

## Why It's Good For The Game
Agrega una razón mas para que un chap nunca olvide cargar su agua bendita.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/116956716-9105a600-ac5b-11eb-81a3-595b8d7e81fd.png)

## Changelog
:cl:
tweak: Holy Water 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
