### PR TITLE
Fix Radio Sprites

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,6 +1,7 @@
 /obj/item/radio/intercom
 	name = "station intercom (General)"
 	desc = "Talk through this."
+	icon = 'icons/hispania/obj/radio.dmi'
 	icon_state = "intercom"
 	anchored = 1
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(default_medbay_channels, list(
 ))
 
 /obj/item/radio
-	icon = 'icons/hispania/obj/radio.dmi'
+	icon = 'icons/obj/radio.dmi'
 	name = "station bounced radio"
 	dog_fashion = /datum/dog_fashion/back
 	suffix = "\[3\]"


### PR DESCRIPTION
## What Does This PR Do
Repara un error de direcciones que volvía las radios en objetos invisibles.

## Why It's Good For The Game
Evita un objeto importante sea invisible.

## Changelog
:cl:
fix: Radio Invisible
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
