### PR TITLE
Balance Armadura

### DIFF
--- a/code/hispania/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/hispania/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -100,7 +100,8 @@
 	item_state = "adamsuit"
 	flags_inv = NONE
 	slowdown = 4
-	var/hit_reflect_chance = 40
+	armor = list("melee" = 65, "bullet" = 65, "laser" = 55, "energy" = 50, "bomb" = 70, "bio" = 70, "rad" = 90, "fire" = 90, "acid" = 90)
+	var/hit_reflect_chance = 30
 	hispania_icon = TRUE
 
 /obj/item/clothing/suit/armor/heavy/adamantine/IsReflect(def_zone)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -466,6 +466,7 @@
 		to_chat(user, "<span class='warning'>The potion can only be used on items or vehicles!</span>")
 		return
 	if(isitem(O))
+		if(istype(O, /obj/item/clothing/suit/armor/heavy/adamantine)) return
 		var/obj/item/I = O
 		if(I.slowdown <= 0)
 			to_chat(user, "<span class='warning'>[I] can't be made any faster!</span>")


### PR DESCRIPTION
## What Does This PR Do
Balancea los valores de cierta armadura y la hace incapaz de ser mejorada con speed potion.

## Why It's Good For The Game
Evita una armadura que solo existe por adminspawn.

## Changelog
:cl:
add: Balance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
