### PR TITLE
Fix Caviar Sprite

### DIFF
--- a/code/hispania/game/objects/items/trash.dm
+++ b/code/hispania/game/objects/items/trash.dm
@@ -60,4 +60,4 @@
 /obj/item/trash/canned_fishegg
 	name ="empty canned caviar"
 	icon = 'icons/hispania/obj/trash.dmi'
-	icon_state = "carpeggs"
+	icon_state = "fisheggs"


### PR DESCRIPTION
## What Does This PR Do
Repara un pequeño error de nombre a un icono que cambiaba el color de la lata de caviar normal a caviar ilegal cuando se convierte en basura.

## Why It's Good For The Game
Pequeños detalle de la lógica resueltos

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/117415003-6d519280-aedd-11eb-883e-8c82924ed1ef.png)


## Changelog
:cl:
fix: Caviar Sprite Trash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
