### PR TITLE
Tweak Curas Avanzadas Virus

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 									"mitocholide", "spaceacillin", "pen_acid",
 									"haloperidol", "carpotoxin", "prions",
 									"nanomachines", "bath_salts"
-))
+)) ///Curas Diferentes Hispania
 
 /*
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -10,10 +10,10 @@ GLOBAL_LIST_EMPTY(archive_diseases)
 
 // The order goes from easy to cure to hard to cure.
 GLOBAL_LIST_INIT(advance_cures, list(
-									"sodiumchloride", "sugar", "orangejuice",
-									"spaceacillin", "salglu_solution", "ethanol",
-									"teporone", "diphenhydramine", "lipolicide",
-									"silver", "gold"
+									"salglu_solution", "mannitol", "perfluorodecalin",
+									"mitocholide", "spaceacillin", "pen_acid",
+									"haloperidol", "carpotoxin", "prions",
+									"nanomachines", "bath_salts"
 ))
 
 /*


### PR DESCRIPTION
## What Does This PR Do
Sustituye toda la lista actual de curas para virus por las siguientes: "salglu_solution", "mannitol", "perfluorodecalin","mitocholide", "spaceacillin", "pen_acid","haloperidol", "carpotoxin", "prions","nanomachines", "bath_salts". 

## Why It's Good For The Game
Sustituye las curas de los virus sencillas por componentes químicos mas complicados de encontrar pero que se encuentran bien documentados en las Wikis existentes. Esto hace que los virus requieran mas inversión de tiempo en ser curados y no un simple viaje a cargo o ciencias por una barra de oro o silver. 

## Changelog
:cl:
tweak: Curas diferentes a virus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
