### PR TITLE
Tweak Space Pod Mining Kit

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -267,7 +267,19 @@
 			new /obj/item/twohanded/kinetic_crusher(drop_location)
 		if("Mining Conscription Kit")
 			new /obj/item/storage/backpack/duffel/mining_conscript(drop_location)
-
+		//HISPANIA SPACEPOD STARTER KIT STARTS HERE
+		if("Spacepod Starter Kit")
+			var/confirm = alert("Are you sure theres a mechanic on the station?", "Confirm Pick", "Yes", "No")
+			if(confirm == "Yes")
+				new /obj/item/spacepod_equipment/weaponry/mining_laser_basic(drop_location)
+				new /obj/item/spacepod_equipment/cargo/ore(drop_location)
+				new /obj/item/spacepod_equipment/lock/keyed(drop_location)
+				new /obj/item/spacepod_key(drop_location)
+				new /obj/item/pod_parts/core(drop_location)
+				new /obj/item/circuitboard/mecha/pod(drop_location)
+			else
+				return
+			//HISPANIA SPACEPOD STARTER KIT ENDS HERE
 	qdel(voucher)
 
 /obj/machinery/mineral/equipment_vendor/ex_act(severity, target)


### PR DESCRIPTION
## What Does This PR Do
Repara la seleccion del Space Pod Starter Kit, añade una ventana de confirmación preguntando si hay un mecánico en la estación. Agrega una mainboard y core para que el mecanico no tenga que sacrificar su primer spacepod para dar una a un minero. 

## Why It's Good For The Game
Añade mas viabilidad al kit aunque nadie lo haca mas que cada mil años lol

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/119014350-80dd0e80-b95d-11eb-9689-147722626d46.png)
![image](https://user-images.githubusercontent.com/46639834/119014355-820e3b80-b95d-11eb-8877-d5fbeec956b2.png)
![image](https://user-images.githubusercontent.com/46639834/119014363-83d7ff00-b95d-11eb-90ec-0f44903eb209.png)

## Changelog
:cl:
tweak: SpacePod Starter Kit
/:cl:

