### PR TITLE
[Map Changes] Hispania Disposals 

### DIFF
--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -27393,6 +27393,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "bco" = (
@@ -31857,6 +31858,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "bkJ" = (
@@ -45472,11 +45474,13 @@
 	pixel_y = 0;
 	tag = ""
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2";
+	tag = "icon-pipe-j1 (WEST)"
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bNx" = (
@@ -46646,6 +46650,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bPv" = (
@@ -49803,6 +49808,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/hallway/secondary/exit)
 "bUV" = (
@@ -75964,11 +75970,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/maintenance/aft)
-"daC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "daG" = (
 /obj/machinery/light{
 	dir = 1
@@ -89039,6 +89040,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 5
@@ -90472,9 +90477,6 @@
 /turf/simulated/floor/plating,
 /area/storage/secure)
 "lQt" = (
-/obj/structure/closet/emcloset,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = -27;
@@ -91843,13 +91845,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/dorms)
 "nfu" = (
-/obj/structure/rack{
-	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution";
 	dir = 9
@@ -103252,6 +103248,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
+"yjY" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "ykz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -155595,7 +155596,7 @@ bjR
 nfu
 xxN
 lQt
-urf
+yjY
 cFW
 baU
 cIJ
@@ -155852,7 +155853,7 @@ bjR
 fIV
 xxN
 uZH
-daC
+urf
 baV
 baV
 baV

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -1126,7 +1126,15 @@
 	},
 /area/crew_quarters/dorms)
 "abY" = (
-/obj/item/storage/fancy/mre_cracker,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "abZ" = (
@@ -27349,7 +27357,6 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bck" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27359,6 +27366,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bcl" = (
@@ -27382,20 +27390,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
-"bcn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "bco" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood,
@@ -31654,10 +31648,10 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/nw)
 "bkt" = (
-/obj/effect/spawner/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "bku" = (
@@ -31853,14 +31847,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
-"bkI" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/space,
-/area/space/nearstation)
 "bkJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -74492,6 +74478,9 @@
 	base_state = "left"
 	},
 /obj/effect/decal/warning_stripes/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/bar)
 "cWH" = (
@@ -90691,6 +90680,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/library)
+"lYE" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/escapepodbay)
 "lYJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -95230,6 +95224,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/dorms)
+"qDL" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/maintenance/fsmaint2)
 "qEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	req_access_txt = "0"
@@ -103248,11 +103248,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"yjY" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
-/area/escapepodbay)
 "ykz" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -144000,7 +143995,7 @@ aQC
 aGY
 aGY
 aGX
-aLc
+qDL
 aGY
 bhp
 bjX
@@ -144517,7 +144512,7 @@ aMz
 aGX
 aMz
 aMz
-bkt
+bkN
 bck
 beb
 bdV
@@ -144773,9 +144768,9 @@ aGY
 aGX
 aTZ
 aGY
-aMr
-bkI
-bcn
+aGX
+bkN
+bcm
 beb
 bdW
 bfN
@@ -145027,12 +145022,12 @@ aGX
 aHb
 hTh
 aGY
-aTg
+aGY
 aGY
 aGY
 aHP
 bkt
-bck
+bcm
 beb
 bei
 bfL
@@ -145797,7 +145792,7 @@ aRI
 aMz
 aHb
 aOG
-aGY
+aQI
 aUc
 aGY
 aVQ
@@ -155596,7 +155591,7 @@ bjR
 nfu
 xxN
 lQt
-yjY
+lYE
 cFW
 baU
 cIJ


### PR DESCRIPTION
## What Does This PR Do
Repara unos cuantos detalles referentes a las pipes que se encuentran en Bar, Maint Serv y Mecanica al igual que reposiciona las puertas de mecánica para que funcionen de forma optima con dos spacepods en docking.

## Why It's Good For The Game
Evita basura al espacio. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/120861349-cb10e300-c54c-11eb-94d6-65c5df4f49da.png)


## Changelog
:cl:
fix: Disposals Hispania
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
