### PR TITLE
Fix Sprite Drinks Hispania

### DIFF
--- a/code/hispania/game/machinery/vending.dm
+++ b/code/hispania/game/machinery/vending.dm
@@ -18,8 +18,8 @@
 	hispa_contraband = list(/obj/item/reagent_containers/food/drinks/bottle/hispania/vampire_bestfriend = 5)
 
 /obj/machinery/vending/coffee
-	hispa_products = list(/obj/item/reagent_containers/food/drinks/cans/mr_coffe_brown = 10)
-	hispa_prices = list(/obj/item/reagent_containers/food/drinks/cans/mr_coffe_brown = 25)
+	hispa_products = list(/obj/item/reagent_containers/food/drinks/cans/hispania/mr_coffe_brown = 10)
+	hispa_prices = list(/obj/item/reagent_containers/food/drinks/cans/hispania/mr_coffe_brown = 25)
 
 /obj/machinery/vending/security
 	hispa_products = list(/obj/item/taperoll = 8, /obj/item/device/binoculars/security = 2, /obj/item/storage/bag/plasticbag/mre = 2)
@@ -306,10 +306,10 @@
 					/obj/item/clothing/shoes/sandal = 15)
 
 /obj/machinery/vending/cola
-	hispa_products = list(/obj/item/reagent_containers/food/drinks/cans/space_mundet = 10, /obj/item/reagent_containers/food/drinks/cans/behemoth_energy = 2,
-					/obj/item/reagent_containers/food/drinks/cans/behemoth_energy_lite = 1)
-	hispa_prices = list(/obj/item/reagent_containers/food/drinks/cans/space_mundet = 20, /obj/item/reagent_containers/food/drinks/cans/behemoth_energy = 50,
-					/obj/item/reagent_containers/food/drinks/cans/behemoth_energy_lite = 50)
+	hispa_products = list(/obj/item/reagent_containers/food/drinks/cans/hispania/space_mundet = 10, /obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy = 2,
+					/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy_lite = 1)
+	hispa_prices = list(/obj/item/reagent_containers/food/drinks/cans/hispania/space_mundet = 20, /obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy = 50,
+					/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy_lite = 50)
 
 /obj/machinery/vending/wallmed
 	hispa_products = list(/obj/item/reagent_containers/food/pill/patch/styptic = 1, /obj/item/reagent_containers/food/pill/patch/silver_sulf = 1)

--- a/code/hispania/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/hispania/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -1,38 +1,41 @@
 /// HISPANIA CANS
-/obj/item/reagent_containers/food/drinks/cans/space_mundet
+/obj/item/reagent_containers/food/drinks/cans/hispania
+	icon = 'icons/hispania/obj/drinks.dmi'
+
+/obj/item/reagent_containers/food/drinks/cans/hispania/space_mundet
 	name = "Space Mundet"
 	desc = "A can of apple juice. Just like in your childhood"
 	icon_state = "space_mundet"
 	item_state = "space_mundet"
 	list_reagents = list("applejuice" = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/mr_coffe_brown
+/obj/item/reagent_containers/food/drinks/cans/hispania/mr_coffe_brown
 	name = "Mrs Brown"
 	desc = "A can of iced coffe. A weird looking can with a big red star."
 	icon_state = "mrs_brown"
 	item_state = "mrs_brown"
 	list_reagents = list("icecoffee" = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/behemoth_energy
+/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy
 	name = "Behemoth Energy"
 	desc = "Tear into a can of the meanest energy drink on the planet, Behemoth Energy."
 	icon_state = "behemoth"
 	item_state = "behemoth"
 	list_reagents = list("sugar" = 5, "ale" = 10, "sodawater" = 10)
 
-/obj/item/reagent_containers/food/drinks/cans/behemoth_energy/New()
+/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy/New()
 	..()
 	if(prob(30))
 		reagents.add_reagent("methamphetamine", 3)
 
-/obj/item/reagent_containers/food/drinks/cans/behemoth_energy_lite
+/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy_lite
 	name = "Behemoth Energy Zero"
 	desc = "Tear into a can of the meanest energy drink on the planet, Behemoth Energy. Yup, Quake was a good  game."
 	icon_state = "behemoth_lite"
 	item_state = "behemoth_lite"
 	list_reagents = list("ale" = 10, "sodawater" = 20)
 
-/obj/item/reagent_containers/food/drinks/cans/behemoth_energy_lite/New()
+/obj/item/reagent_containers/food/drinks/cans/hispania/behemoth_energy_lite/New()
 	..()
 	if(prob(10))
 		reagents.add_reagent("methamphetamine", 3)


### PR DESCRIPTION
## What Does This PR Do
Repara un error que quedo de hace tiempo referente a la ruta de icono para bebidas

## Why It's Good For The Game
Repara un error que da bebidas invisibles.

## Changelog
:cl:
fix: Drinks Sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
