### PR TITLE
Tweak Populatecontent instead of New

### DIFF
--- a/code/hispania/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/hispania/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -1,8 +1,8 @@
-/obj/structure/closet/secure_closet/cargotech/New()
+/obj/structure/closet/secure_closet/cargotech/populate_contents()
 	..()
 	new /obj/item/storage/bag/sheetsnatcher(src)
 	new /obj/item/storage/bag/sheetsnatcher(src)
 
-/obj/structure/closet/secure_closet/quartermaster/New()
+/obj/structure/closet/secure_closet/quartermaster/populate_contents()
 	..()
 	new /obj/item/storage/backpack/duffel/mining_conscript(src)

--- a/code/hispania/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/hispania/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,10 +1,10 @@
-/obj/structure/closet/secure_closet/engineering_electrical/New()
+/obj/structure/closet/secure_closet/engineering_electrical/populate_contents()
 	..()
 	new /obj/item/inducer/apc(src)
 	new /obj/item/inducer/apc(src)
 	new/obj/item/clothing/glasses/meson/engine/tray(src)
 	new/obj/item/clothing/glasses/meson/engine/tray(src)
 
-/obj/structure/closet/secure_closet/engineering_chief/New()
+/obj/structure/closet/secure_closet/engineering_chief/populate_contents()
 	..()
 	new /obj/item/whistle(src)

--- a/code/hispania/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/hispania/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -1,3 +1,3 @@
-/obj/structure/closet/secure_closet/CMO/New()
+/obj/structure/closet/secure_closet/CMO/populate_contents()
 	..()
 	new /obj/item/whistle(src)

--- a/code/hispania/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/hispania/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -1,7 +1,7 @@
-/obj/structure/closet/secure_closet/scientist/New()
+/obj/structure/closet/secure_closet/scientist/populate_contents()
 	..()
 	new /obj/item/storage/bag/component(src)
 
-/obj/structure/closet/secure_closet/RD/New()
+/obj/structure/closet/secure_closet/RD/populate_contents()
 	..()
 	new /obj/item/whistle(src)

--- a/code/hispania/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/hispania/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -1,13 +1,13 @@
-/obj/structure/closet/secure_closet/magistrate/New()
+/obj/structure/closet/secure_closet/magistrate/populate_contents()
 	..()
 	new /obj/item/gun/energy/disabler/magistrate(src)
 
-/obj/structure/closet/secure_closet/detective/New()
+/obj/structure/closet/secure_closet/detective/populate_contents()
 	..()
 	new /obj/item/storage/belt/security(src)
 	new /obj/item/taperoll(src)
 
-/obj/structure/closet/secure_closet/brigdoc/New()
+/obj/structure/closet/secure_closet/brigdoc/populate_contents()
 	..()
 	new /obj/item/storage/box/autoinjectors(src)
 	new /obj/item/handheld_defibrillator(src)
@@ -15,15 +15,15 @@
 	new /obj/item/storage/pill_bottle( src )
 	new /obj/item/storage/pill_bottle/patch_pack(src)
 
-/obj/structure/closet/secure_closet/captains/New()
+/obj/structure/closet/secure_closet/captains/populate_contents()
 	..()
 	new /obj/item/whistle(src)
 
-/obj/structure/closet/secure_closet/hop/New()
+/obj/structure/closet/secure_closet/hop/populate_contents()
 	..()
 	new /obj/item/whistle(src)
 
-/obj/structure/closet/secure_closet/hos/New()
+/obj/structure/closet/secure_closet/hos/populate_contents()
 	..()
 	new /obj/item/whistle(src)
 


### PR DESCRIPTION
## What Does This PR Do
Reemplaza el método por el cual agregábamos cosas a los lockers por el actual usado en paradise. 

## Changelog
:cl:
tweak: populate instead of new
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
