### PR TITLE
[Map Changes] Hispania y Lavaland Estándar 

### DIFF
--- a/_maps/map_files/hispania/Lavaland.dmm
+++ b/_maps/map_files/hispania/Lavaland.dmm
@@ -2047,7 +2047,7 @@
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
 	width = 7
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
 "eJ" = (
 /obj/machinery/door/airlock/external{
@@ -4645,11 +4645,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
-"sn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+"si" = (
 /obj/structure/closet/walllocker/emerglocker/west,
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 20
+	},
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "sS" = (
@@ -4675,13 +4676,6 @@
 /area/mine/living_quarters)
 "uR" = (
 /turf/simulated/wall/mineral/titanium,
-/area/shuttle/mining)
-"vm" = (
-/obj/structure/ore_box,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "wT" = (
 /obj/machinery/light/small{
@@ -4964,6 +4958,14 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/siberia)
+"Vv" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	req_access_txt = "48"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "VH" = (
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -4973,6 +4975,7 @@
 /area/mine/living_quarters)
 "Xz" = (
 /obj/structure/closet/crate,
+/obj/machinery/light/small,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "Yb" = (
@@ -16773,9 +16776,9 @@ cQ
 cQ
 bp
 bp
-bp
 aD
-bp
+aD
+aD
 bp
 bp
 bp
@@ -17031,7 +17034,7 @@ bp
 aD
 aD
 aD
-bp
+aD
 aD
 aD
 aD
@@ -17288,7 +17291,7 @@ aD
 uR
 uR
 zi
-uR
+Vv
 zi
 uR
 uR
@@ -17545,9 +17548,9 @@ aD
 uR
 Pr
 Pl
-sn
+Cx
 Hr
-SM
+si
 uR
 aD
 bp
@@ -18575,7 +18578,7 @@ Re
 Pl
 Cx
 Hr
-vm
+SM
 uR
 aD
 aD

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -72475,6 +72475,11 @@
 /obj/effect/decal/warning_stripes/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellowcorners"
@@ -72754,6 +72759,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -75597,6 +75607,11 @@
 	dir = 4;
 	level = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowcorners"
@@ -75639,6 +75654,11 @@
 	dir = 4;
 	level = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowcorners"
@@ -75654,6 +75674,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -82457,6 +82482,16 @@
 	icon_state = "neutral"
 	},
 /area/engine/singularity)
+"dtT" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1;
+	name = "TSF Discovery";
+	req_access_txt = "20"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/tsf)
 "dui" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -82763,6 +82798,12 @@
 	tag = "icon-wood-broken"
 	},
 /area/maintenance/asmaint2)
+"dOb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
 "dPg" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -82854,7 +82895,7 @@
 	protected = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "dTj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83286,6 +83327,13 @@
 	icon_state = "dark"
 	},
 /area/engine/engineering)
+"ems" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "emw" = (
 /obj/machinery/light{
 	dir = 1
@@ -83437,7 +83485,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "eqX" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -83792,6 +83840,13 @@
 "eMI" = (
 /turf/simulated/wall/r_wall,
 /area/engine/supermatter)
+"eNa" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel,
+/area/hallway/secondary/entry)
 "eNQ" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/drinks/cans/beer,
@@ -84897,7 +84952,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "ggr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5;
@@ -85032,7 +85087,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "gmO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85433,7 +85488,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "gFz" = (
 /obj/machinery/power/turbine{
 	dir = 4
@@ -86789,7 +86844,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "ice" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/ai_status_display{
@@ -87067,7 +87122,7 @@
 	},
 /mob/living/simple_animal/pet/dog/pug/unfunny,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "isM" = (
 /turf/simulated/floor/wood,
 /area/maintenance/asmaint2)
@@ -88002,7 +88057,7 @@
 "jsA" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "jtZ" = (
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
@@ -88239,7 +88294,7 @@
 	},
 /obj/structure/closet,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "jJR" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -88347,7 +88402,11 @@
 "jNI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
+"jNW" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
 "jNZ" = (
 /obj/effect/spawner/random_barrier/obstruction,
 /obj/structure/disposalpipe/segment,
@@ -88373,6 +88432,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/singularity)
@@ -88818,7 +88882,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "kox" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89057,7 +89121,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "kCT" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
@@ -89159,7 +89223,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "kJY" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -89187,7 +89251,7 @@
 	id_tag = "trash"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "kMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -89487,25 +89551,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/engine/singularity)
-"lcO" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkyellowcorners"
-	},
-/area/engine/engineering)
 "lcR" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
@@ -89998,7 +90043,7 @@
 "lwZ" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "lxm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90580,6 +90625,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -91208,7 +91258,7 @@
 /obj/effect/decal/warning_stripes/east,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "mAs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91334,7 +91384,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "mFD" = (
 /obj/machinery/light{
 	dir = 1
@@ -91915,7 +91965,7 @@
 /obj/item/shovel,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "njs" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -92184,7 +92234,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "nwz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -92366,7 +92416,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "nDA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -92544,7 +92594,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "nOr" = (
 /obj/machinery/atmospherics/binary/valve/digital/open{
 	name = "Mixed Air Outlet Valve"
@@ -92984,7 +93034,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "olI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -93274,6 +93324,11 @@
 	initialize_directions = 11;
 	level = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -93317,7 +93372,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "oFp" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -94210,7 +94265,7 @@
 /area/shuttle/tsf)
 "pFw" = (
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "pFG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94398,7 +94453,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "pTq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/computer/mob_battle_terminal/blue{
@@ -94490,7 +94545,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "pXk" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -94700,7 +94755,7 @@
 	},
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "qjM" = (
 /obj/effect/decal/warning_stripes/northwestcorner,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -94828,7 +94883,7 @@
 	pixel_x = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "qpf" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering Singularity North-East";
@@ -94852,7 +94907,7 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "qpI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94944,6 +94999,11 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/engine/singularity)
 "qsL" = (
@@ -95307,7 +95367,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "qKQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -95792,6 +95852,11 @@
 /area/atmos)
 "ruy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "rampbottom";
 	tag = "icon-stage_stairs"
@@ -96293,6 +96358,11 @@
 	name = "station intercom (General)";
 	pixel_y = 28
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowcorners"
@@ -96365,7 +96435,7 @@
 /area/atmos)
 "rWG" = (
 /turf/simulated/wall,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "rXa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -97428,6 +97498,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"sKq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
 "sKF" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -98383,6 +98460,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -98454,6 +98536,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1;
 	initialize_directions = 11
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -98748,7 +98835,7 @@
 	level = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "ugd" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -99535,7 +99622,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "uYo" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -99975,7 +100062,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/r_wall,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "vvM" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor/plasteel{
@@ -100018,7 +100105,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "vwS" = (
 /obj/machinery/atmospherics/trinary/tvalve/digital/flipped,
 /obj/machinery/light{
@@ -100222,6 +100309,9 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plating/airless,
 /area/engine/singularity)
+"vJs" = (
+/turf/simulated/wall/r_wall,
+/area/maintenance/disposal)
 "vKM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100525,6 +100615,11 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
@@ -100970,6 +101065,16 @@
 /area/storage/tech)
 "wmI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -101508,7 +101613,7 @@
 	id = "garbage"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/incinerator)
+/area/maintenance/disposal)
 "wOb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/cable{
@@ -102203,6 +102308,11 @@
 	dir = 4;
 	level = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowcorners"
@@ -102457,9 +102567,9 @@
 "xCl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -102656,6 +102766,11 @@
 	c_tag = "Engineering Hallway West";
 	dir = 2;
 	network = list("SS13")
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -110021,7 +110136,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bjQ
 aaa
 aaa
 aaa
@@ -110278,7 +110393,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aLd
 aaa
 aaa
 aaa
@@ -110535,7 +110650,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aSd
 aaa
 aaa
 aaa
@@ -110792,7 +110907,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aSd
 aaa
 aaa
 aaa
@@ -111049,10 +111164,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+aSd
+aSd
+aSd
 aaa
 aaa
 aaa
@@ -111306,10 +111421,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+bGm
+bLY
+bKp
 aaa
 aaa
 aaa
@@ -111563,11 +111678,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+bGl
+bLX
+bKp
+bPN
 aaa
 aaa
 aaa
@@ -111820,10 +111935,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+bKp
+bKp
+bOb
 aaa
 aaa
 aaa
@@ -112077,10 +112192,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+aMd
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -112334,10 +112449,10 @@ aaa
 aaa
 aaa
 aaa
-bjQ
-aaa
-aaa
-aaa
+aSd
+aMd
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -112592,9 +112707,9 @@ aaa
 aaa
 aaa
 aLd
-aaa
-aaa
-aaa
+ems
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -112849,9 +112964,9 @@ aaa
 aaa
 aaa
 aSd
-aaa
-aaa
-aaa
+aMd
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -113106,9 +113221,9 @@ aaa
 aaa
 aaa
 aSd
-aaa
-aaa
-aaa
+aMd
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -113362,9 +113477,9 @@ aaa
 aaa
 aaa
 aaa
-aSd
-aSd
-aSd
+aLd
+aMd
+bLZ
 aSd
 aaa
 aaa
@@ -113620,9 +113735,9 @@ aaa
 aaa
 aaa
 aSd
-bGm
-bLY
-bKp
+eNa
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -113877,10 +113992,10 @@ aaa
 aaa
 aaa
 aSd
-bGl
-bLX
-bKp
-bPN
+aMd
+bLZ
+aSd
+aaa
 aaa
 aaa
 aaa
@@ -114134,9 +114249,9 @@ aaa
 aaa
 aaa
 aSd
-bKp
-bKp
-bOb
+aMd
+bLZ
+aSd
 aaa
 aaa
 aaa
@@ -114905,7 +115020,7 @@ bDC
 aSd
 aaa
 aSd
-aMd
+ems
 bLZ
 aSd
 aaa
@@ -115181,9 +115296,9 @@ aaa
 aaa
 aaa
 aaa
-cwx
+vJs
 dSF
-cwx
+vJs
 aaa
 aaa
 aaa
@@ -115438,12 +115553,12 @@ aaa
 aaa
 aaa
 aaa
-cwx
+vJs
 kMy
-cwx
+vJs
 lwZ
 lwZ
-cwx
+vJs
 aab
 cvp
 vUA
@@ -115695,12 +115810,12 @@ aaa
 aaa
 aaa
 aaa
-cwx
+vJs
 nNR
 lwZ
 pFw
 jIF
-cwx
+vJs
 aab
 cvp
 eYZ
@@ -115951,14 +116066,14 @@ aaa
 aaa
 aaa
 aaa
-cwx
-cwx
+vJs
+vJs
 wNQ
 rWG
 irX
 pFw
-cwx
-cwx
+vJs
+vJs
 cvp
 cLi
 cLi
@@ -116215,7 +116330,7 @@ qiT
 pSk
 jNI
 bKD
-cwx
+vJs
 cMr
 cWn
 rin
@@ -116465,14 +116580,14 @@ aaa
 aaa
 aaa
 aaa
-czF
+dOb
 mFC
 wNQ
 pWG
 kJL
 gml
 niD
-cwx
+vJs
 cND
 cWn
 sSs
@@ -116722,14 +116837,14 @@ cgQ
 cgQ
 cgQ
 cgQ
-czF
+dOb
 kCS
 wNQ
 nDx
 uYh
 olB
 icc
-cwx
+vJs
 pYW
 fqB
 cNB
@@ -116979,14 +117094,14 @@ moM
 cgQ
 rSe
 lln
-czF
+dOb
 qKE
 wNQ
 qpn
 uew
 nwb
 gfZ
-cwx
+vJs
 cLi
 cLi
 cLi
@@ -117236,14 +117351,14 @@ coL
 cgQ
 gQH
 lNZ
-czP
+sKq
 oDX
 eqU
 vwA
 knO
-cwx
-cwx
-cwx
+vJs
+vJs
+vJs
 jAu
 cLi
 sfP
@@ -117493,12 +117608,12 @@ gVN
 cgQ
 sNS
 cgQ
-cwy
-cwy
-cwy
-cwx
+jNW
+jNW
+jNW
+vJs
 qox
-cwx
+vJs
 jsA
 gFa
 cNB
@@ -130891,7 +131006,7 @@ cXy
 wpa
 cYQ
 xCl
-lcO
+daK
 fDo
 cSU
 cSU
@@ -149160,7 +149275,7 @@ bZZ
 bZZ
 bZZ
 doE
-vOa
+dtT
 ssA
 jCF
 ssA

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -858,17 +858,6 @@
 	tag = "icon-stage_stairs"
 	},
 /area/crew_quarters/dorms)
-"abz" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/item/clothing/gloves/boxing/green,
-/obj/item/clothing/gloves/boxing,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/maintenance/fsmaint2)
 "abA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -143517,7 +143506,7 @@ aGX
 aGY
 aGY
 aGY
-abz
+aGY
 aGY
 aGY
 aGY


### PR DESCRIPTION
## What Does This PR Do
Repara un error de areas en Disposals, reconfigura ciertos cables de los APCs conectados al motor, agrega un tiny fan faltante a la TSF y expande el docking port al area de arrivals para evitar una instancia donde la versión medica se come parte de la estación. 

En lavaland añade una doble puerta a la shuttle para Map Rotation. 

## Changelog
:cl:
tweak: Tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
