### PR TITLE
Tweak Station Goals

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -20,6 +20,9 @@
 	exp_requirements = 2880
 	exp_type = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/cmo
+	required_objectives = list(
+		/datum/job_objective/make_station_goal
+	)
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -23,7 +23,8 @@
 	exp_type = EXP_TYPE_SCIENCE
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
-		/datum/job_objective/further_research
+		/datum/job_objective/further_research,
+		/datum/job_objective/make_station_goal
 	)
 
 	outfit = /datum/outfit/job/rd

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -23,6 +23,9 @@
 	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
+	required_objectives = list(
+		/datum/job_objective/make_station_goal
+	)
 
 /datum/outfit/job/hos
 	name = "Head of Security"

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -17,6 +17,9 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 	exp_type = EXP_TYPE_COMMAND
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/captain
+	required_objectives = list(
+		/datum/job_objective/make_station_goal
+	)
 
 /datum/job/captain/get_access()
 	return get_all_accesses()
@@ -81,6 +84,9 @@ GLOBAL_DATUM_INIT(captain_announcement, /datum/announcement/minor, new(do_newsca
 			            ACCESS_THEATRE, ACCESS_CHAPEL_OFFICE, ACCESS_LIBRARY, ACCESS_MINING, ACCESS_HEADS_VAULT, ACCESS_MINING_STATION,
 			            ACCESS_CLOWN, ACCESS_MIME, ACCESS_HOP, ACCESS_RC_ANNOUNCE, ACCESS_KEYCARD_AUTH, ACCESS_GATEWAY, ACCESS_WEAPONS, ACCESS_MINERAL_STOREROOM)
 	outfit = /datum/outfit/job/hop
+	required_objectives = list(
+		/datum/job_objective/make_station_goal
+	)
 
 /datum/outfit/job/hop
 	name = "Head of Personnel"

--- a/code/hispania/game/jobs/job_objectives/engineering.dm
+++ b/code/hispania/game/jobs/job_objectives/engineering.dm
@@ -21,7 +21,8 @@
 	var/datum/station_goal/ss = new/datum/station_goal/station_shield
 	var/datum/station_goal/bsa = new/datum/station_goal/bluespace_cannon
 	var/datum/station_goal/dnav = new/datum/station_goal/dna_vault
-	if(ss.check_completion() || bsa.check_completion() || dnav.check_completion())
+	var/datum/station_goal/redesp = new/datum/station_goal/redspacesearch
+	if(ss.check_completion() || bsa.check_completion() || dnav.check_completion() || redesp.check_completion())
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## What Does This PR Do
Ahora todos los jefes departamentales tienen que supervisar los Objetivos de la Estación pues es parte de sus goals.

## Why It's Good For The Game
Motiva a los jefes departamentales a no depende unicamente de su CE para coordinar todos los preparativos para esto o en algunos casos evita que ignoren directamente los objetivos laborales. 

## Changelog
:cl:
tweak: Objetivos Laborales
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
