### PR TITLE
Add SpacePods Models (Heavy, Light, Estandar)

### DIFF
--- a/code/hispania/modules/research/designs/spacepod_designs.dm
+++ b/code/hispania/modules/research/designs/spacepod_designs.dm
@@ -52,6 +52,16 @@
 //////SPACEPOD MISC. ITEMS////////////////
 //////////////////////////////////////////
 
+/datum/design/reinforced_plates_spacepod
+	construction_time = 100
+	name = "Spacepod Reinforced Plates"
+	desc = "A bunch of plates that can be install near the engine to make it more robust."
+	id = "podmisc_tracker"
+	req_tech = list("materials" = 5)
+	build_type = PODFAB
+	materials = list(MAT_METAL=5000, MAT_SILVER = 2000)
+	build_path = /obj/item/spacepod_equipment/misc/spacepod_plates
+	category = list("Pod_Parts")
 
 //////////////////////////////////////////
 //////SPACEPOD CARGO ITEMS////////////////

--- a/code/hispania/modules/research/designs/spacepod_designs.dm
+++ b/code/hispania/modules/research/designs/spacepod_designs.dm
@@ -52,6 +52,17 @@
 //////SPACEPOD MISC. ITEMS////////////////
 //////////////////////////////////////////
 
+/datum/design/paintkit
+	construction_time = 100
+	name = "Spacepod Paintkit Bucket"
+	desc = "A bucket full with paint for your spacepod."
+	id = "spacepodpaintkit"
+	req_tech = list("materials" = 1, "combat" = 1, "engineering" = 1)
+	build_type = PODFAB
+	materials = list(MAT_METAL=5000)
+	build_path = /obj/item/pod_paint_bucket
+	category = list("Pod_Parts")
+
 /datum/design/reinforced_plates_spacepod
 	construction_time = 100
 	name = "Spacepod Reinforced Engine"

--- a/code/hispania/modules/research/designs/spacepod_designs.dm
+++ b/code/hispania/modules/research/designs/spacepod_designs.dm
@@ -54,13 +54,35 @@
 
 /datum/design/reinforced_plates_spacepod
 	construction_time = 100
-	name = "Spacepod Reinforced Plates"
-	desc = "A bunch of plates that can be install near the engine to make it more robust."
-	id = "podmisc_tracker"
-	req_tech = list("materials" = 5)
+	name = "Spacepod Reinforced Engine"
+	desc = "A bunch of plates that can be install near the engine to make it more robust but slower."
+	id = "pod_plates_spacepod"
+	req_tech = list("materials" = 5, "combat" = 4, "engineering" = 4)
 	build_type = PODFAB
 	materials = list(MAT_METAL=5000, MAT_SILVER = 2000)
-	build_path = /obj/item/spacepod_equipment/misc/spacepod_plates
+	build_path = /obj/item/fluff/plates_spacepod
+	category = list("Pod_Parts")
+
+/datum/design/modified_engine
+	construction_time = 100
+	name = "Spacepod Modified Engine"
+	desc = "A bunch of diagrams on how to make it faster but more easy to break."
+	id = "pod_enginelight_spacepod"
+	req_tech = list("materials" = 5, "combat" = 4, "engineering" = 4)
+	build_type = PODFAB
+	materials = list(MAT_METAL=5000, MAT_SILVER = 2000, ,MAT_BLUESPACE = 1000)
+	build_path = /obj/item/fluff/plates_spacepod/velocity
+	category = list("Pod_Parts")
+
+/datum/design/basic_engine
+	construction_time = 100
+	name = "Spacepod Standard Engine"
+	desc = "A bunch of diagrams on how to revert any changes to your engine."
+	id = "pod_standard_spacepod"
+	req_tech = list("materials" = 5, "combat" = 4, "engineering" = 4)
+	build_type = PODFAB
+	materials = list(MAT_METAL=5000)
+	build_path = /obj/item/fluff/plates_spacepod/basic_engine
 	category = list("Pod_Parts")
 
 //////////////////////////////////////////

--- a/code/hispania/modules/spacepods/equipment.dm
+++ b/code/hispania/modules/spacepods/equipment.dm
@@ -94,7 +94,7 @@
 		to_chat(user, "<span class='warning'>You can't use this on [target]!</span>")
 		return
 	var/obj/spacepod/pod = target
-	if(!pod.unique_model)
+	if(!pod.unique_model || istype(src, /obj/item/fluff/plates_spacepod/basic_engine))
 		to_chat(user, "<span class='notice'>You start to work on [target].</span>")
 		if(!do_after(user, 40, target = src))
 			return TRUE
@@ -105,6 +105,7 @@
 		pod.name = new_name
 		pod.icon_state = nuevoicon
 		pod.can_paint = pintura
+		pod.maxhealth = vida
 		qdel(src)
 	else
 		to_chat(user, "<span class='warning'>You can't modify this kind of engine anymore!</span>")

--- a/code/hispania/modules/spacepods/equipment.dm
+++ b/code/hispania/modules/spacepods/equipment.dm
@@ -55,12 +55,59 @@
 ///////////////////////////////////////
 */
 
-/obj/item/spacepod_equipment/misc/spacepod_plates
-	name = "spacepod reinforced plates"
+/obj/item/fluff/plates_spacepod //Placas de refuerzo
+	name = "spacepod reinforced engine"
 	desc = "A bunch of plates that can be install near the engine to make it more robust."
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_abooster_ccw"
+	var/vida = 500
+	var/peso = 3
+	var/modelo = TRUE
+	var/new_name = "heavy duty spacepod"
+	var/nuevoicon = "pod_industrial"
+	var/pintura = FALSE
 
+/obj/item/fluff/plates_spacepod/velocity //Motor de Velocidad
+	name = "spacepod modified engine"
+	desc = "A bunch of diagrams on how to make it faster but more easy to break."
+	icon = 'icons/obj/paintkit.dmi'
+	icon_state = "paintkit"
+	vida = 60
+	peso = 1
+	new_name = "light burst spacepod"
+	nuevoicon = "pod_black"
+
+/obj/item/fluff/plates_spacepod/basic_engine //Motor de Velocidad
+	name = "spacepod standard engine"
+	desc = "A bunch of diagrams on how to revert any changes to your engine."
+	icon = 'icons/obj/paintkit.dmi'
+	icon_state = "paintkit"
+	vida = 250
+	peso = 2
+	modelo = FALSE
+	new_name = "spacepod"
+	nuevoicon = "pod_civ"
+	pintura = TRUE
+
+/obj/item/fluff/plates_spacepod/afterattack(atom/target, mob/user, proximity, params)
+	if(!istype(target, /obj/spacepod))
+		to_chat(user, "<span class='warning'>You can't use this on [target]!</span>")
+		return
+	var/obj/spacepod/pod = target
+	if(!pod.unique_model)
+		to_chat(user, "<span class='notice'>You start to work on [target].</span>")
+		if(!do_after(user, 40, target = src))
+			return TRUE
+		to_chat(user, "<span class='notice'>You install the items on [target] based on the kit blueprints and repair all damage to the pod.</span>")
+		pod.health = vida
+		pod.move_delay = peso
+		pod.unique_model = modelo
+		pod.name = new_name
+		pod.icon_state = nuevoicon
+		pod.can_paint = pintura
+		qdel(src)
+	else
+		to_chat(user, "<span class='warning'>You can't modify this kind of engine anymore!</span>")
 /*
 ///////////////////////////////////////
 /////////Cargo System//////////////////

--- a/code/hispania/modules/spacepods/equipment.dm
+++ b/code/hispania/modules/spacepods/equipment.dm
@@ -55,6 +55,12 @@
 ///////////////////////////////////////
 */
 
+/obj/item/spacepod_equipment/misc/spacepod_plates
+	name = "spacepod reinforced plates"
+	desc = "A bunch of plates that can be install near the engine to make it more robust."
+	icon = 'icons/mecha/mecha_equipment.dmi'
+	icon_state = "mecha_abooster_ccw"
+
 /*
 ///////////////////////////////////////
 /////////Cargo System//////////////////

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -202,7 +202,7 @@
 	if(istype(loc, /obj/spacepod)) // Spacdpods!
 		var/obj/spacepod/S = loc
 		stat("Spacepod Charge", "[istype(S.battery) ? "[(S.battery.charge / S.battery.maxcharge) * 100]" : "No cell detected"]")
-		stat("Spacepod Integrity", "[!S.health ? "0" : "[(S.health / initial(S.health)) * 100]"]%")
+		stat("Spacepod Integrity", "[!S.health ? "0" : "[(S.health / S.maxhealth) * 100]"]%") //Hispania Spacepods
 
 /mob/living/carbon/human/ex_act(severity)
 	if(status_flags & GODMODE)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -64,6 +64,7 @@
 	var/move_delay = 2
 	var/next_move = 0
 	var/can_paint = TRUE
+	var/unique_model = FALSE //Hispania Models
 
 /obj/spacepod/proc/apply_paint(mob/user as mob)
 	var/part_type

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -48,6 +48,7 @@
 	var/list/pod_paint_effect
 	var/list/colors = new/list(4)
 	var/health = 250
+	var/maxhealth = 250
 	var/empcounter = 0 //Used for disabling movement when hit by an EMP
 
 	var/lights = 0
@@ -207,9 +208,9 @@
 			to_add = pod_paint_effect[PAINT]
 			to_add.color = colors[PAINT]
 			overlays += to_add
-	if(health <= round(initial(health)/2))
+	if(health <= round(maxhealth/2))
 		overlays += pod_overlays[DAMAGE]
-		if(health <= round(initial(health)/4))
+		if(health <= round(maxhealth/4))
 			overlays += pod_overlays[FIRE]
 
 
@@ -263,7 +264,7 @@
 /obj/spacepod/proc/deal_damage(damage)
 	var/oldhealth = health
 	health = max(0, health - damage)
-	var/percentage = (health / initial(health)) * 100
+	var/percentage = (health / maxhealth) * 100
 	occupant_sanity_check()
 	if(oldhealth > health && percentage <= 25 && percentage > 0)
 		play_sound_to_riders('sound/effects/engine_alert2.ogg')
@@ -290,7 +291,7 @@
 
 /obj/spacepod/proc/repair_damage(repair_amount)
 	if(health)
-		health = min(initial(health), health + repair_amount)
+		health = min(maxhealth, health + repair_amount)
 		update_icons()
 
 
@@ -436,7 +437,7 @@
 	if(!hatch_open)
 		to_chat(user, "<span class='warning'>You must open the maintenance hatch before attempting repairs.</span>")
 		return
-	if(health >= initial(health))
+	if(health >= maxhealth)
 		to_chat(user, "<span class='boldnotice'>[src] is fully repaired!</span>")
 		return
 	if(!I.tool_use_check(user, 0))


### PR DESCRIPTION
## What Does This PR Do
Añade tres nuevos tipos de objeto para las space pods las cuales modifican valores a cada uno:

"spacepod standard engine" : Valores basicos y revert a cualquier cambio de las otras dos.
"spacepod modified engine": Rápida pero con poca resistencia a daño. (Icon Unico)
"spacepod reinforced engine": Lenta pero con una alta resistencia a daño.  (Icon Unico)

Agrega a su vez el spacepod paint kit como design. Modifica el código para hacer cálculos correctos de porcentaje.

## Why It's Good For The Game
Agrega mas diversidad a la capacidad de tipos de spacepod que puede crear el mecánico. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/120540426-4d16d580-c3ae-11eb-9431-f50462f1c252.png)
![image](https://user-images.githubusercontent.com/46639834/120542348-9c5e0580-c3b0-11eb-8da2-f516e4fbf13b.png)



## Changelog
:cl:
add: Spacepod Models
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
