### PR TITLE
L6 SAW TOY BUFF

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -492,7 +492,7 @@
 /obj/item/ammo_box/magazine/toy/m762
 	name = "donksoft box magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
-	max_ammo = 50
+	max_ammo = 100
 
 /obj/item/ammo_box/magazine/toy/m762/update_icon()
 	..()

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -496,7 +496,7 @@
 
 /obj/item/ammo_box/magazine/toy/m762/update_icon()
 	..()
-	icon_state = "a762-[round(ammo_count(),10)]"
+	icon_state = "a762-[round(ammo_count()/25,1)*25]"
 
 /obj/item/ammo_box/magazine/toy/m762/riot
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot


### PR DESCRIPTION
Acomoda acordemente la munición de la L6 SAW de juguete a tener 100 balas como su versión real. A su vez esto repara un bug que tenia con la sprites siendo que estaba hecho para ir en  0,25,50,75,100 balas, cosa que no funciona bien con 50.

## Changelog
:cl:
tweak: L6SAW de juguete ahora con 100 de munición.
/:cl: