### PR TITLE
[Map Changes] Reparaciones Delta y Meta

### DIFF
--- a/_maps/map_files/Delta/delta_hispania.dmm
+++ b/_maps/map_files/Delta/delta_hispania.dmm
@@ -50478,18 +50478,6 @@
 	icon_state = "dark"
 	},
 /area/construction/hallway)
-"bTQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/item/radio/beacon,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/construction/hallway)
 "bTR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -57921,6 +57909,12 @@
 /area/security/brig)
 "cgu" = (
 /obj/machinery/tcomms/core/station,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "cgB" = (
@@ -60381,7 +60375,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "1"
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -61908,7 +61902,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "1"
+	req_access_txt = "63"
 	},
 /turf/simulated/floor/plasteel,
 /area/security/range)
@@ -110099,6 +110093,13 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"fuk" = (
+/obj/machinery/autolathe,
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "whitepurplecorner"
+	},
+/area/medical/research)
 "fxn" = (
 /obj/structure/closet/athletic_mixed,
 /turf/simulated/floor/plasteel{
@@ -111487,6 +111488,16 @@
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/tsf)
+"tdE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
+	},
+/obj/item/radio/beacon,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/turret_protected/aisat)
 "tef" = (
 /obj/machinery/vending/discdan,
 /turf/simulated/floor/plasteel{
@@ -122971,7 +122982,7 @@ bNM
 bQD
 bRH
 bTK
-bVM
+tdE
 bXN
 bNM
 bku
@@ -124769,7 +124780,7 @@ bLV
 brr
 bku
 bRL
-bTQ
+bTS
 bpq
 brr
 abi
@@ -150759,7 +150770,7 @@ cMm
 cNK
 cPu
 cMl
-cSt
+fuk
 cTT
 cVx
 cWR

--- a/_maps/map_files/Delta/delta_hispania.dmm
+++ b/_maps/map_files/Delta/delta_hispania.dmm
@@ -110914,6 +110914,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/medical/psych)
+"nuR" = (
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/vending/walldrobe/sec{
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/main)
 "nxd" = (
 /obj/structure/sign/cargo,
 /turf/simulated/wall/mineral/plastitanium,
@@ -140974,8 +140983,8 @@ byF
 bGO
 bIL
 bKx
-bIL
 bOn
+bIL
 sdt
 bIL
 bUA
@@ -166920,7 +166929,7 @@ bpa
 brc
 bsU
 bui
-bsU
+nuR
 bwE
 bmf
 bIa

--- a/_maps/map_files/Delta/delta_hispania.dmm
+++ b/_maps/map_files/Delta/delta_hispania.dmm
@@ -47627,7 +47627,7 @@
 	tag = ""
 	},
 /obj/machinery/computer/security{
-	network = list("SS13","Mining Outpost")
+	network = list("SS13","Research Outpost","Mining Outpost")
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -111013,6 +111013,9 @@
 	icon_state = "whitebluefull"
 	},
 /area/medical/surgery)
+"otb" = (
+/turf/space,
+/area/shuttle/gamma/station)
 "oCh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -111397,6 +111400,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"sck" = (
+/obj/structure/lattice,
+/turf/space,
+/area/shuttle/gamma/station)
 "sdt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atm{
@@ -167444,13 +167451,13 @@ bWC
 abj
 iAx
 aaa
-eCr
-aaa
-aaa
-eCr
-aaa
-aaa
-aaa
+otb
+otb
+otb
+otb
+otb
+otb
+otb
 bvh
 aaa
 aaa
@@ -167701,13 +167708,13 @@ abi
 abj
 lOI
 eCr
-eCr
-eCr
-eCr
-eCr
-eCr
-eCr
-abj
+otb
+otb
+otb
+otb
+otb
+otb
+sck
 bvh
 abi
 abi
@@ -167958,13 +167965,13 @@ abj
 aaa
 lOI
 aaa
-eCr
-aaa
-aaa
-eCr
-aaa
-aaa
-aaa
+otb
+otb
+otb
+otb
+otb
+otb
+otb
 bvh
 aaa
 aaa
@@ -168215,13 +168222,13 @@ abi
 abi
 lOI
 eCr
-eCr
-eCr
-eCr
-eCr
-eCr
-eCr
-eCr
+otb
+otb
+otb
+otb
+otb
+otb
+otb
 abi
 abj
 abj
@@ -168472,13 +168479,13 @@ aaa
 aaa
 iAx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+otb
+otb
+otb
+otb
+otb
+otb
+otb
 iAx
 aaa
 aaa
@@ -168729,13 +168736,13 @@ aaa
 aaa
 iAx
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+otb
+otb
+otb
+otb
+otb
+otb
+otb
 iAx
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation_hispania.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_hispania.dmm
@@ -2469,7 +2469,9 @@
 	},
 /area/security/hos)
 "ahb" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security{
+	network = list("SS13","Research Outpost","Mining Outpost")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4334,6 +4336,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/book/manual/security_space_law,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4922,20 +4925,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/security/main)
-"alE" = (
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_y = -22
-	},
-/obj/structure/table/reinforced,
-/obj/item/book/manual/security_space_law,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/podbay)
 "alF" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -4958,11 +4947,15 @@
 	},
 /area/security/main)
 "alI" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Pods";
+	req_access_txt = "71"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/podbay)
 "alK" = (
@@ -4970,6 +4963,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6;
+	level = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5203,14 +5200,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
-"amo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
 "amq" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -5432,11 +5421,6 @@
 	},
 /area/security/main)
 "amI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Pods";
-	req_access_txt = "71"
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -5453,9 +5437,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/wall/r_wall,
 /area/security/podbay)
 "amJ" = (
 /obj/structure/cable/yellow{
@@ -5493,15 +5475,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
+/turf/simulated/wall/r_wall,
 /area/security/podbay)
 "amM" = (
 /obj/machinery/computer/secure_data,
@@ -5566,15 +5546,6 @@
 	tag = "icon-vault"
 	},
 /area/security/main)
-"amV" = (
-/obj/structure/table/reinforced,
-/obj/item/spacepod_key{
-	id = 100000
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/podbay)
 "amW" = (
 /obj/machinery/light{
 	dir = 1
@@ -5595,17 +5566,6 @@
 /area/crew_quarters/fitness{
 	name = "\improper Recreation Area"
 	})
-"amX" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/pen,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/podbay)
 "amZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -9277,7 +9237,9 @@
 	},
 /area/security/brig)
 "avd" = (
-/obj/machinery/computer/security,
+/obj/machinery/computer/security{
+	network = list("SS13","Research Outpost","Mining Outpost")
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -9804,19 +9766,6 @@
 	icon_state = "dark"
 	},
 /area/security/brig)
-"awl" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
-"awm" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
 "awn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9838,10 +9787,6 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/wood,
 /area/crew_quarters/mrchangs)
-"awp" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/maintenance/fore)
 "awq" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -11577,6 +11522,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/fore)
 "azN" = (
@@ -44874,6 +44820,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/table/reinforced,
+/obj/item/spacepod_key{
+	id = 100000
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46521,6 +46471,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77947,6 +77903,10 @@
 /obj/effect/landmark/start{
 	name = "Security Pod Pilot"
 	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_y = -22
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79553,6 +79513,20 @@
 	},
 /turf/simulated/floor/engine,
 /area/engine/engineering)
+"eeg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "egZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -79795,6 +79769,13 @@
 /area/maintenance/fpmaint2{
 	name = "Port Maintenance"
 	})
+"eYM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "ffB" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -80437,6 +80418,11 @@
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/tsf)
+"gtG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/fore)
 "gwJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
@@ -82765,13 +82751,10 @@
 /turf/simulated/floor/carpet,
 /area/magistrateoffice)
 "msg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/wall/r_wall,
 /area/security/podbay)
 "mye" = (
 /obj/effect/decal/cleanable/blood,
@@ -86683,7 +86666,7 @@
 	})
 "xbe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -86889,6 +86872,14 @@
 /obj/item/clothing/under/solgov,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"xNf" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/podbay)
 "xOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -118780,9 +118771,9 @@ alP
 deR
 amJ
 asp
-asp
-aod
 apG
+aod
+asp
 asp
 asx
 atK
@@ -119037,10 +119028,10 @@ aid
 alI
 amI
 aid
-atK
-atK
 apF
+atK
 ard
+atK
 apF
 atK
 awd
@@ -119293,13 +119284,13 @@ akC
 akO
 alK
 amL
-aid
 alq
 alq
 alq
 alq
 alq
-atK
+alq
+alq
 awd
 awJ
 atK
@@ -119311,7 +119302,7 @@ aBE
 aAw
 akD
 aEf
-ayG
+gtG
 ayG
 ayG
 cmU
@@ -119550,14 +119541,14 @@ poJ
 xXW
 xbe
 msg
-aid
+alq
+alq
 alq
 alq
 alq
 alq
 alq
 atF
-awl
 arR
 amO
 avl
@@ -119805,16 +119796,16 @@ xOM
 agj
 azE
 bPL
-azE
-alE
+xNf
 aid
 alq
 alq
 alq
 alq
 alq
+alq
+alq
 atF
-alW
 azL
 amO
 avm
@@ -120063,16 +120054,16 @@ afr
 aBK
 bTg
 deG
-amV
 aid
 alq
 alq
 alq
 alq
 alq
+alq
+alq
 atF
-amo
-azL
+eeg
 amO
 avn
 axC
@@ -120320,15 +120311,15 @@ aid
 ays
 bTf
 deC
-amX
 aid
 alq
 alq
 alq
 alq
 alq
+alq
+alq
 atF
-awp
 dFD
 amO
 amO
@@ -120578,22 +120569,22 @@ aid
 aid
 aid
 aid
-aid
+alq
+alq
 alq
 alq
 alq
 alq
 alq
 atF
-awm
 asA
+eYM
+gtG
 ayG
 ayG
 ayG
 ayG
-ayG
-ayG
-ayG
+gtG
 ayG
 aDd
 alW
@@ -120834,7 +120825,7 @@ aaa
 abq
 abq
 abq
-abq
+aWA
 aid
 anQ
 anQ

--- a/_maps/map_files/MetaStation/MetaStation_hispania.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_hispania.dmm
@@ -13977,7 +13977,7 @@
 /area/space)
 "aEJ" = (
 /obj/machinery/door/airlock/external{
-	locked = 1;
+	locked = 0;
 	name = "Mining Dock Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -13992,7 +13992,7 @@
 	})
 "aEL" = (
 /obj/machinery/door/airlock/mining/glass{
-	locked = 1;
+	locked = 0;
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
@@ -14995,7 +14995,9 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/sleep)
 "aGU" = (
-/obj/machinery/door/airlock/tranquillite,
+/obj/machinery/door/airlock/tranquillite{
+	req_access_txt = "46"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16383,7 +16385,9 @@
 /turf/simulated/floor/engine,
 /area/engine/engineering)
 "aJK" = (
-/obj/machinery/door/airlock/bananium/glass,
+/obj/machinery/door/airlock/bananium/glass{
+	req_access_txt = "46"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation_hispania.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_hispania.dmm
@@ -370,6 +370,9 @@
 /obj/item/cultivator,
 /obj/item/seeds/carrot,
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -432,7 +435,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/plasteel{
@@ -22423,6 +22426,7 @@
 /obj/item/paper,
 /obj/item/paper,
 /obj/effect/decal/warning_stripes/east,
+/obj/item/rcs,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "aXo" = (
@@ -27822,6 +27826,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/warning_stripes/south,
+/obj/item/rcs,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/storage)
 "biJ" = (
@@ -44029,6 +44034,7 @@
 	pixel_x = -4;
 	pixel_y = 10
 	},
+/obj/item/rcs,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},

--- a/_maps/map_files/MetaStation/MetaStation_hispania.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_hispania.dmm
@@ -715,6 +715,9 @@
 	pixel_y = 28
 	},
 /obj/machinery/computer/card/minor/hos,
+/obj/machinery/vending/walldrobe/hos{
+	pixel_x = 28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3069,21 +3072,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/security/hos)
-"aib" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -25976,6 +25964,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/vending/walldrobe/ce{
+	pixel_x = 29;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "vault"
@@ -37343,6 +37335,9 @@
 	c_tag = "Captain's Office";
 	dir = 8
 	},
+/obj/machinery/vending/walldrobe/cap{
+	pixel_x = 28
+	},
 /turf/simulated/floor/carpet{
 	icon_state = "carpet10-8";
 	tag = "icon-carpet10-8"
@@ -45340,6 +45335,7 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
+/obj/item/clothing/glasses/welding/superior,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "cafeteria";
@@ -57514,10 +57510,8 @@
 	name = "Medbay Storage"
 	})
 "cpF" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/machinery/vending/walldrobe/cmo{
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -70937,6 +70931,9 @@
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Research Director's Office"
+	},
+/obj/machinery/vending/walldrobe/rd{
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -85446,6 +85443,10 @@
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/vending/walldrobe/sec{
+	pixel_x = 0;
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
@@ -117992,7 +117993,7 @@ abq
 aaa
 agC
 adg
-aib
+aiW
 aja
 ugy
 akU


### PR DESCRIPTION
## What Does This PR Do
Aquí agregare todos los reportes que reciba de Delta y Meta en un periodo de 1 semana.
Delta:

- Repara cable faltante a APC de Comms
- Repara acceso de maint a seguridad
- Reagrega el Autolathe a recibidor de ciencias
- Reposiciona tracking beacon a sat de comms
- Repara el sistema de Gamma Armory
- Agrega Walldrobes Faltantes

Meta:

- Repara accesos a oficina de payaso y mimo
- Evita bolts en puertas de mineria al iniciar el turno
- Repara lista de camaras visibles desde oficina de HoS y Warden
- Repara sistema de Gamma Armory
- Agrega Walldrobes Faltantes

## Changelog
:cl:
add: Reparaciones Delta
add: Reparaciones Meta
/:cl:

