### PR TITLE
Tweak Dead Vote

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -196,8 +196,10 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/submit_vote(ckey, vote)
 	if(mode)
+		/*
 		if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)
 			return 0
+		*/
 		if(current_votes[ckey])
 			choices[choices[current_votes[ckey]]]--
 		if(vote && 1<=vote && vote<=choices.len)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -199,7 +199,7 @@ SUBSYSTEM_DEF(vote)
 		/*
 		if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)
 			return 0
-		*/
+		*///Ghost Vote Hispania
 		if(current_votes[ckey])
 			choices[choices[current_votes[ckey]]]--
 		if(vote && 1<=vote && vote<=choices.len)


### PR DESCRIPTION
## What Does This PR Do
Esto habilita que todos los jugadores independientes a su estado puedan votar.

## Why It's Good For The Game
Actualmente no tenemos una Pop tan grande como la de paradise donde la metagang de fantasmas puede tirar un crew transfer cuando mueren así que es mas optimo que todos los jugadores puedan votar independiente a su estado. 

## Changelog
:cl:
tweak: Ghost  Vote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
