### PR TITLE
Tweak Mega Carp Random Values

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -150,10 +150,10 @@
 /mob/living/simple_animal/hostile/carp/megacarp/Initialize()
 	. = ..()
 	name = "[pick(GLOB.megacarp_first_names)] [pick(GLOB.megacarp_last_names)]"
-	melee_damage_lower += rand(2, 10)
-	melee_damage_upper += rand(10, 20)
-	maxHealth += rand(30, 60)
-	move_to_delay = rand(3, 7)
+	melee_damage_lower += rand(10, 20)
+	melee_damage_upper += rand(20, 30)
+	maxHealth += rand(70, 150)
+	move_to_delay = rand(2, 5)
 
 /mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE)
 	. = ..()


### PR DESCRIPTION
## What Does This PR Do
Modifica los valores aleatorias con los cuales se generan las mega carpas.

## Why It's Good For The Game
Actualmente el mob era solo una carpa mas con ligeramente mas daño y con poca probabilidad de aparecer. Esto hace que ver una carpa enorme tenga mas sentido sea muchísimo mas peligrosa a la vez que hace justicia a sus nombres.

## Changelog
:cl:
tweak: Mega Carp Values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
