### PR TITLE
Tweak Valores de Audio a Laugh y Scream

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -647,9 +647,9 @@
 					m_type = 2
 					//Hispania Laugh Starts Here
 					if(gender == FEMALE)
-						playsound(loc, pick(dna.species.female_laughs_sound), 120, 1, frequency = get_age_pitch()) //Hispania Screams
+						playsound(loc, pick(dna.species.female_laughs_sound), 60, 1, frequency = get_age_pitch()) //Hispania Screams
 					else
-						playsound(loc, pick(dna.species.male_laughs_sound), 120, 1, frequency = get_age_pitch()) //Hispania Screams
+						playsound(loc, pick(dna.species.male_laughs_sound), 60, 1, frequency = get_age_pitch()) //Hispania Screams
 					//Hispania Laugh Ends Here
 				else
 					message = "<B>[src]</B> makes a noise."
@@ -891,10 +891,10 @@
 					m_type = 2
 					if(gender == FEMALE)
 						//playsound(loc, dna.species.female_scream_sound, 80, 1, frequency = get_age_pitch())
-						playsound(loc, pick(dna.species.female_scream_sound), 120, 1, frequency = get_age_pitch()) //Hispania Screams
+						playsound(loc, pick(dna.species.female_scream_sound), 80, 1, frequency = get_age_pitch()) //Hispania Screams
 					else
 						//playsound(loc, dna.species.male_scream_sound, 80, 1, frequency = get_age_pitch()) //default to male screams if no gender is present.
-						playsound(loc, pick(dna.species.male_scream_sound), 120, 1, frequency = get_age_pitch()) //Hispania Screams
+						playsound(loc, pick(dna.species.male_scream_sound), 80, 1, frequency = get_age_pitch()) //Hispania Screams
 
 				else
 					message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."


### PR DESCRIPTION
## What Does This PR Do
Baja el valor de sonido de estos dos emotes.

## Why It's Good For The Game
Hacer mas bajo el audio los hace sonar de forma mas concorde a lo que quieren dar a expresar.

## Changelog
:cl:
tweak: Laugh and Scream Audio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
