### PR TITLE
Tweak Mining Belts

### DIFF
--- a/code/hispania/modules/crafting/recipes.dm
+++ b/code/hispania/modules/crafting/recipes.dm
@@ -145,7 +145,7 @@
 				 /obj/item/stack/sheet/sinew = 4)
 	category = CAT_PRIMAL
 
-/datum/crafting_recipe/watchebelt
+/datum/crafting_recipe/lighterbelt
 	name = "Lighter Explorer's Webbing"
 	result = list(/obj/item/storage/belt/mining/alt)
 	time = 60

--- a/code/hispania/modules/crafting/recipes.dm
+++ b/code/hispania/modules/crafting/recipes.dm
@@ -136,3 +136,19 @@
 				 /obj/item/stack/sheet/sinew = 3,
 				 /obj/item/stack/sheet/cartiplaz = 6)
 	category = CAT_PRIMAL
+
+/datum/crafting_recipe/watchebelt
+	name = "Sinew Belt"
+	result = list(/obj/item/storage/belt/mining/primitive)
+	time = 80
+	reqs = list(/obj/item/stack/sheet/bone = 4,
+				 /obj/item/stack/sheet/sinew = 4)
+	category = CAT_PRIMAL
+
+/datum/crafting_recipe/watchebelt
+	name = "Lighter Explorer's Webbing"
+	result = list(/obj/item/storage/belt/mining/alt)
+	time = 60
+	reqs = list(/obj/item/storage/belt/mining = 1)
+	pathtools = list(/obj/item/kitchen/knife)
+	category = CAT_PRIMAL


### PR DESCRIPTION
## What Does This PR Do
Agrega los diferentes diseños que existen para el mining belt a la categoría de Primal.

## Why It's Good For The Game
Proporciona estos items con sprite alternativo que existen en el code pero rara vez son ocupados, no ofrecen ninguna ventaja ni diferencia aparte de su sprite. 

Light Weebing: Diseño menos robusto al original. crateable con mining weebing (1) y ocupas un cuchillo
Sinew Weebing: Belt de menos capacidad crafteable con sinew (4) y huesos (4)

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/118383563-9bf9f800-b5c4-11eb-94dc-3bf416e3a9be.png)


## Changelog
:cl:
tweak: Mining Weebing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
