### PR TITLE
Fix Cataplasmas

### DIFF
--- a/code/hispania/game/objects/items/divices/stacks/medical.dm
+++ b/code/hispania/game/objects/items/divices/stacks/medical.dm
@@ -36,34 +36,27 @@
 		M.Weaken(2)
 	return ..()
 
-/obj/item/stack/medical/ointment/fiery_cataplasm
+/obj/item/stack/medical/ointment/earthly_cataplasm/fiery_cataplasm
 	name = "fiery herbal cataplasm"
 	singular_name = "fiery herbal cataplasm"
 	desc = "A type of primitive herbal cataplasm made with Lavaland plants. Smells horrible.\n It is imbued with ancient wisdom."
-	icon = 'icons/hispania/obj/miscellaneous.dmi'
 	icon_state = "poultice_orange"
 	amount = 10
 	max_amount = 10
 	heal_burn = 30
 	self_delay = 15
 
-/obj/item/stack/medical/ointment/fiery_cataplasm/heal(mob/living/M, mob/user)
-	if(ishuman(M))
-		var/obj/item/clothing/mask/P = M.wear_mask
-		playsound(src, 'sound/misc/soggy.ogg', 30, TRUE)
-		if(P && (P.flags_cover & MASKCOVERSMOUTH))
-			to_chat(M, "<span class='warning'>You slightly smell and taste something foul...</span>")
-			return ..()
-		if(HAS_TRAIT(M, TRAIT_NOBREATH))
-			to_chat(M, "<span class='warning'>You slightly taste something foul...</span>")
-			return ..()
-		if(M.mind && (M.mind.assigned_role == "Detective" || M.mind.assigned_role == "Coroner"))
-			to_chat(M, "<span class='warning'>You taste and smell something foul but nothing new...</span>")
-			return ..()
-		if(isashwalker(M))
-			to_chat(M, "<span class='warning'>You embrace nature..</span>")
-			return ..()
-		to_chat(M, "<span class='warning'>You smell and taste something foul...</span>")
-		M.fakevomit()
-		M.Weaken(2)
-	return ..()
+//////Delay de aplicacion cataplasmas////
+/obj/item/stack/medical/ointment/earthly_cataplasm/attack(mob/living/carbon/M, mob/user)
+	if(!istype(M))
+		return FALSE
+	if(user != M)
+		M.visible_message("<span class='notice'>[user] attempts to apply [src].</span>")
+		if(self_delay)
+			if(!do_mob(user, M, 20))
+				return TRUE
+		return ..()
+	else
+		heal(M, user)
+		M.UpdateDamageIcon()
+		use(1)

--- a/code/hispania/modules/crafting/recipes.dm
+++ b/code/hispania/modules/crafting/recipes.dm
@@ -120,7 +120,7 @@
 
 /datum/crafting_recipe/fiery_cataplasm
 	name = "Fiery Herbal Cataplasm"
-	result = list(/obj/item/stack/medical/ointment/fiery_cataplasm)
+	result = list(/obj/item/stack/medical/ointment/earthly_cataplasm/fiery_cataplasm)
 	time = 40
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf = 4,
 		        /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap= 4,


### PR DESCRIPTION
## What Does This PR Do
Evita un posible exploit actualmente que existe y acomoda el código de forma heredada para evitar líneas extras. A su vez vuelve los cataplasmas mas rápidos de aplicar pero siguen dependiendo de zona donde se aplica a diferencia de los parches. 

## Why It's Good For The Game
Repara un posible error que puede dar mecánicas poco balanceadas.

## Changelog
:cl:
tweak: Cataplasmas Heredados
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
