### PR TITLE
Tweak Readys en Lobby

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -98,8 +98,8 @@
 
 		if(SSticker.current_state == GAME_STATE_PREGAME)
 			stat("Players:", "[totalPlayers]")
-			if(check_rights(R_ADMIN, 0, src))
-				stat("Players Ready:", "[totalPlayersReady]")
+			//if(check_rights(R_ADMIN, 0, src)) Readys Global
+			stat("Players Ready:", "[totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in GLOB.player_list)


### PR DESCRIPTION
## What Does This PR Do
Convierte la estadística de jugadores listos antes de iniciar la partida visible para todos.

## Why It's Good For The Game
Algunos jugadores gustan de poder ver esta estadística y resulta bastante útil para poder estar al tanto de las posibilidades. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/117540415-eb449500-afd4-11eb-8d63-2b0f4f074b4b.png)

## Changelog
:cl:
tweak: Readys en Lobby
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
