### PR TITLE
Quirks visibles en medical records

### DIFF
--- a/code/hispania/controllers/subsystem/processing/quirks.dm
+++ b/code/hispania/controllers/subsystem/processing/quirks.dm
@@ -40,5 +40,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences")
 			cli.prefs.all_quirks -= V
 			badquirk = TRUE
+	user.med_record += " / " + user.get_trait_string(TRUE) // HOLA MAMAAAAA RECORDS MEDICOS
 	if(badquirk)
 		cli.prefs.save_character()

--- a/code/hispania/datums/traits/_quirk.dm
+++ b/code/hispania/datums/traits/_quirk.dm
@@ -79,8 +79,8 @@
 			var/datum/quirk/T = V
 			dat += T.medical_record_text
 		if(!dat.len)
-			return "None"
-		return dat.Join("<br>")
+			return "Paciente sin rasgos destacables."
+		return dat.Join(" || ")
 
 /mob/living/proc/cleanse_trait_datums() //removes all trait datums
 	for(var/V in roundstart_quirks)


### PR DESCRIPTION
- Los traits con medical_record ahora aparecen en los records médicos, como deberían.

## Why It's Good For The Game
Los records recibirán un uso real, el saber los rasgos de tu oponente te ayudara a emplear un mejor trabajo.

## Images of changes
![lasagna](https://user-images.githubusercontent.com/55407528/119846240-f6099000-bed7-11eb-9e49-0fb422857c88.png)

## Changelog
:cl:
fix: Medical records muestran quirks.
/:cl:

