### PR TITLE
Fix Auto Belt

### DIFF
--- a/code/hispania/modules/crafting/recipes.dm
+++ b/code/hispania/modules/crafting/recipes.dm
@@ -149,6 +149,7 @@
 	name = "Lighter Explorer's Webbing"
 	result = list(/obj/item/storage/belt/mining/alt)
 	time = 60
-	reqs = list(/obj/item/storage/belt/mining = 1)
+	reqs = list(/obj/item/stack/sheet/leather = 2,
+				/obj/item/storage/belt/mining = 1)
 	pathtools = list(/obj/item/kitchen/knife)
 	category = CAT_PRIMAL


### PR DESCRIPTION
## What Does This PR Do
Hace que el light velt requiera 2 de cuero de esta forma tiene sentido el cambio para cuando se crea desde la ruta de un velt improvisado.

## Why It's Good For The Game
Evita belts gratis a mineria

## Changelog
:cl:
fix: Cuero para belts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
