### PR TITLE
Tweak Medikits Vending Lavaland

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -45,7 +45,7 @@
 	)
 	prize_list["Consumables"] = list(
 		EQUIPMENT("10 Marker Beacons", 				/obj/item/stack/marker_beacon/ten, 									100),
-		EQUIPMENT("Brute First-Aid Kit", 			/obj/item/storage/firstaid/brute,									600),
+		EQUIPMENT("First-Aid Kit", 					/obj/item/storage/firstaid/regular,									600), //Hispania Medikits
 		EQUIPMENT("Fulton Pack", 					/obj/item/extraction_pack, 											1000),
 		EQUIPMENT("Jaunter", 						/obj/item/wormhole_jaunter, 										750),
 		EQUIPMENT("Lazarus Injector", 				/obj/item/lazarus_injector, 										1000),


### PR DESCRIPTION
## What Does This PR Do
Modifica el tipo de botiquín que puedes comprar en las vending.

## Why It's Good For The Game
Actualmente tras la adicción de los menders se dejo el tipo de botiquín por el brute que viene con mender en lugar de parches. Esto lo cambia por la versión tradicional de medikits que viene con dos parches brute y 2 burns.

## Changelog
:cl:
tweak: Medikits Vending Lavaland
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
