### PR TITLE
Tweak Orion Trail Prize

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -951,7 +951,7 @@
 		message_admins("[key_name_admin(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 		log_game("[key_name(usr)] made it to Orion on an emagged machine and got an explosive toy ship.")
 	else
-		var/score = alive + round(food/2) + round(fuel/5) + engine + hull + electronics - lings_aboard
+		var/score = alive + round(food/2) + round(fuel/5) + engine + hull + electronics - lings_aboard + 20 //Boost Hispania
 		prizevend(score)
 	emagged = 0
 	name = "The Orion Trail"


### PR DESCRIPTION
## What Does This PR Do
Modifica el total de recompensa que da la arcade de Orion Trail agregando de base que si sobrevives puedes ganar 20 créditos mas tus estadísticas, actualmente es la maquina que requiere mas tiempo para jugar y su recompensa es muy baja.

## Why It's Good For The Game
Es de las maquinas mas complicadas por tantas posibilidades para ganar espero que con esto la gente lo vea como una inversión de tiempo mas viable.

## Changelog
:cl:
tweak: Orion Trail Prize
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
