### PR TITLE
Retoques al maint fauna

### DIFF
--- a/code/hispania/game/objects/effects/spawners/lootdrop.dm
+++ b/code/hispania/game/objects/effects/spawners/lootdrop.dm
@@ -14,6 +14,6 @@
 				/mob/living/simple_animal/lizard = 30,
 				/mob/living/simple_animal/cockroach = 30,
 				/mob/living/simple_animal/hostile/retaliate/poison/snake = 10,
-				/mob/living/simple_animal/hostile/poison/giant_spider/hunter = 5,
+				/mob/living/simple_animal/hostile/poison/giant_spider = 5,
 				"" = 20 //Nada
 				)

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -58,5 +58,6 @@
 		visible_message("<span class='notice'>[name] consumes [target] in a single gulp!</span>", "<span class='notice'>You consume [target] in a single gulp!</span>")
 		QDEL_NULL(target)
 		adjustHealth(-2)
+		do_attack_animation(target)
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -55,9 +55,9 @@
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake/AttackingTarget()
 	if(istype(target, /mob/living/simple_animal/mouse))
+		do_attack_animation(target)
 		visible_message("<span class='notice'>[name] consumes [target] in a single gulp!</span>", "<span class='notice'>You consume [target] in a single gulp!</span>")
 		QDEL_NULL(target)
 		adjustHealth(-2)
-		do_attack_animation(target)
 	else
 		return ..()


### PR DESCRIPTION
## What Does This PR Do
Remplazamos el maint spawner del hunter terror por la estándar que no tiene veneno al morder pero tiene 80+ de vida, dándole un buen trabajo a sec cuando sea avistada en maint y no siendo un peligro tan grande para los tripulantes.

También una animación de ataque a la serpiente para que no sea puro flavor text al devorar una rata.

## Why It's Good For The Game
El veneno es un daño difícil de regenerar como tripulante, con la 10u y el golpe quedas con un delay al caminar potente, y con 2 mordidas ya no vives en un par de minutos, es demasiado.

## Changelog
:cl:
tweak: Araña terror estandar para el maint de fauna en vez de la hunter.
tweak: Animación al devorar ratas.
/:cl: