### PR TITLE
[Map Changes] Rechargers a Blueshield e Ingenieria

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -99598,6 +99598,7 @@
 "var" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/machinery/recharger,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellowfull"
@@ -100680,6 +100681,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/supermatter)
+"wau" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/blueshield)
 "waE" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -134529,7 +134536,7 @@ chf
 bYF
 oev
 cgS
-clR
+wau
 clR
 umP
 cgS


### PR DESCRIPTION
## What Does This PR Do
Reagrega los dos rechargers que se perdieron con la update. 

## Why It's Good For The Game
Ambos son útiles para estos departamentos.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/118684822-28c0d380-b7c8-11eb-8d69-47a943dda8ec.png)
![image](https://user-images.githubusercontent.com/46639834/118684849-2d858780-b7c8-11eb-8a48-9f790a903cfb.png)

## Changelog
:cl:
add: Rechargers Blueshield e Ingenieria
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
