### PR TITLE
Fix Free Clothing en algunas vendings

### DIFF
--- a/code/hispania/game/machinery/vending.dm
+++ b/code/hispania/game/machinery/vending.dm
@@ -113,7 +113,8 @@
 					/obj/item/storage/belt/fannypack/red = 30,
 					/obj/item/clothing/suit/mantle = 200,
 					/obj/item/clothing/suit/mantle/old = 200,
-					/obj/item/clothing/suit/mantle/regal = 200)
+					/obj/item/clothing/suit/mantle/regal = 200,
+					/obj/item/clothing/suit/jacket/motojacket = 450)
 
 //este vending es gratis en paradise
 /obj/machinery/vending/artvend
@@ -244,7 +245,8 @@
 					/obj/item/clothing/under/redhawaiianshirt = 52,
 					/obj/item/clothing/under/pinkhawaiianshirt = 52,
 					/obj/item/clothing/under/bluehawaiianshirt = 52,
-					/obj/item/clothing/under/orangehawaiianshirt = 52)
+					/obj/item/clothing/under/orangehawaiianshirt = 52,
+					/obj/item/clothing/under/tourist_suit = 50)
 
 //este vending es gratis en paradise
 /obj/machinery/vending/hatdispenser
@@ -303,7 +305,8 @@
 					/obj/item/clothing/shoes/purple = 50,
 					/obj/item/clothing/shoes/red = 100,
 					/obj/item/clothing/shoes/white = 100,
-					/obj/item/clothing/shoes/sandal = 15)
+					/obj/item/clothing/shoes/sandal = 15,
+					/obj/item/clothing/shoes/jackboots = 350)
 	hispa_premium = list(/obj/item/clothing/shoes/swagshoes = 1)
 
 /obj/machinery/vending/cola


### PR DESCRIPTION
## What Does This PR Do
Agrega precio a ciertas prendas que se agregaron en paradise pero no se agregaron a la lista de precios.

## Why It's Good For The Game
Evita inconsistencias y ropa gratis para la crew.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/119275110-d1ac6b80-bbd8-11eb-8a16-00ee4b699270.png)
![image](https://user-images.githubusercontent.com/46639834/119275117-dec95a80-bbd8-11eb-9a28-50e9343aa0f3.png)
![image](https://user-images.githubusercontent.com/46639834/119275122-e4bf3b80-bbd8-11eb-9ee9-90f647c5bdad.png)


## Changelog
:cl:
fix: Free Clothes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
