### PR TITLE
PR 1000 - DABABY MEJORADO LESGOOO

### DIFF
--- a/_maps/map_files/dababy/sexo.dmm
+++ b/_maps/map_files/dababy/sexo.dmm
@@ -11989,16 +11989,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
-"Ri" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/obj/item/stamp/hop,
-/obj/item/eftpos,
-/obj/item/book/manual/sop_service,
-/obj/item/book/manual/sop_supply,
-/obj/item/book/manual/sop_command,
-/turf/simulated/floor/plasteel,
-/area/space)
 "Rk" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
@@ -46845,7 +46835,7 @@ fg
 fh
 fm
 aC
-Ri
+aa
 jT
 TQ
 ed

--- a/_maps/map_files/dababy/sexo.dmm
+++ b/_maps/map_files/dababy/sexo.dmm
@@ -1283,9 +1283,7 @@
 /area/hallway/primary/central/ne)
 "cs" = (
 /obj/machinery/computer/message_monitor,
-/obj/item/radio/intercom{
-	step_y = 24
-	},
+/obj/item/radio/intercom,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files/dababy/sexo.dmm
+++ b/_maps/map_files/dababy/sexo.dmm
@@ -88,12 +88,18 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 8
 	},
 /area/security/nuke_storage)
 "al" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
 	dir = 1
@@ -195,6 +201,10 @@
 	},
 /obj/structure/closet/crate{
 	name = "Silver Crate"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	tag = "icon-bulb1 (EAST)"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault";
@@ -391,15 +401,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
-"aQ" = (
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
 "aR" = (
-/obj/machinery/computer/cloning,
 /obj/machinery/camera{
 	c_tag = "Medbay Cloning";
 	network = list("SS13")
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitepurple (NORTH)";
 	icon_state = "whitepurple";
@@ -416,6 +423,7 @@
 /turf/simulated/wall,
 /area/hydroponics)
 "aU" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = 30
@@ -424,10 +432,6 @@
 	icon_state = "dark"
 	},
 /area/gateway)
-"aV" = (
-/obj/machinery/smartfridge,
-/turf/simulated/floor/plasteel,
-/area/hydroponics)
 "aW" = (
 /turf/simulated/wall,
 /area/crew_quarters/kitchen)
@@ -444,6 +448,7 @@
 	name = "Bridge Requests Console";
 	pixel_y = 30
 	},
+/obj/item/stamp/hop,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads)
 "ba" = (
@@ -536,11 +541,23 @@
 "bi" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "bj" = (
 /obj/effect/landmark/start{
 	name = "Chef"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -549,11 +566,25 @@
 	},
 /area/crew_quarters/kitchen)
 "bk" = (
-/obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife,
-/obj/item/reagent_containers/food/drinks/bottle/cream,
+/obj/item/kitchen/knife{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/cream{
+	pixel_x = 4
+	},
 /obj/machinery/reagentgrinder,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -569,6 +600,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/item/storage/bag/uno,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bm" = (
@@ -586,12 +618,16 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bo" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"bp" = (
+"bq" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/bridge)
+"br" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
 	name = "standard air scrubber";
@@ -599,16 +635,9 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"bq" = (
-/obj/effect/spawner/window/reinforced,
-/turf/simulated/floor/plating,
-/area/bridge)
-"br" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -651,8 +680,8 @@
 /area/crew_quarters/bar)
 "bw" = (
 /obj/item/phone{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -660,13 +689,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/turret_protected/ai)
-"bx" = (
-/obj/machinery/porta_turret,
-/turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
 "by" = (
 /obj/structure/cable{
@@ -726,6 +752,14 @@
 /area/crew_quarters/captain)
 "bF" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -737,13 +771,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
 	},
 /obj/machinery/computer/cryopod{
 	density = 0;
@@ -760,6 +787,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -826,14 +854,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "open";
-	id_tag = "hop";
-	name = "Privacy Shutters";
-	opacity = 0
-	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 4;
@@ -847,14 +867,23 @@
 	name = "Head of Personnel's Desk";
 	req_access_txt = "0"
 	},
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bN" = (
+/obj/machinery/computer/aiupload,
+/obj/machinery/power/apc{
+	cell_type = 5000;
+	dir = 8;
+	name = "west bump Important Area";
+	pixel_x = -24;
+	shock_proof = 0
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "0-4";
+	d2 = 4
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Core South";
@@ -862,7 +891,7 @@
 	network = list("SS13","MiniSat")
 	},
 /turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bO" = (
 /obj/machinery/door/airlock/vault{
 	icon_state = "door_locked";
@@ -880,8 +909,9 @@
 /turf/simulated/wall/r_wall,
 /area/medical/chemistry)
 "bQ" = (
+/obj/machinery/computer/borgupload,
 /turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "bR" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -1034,6 +1064,10 @@
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Bridge"
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = -7;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/heads)
 "bZ" = (
@@ -1054,14 +1088,18 @@
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
 "cc" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
 /obj/machinery/light/small{
 	dir = 1;
 	pixel_x = 0;
 	pixel_y = 0
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/medical/medbay2)
@@ -1093,19 +1131,11 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "ce" = (
 /obj/machinery/light{
 	dir = 1;
 	in_use = 1
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -1189,6 +1219,14 @@
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "ck" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central/ne)
 "cm" = (
@@ -1245,6 +1283,9 @@
 /area/hallway/primary/central/ne)
 "cs" = (
 /obj/machinery/computer/message_monitor,
+/obj/item/radio/intercom{
+	step_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1289,10 +1330,6 @@
 	})
 "cw" = (
 /obj/machinery/cryopod/robot,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1323,11 +1360,6 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/hardsuit/engine/atmos,
 /obj/item/clothing/suit/space/hardsuit/engine/atmos,
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "cB" = (
@@ -1413,7 +1445,6 @@
 	},
 /area/medical/surgery1)
 "cJ" = (
-/obj/structure/closet/secure_closet/CMO,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -1426,8 +1457,14 @@
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Chief Medical Officer"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
@@ -1449,9 +1486,7 @@
 	dir = 1;
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/computer/cloning,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitepurple (SOUTHWEST)";
 	icon_state = "whitepurple";
@@ -1499,7 +1534,6 @@
 /obj/item/stack/sheet/glass{
 	amount = 50
 	},
-/obj/item/clothing/head/welding,
 /obj/item/clothing/head/welding{
 	layer = 8
 	},
@@ -1517,6 +1551,9 @@
 	},
 /obj/item/pipe_painter,
 /obj/item/pipe_painter,
+/obj/item/clothing/head/welding{
+	layer = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "yellow"
@@ -1651,10 +1688,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"dh" = (
-/obj/machinery/computer/borgupload,
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
 "di" = (
 /obj/machinery/atmospherics/unary/tank/nitrous_oxide{
 	dir = 8
@@ -1662,7 +1695,7 @@
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "dj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1732,9 +1765,7 @@
 	dir = 6;
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "whitepurple";
@@ -2057,10 +2088,6 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /obj/effect/landmark/start{
 	name = "AI"
 	},
@@ -2117,6 +2144,10 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "ee" = (
@@ -2166,8 +2197,26 @@
 	},
 /area/quartermaster/office)
 "ej" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/door_control{
+	id = "stationawaygate";
+	name = "Gateway Shutters Access Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "62"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -2181,6 +2230,9 @@
 	name = "security checkpoint";
 	req_access_txt = "104"
 	},
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/security/brig)
 "em" = (
@@ -2278,7 +2330,11 @@
 	departmentType = 5;
 	name = "Head of Security Requests Console";
 	pixel_x = 30;
-	pixel_y = 0
+	pixel_y = 6
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 26;
+	pixel_y = -8
 	},
 /turf/simulated/floor/carpet,
 /area/security/hos)
@@ -2397,6 +2453,12 @@
 	name = "Janitor Requests Console";
 	pixel_y = -29
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "station intercom (General)";
+	pixel_x = -28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "eB" = (
@@ -2414,6 +2476,10 @@
 	name = "Morgue Requests Console";
 	pixel_x = 0;
 	pixel_y = -30
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2471,6 +2537,11 @@
 "eF" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24"
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "station intercom (General)";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2587,7 +2658,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/hallway/primary/central/ne)
+/area/gateway)
 "eN" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/warning_stripes/white/hollow,
@@ -2608,6 +2679,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/machinery/computer/scan_consolenew,
 /turf/simulated/floor/plasteel{
 	tag = "icon-whitepurple (SOUTHEAST)";
 	icon_state = "whitepurple";
@@ -2663,9 +2735,13 @@
 "eS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
+	dir = 4;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "eT" = (
@@ -2748,11 +2824,10 @@
 	},
 /area/storage/eva)
 "fd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4;
-	initialize_directions = 11;
-	level = 1
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8;
+	initialize_directions = 11
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -2912,6 +2987,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "fp" = (
@@ -3051,6 +3132,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/walldrobe/ce{
+	pixel_y = 29
+	},
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/rcd_ammo/large,
+/obj/item/megaphone,
+/obj/item/stamp/ce,
+/obj/machinery/keycard_auth{
+	pixel_x = 6;
+	pixel_y = 7
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 9
@@ -3058,6 +3151,9 @@
 /area/engine/chiefs_office)
 "fx" = (
 /obj/machinery/computer/card/minor/ce,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
@@ -3085,6 +3181,10 @@
 /area/engine/gravitygenerator)
 "fB" = (
 /obj/machinery/suit_storage_unit/ce,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 5
@@ -3120,6 +3220,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -3451,9 +3552,6 @@
 /area/medical/medbay2)
 "ga" = (
 /obj/structure/table/reinforced,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
 /obj/machinery/door/window/eastright{
 	name = "Robotics Desk";
 	icon_state = "left";
@@ -3465,6 +3563,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/folder/white,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/micro_laser,
 /turf/simulated/floor/plasteel,
 /area/toxins/lab)
 "gb" = (
@@ -3607,21 +3711,15 @@
 /area/medical/surgery1)
 "gn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/computer/atmoscontrol,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "go" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/mixer,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = 30
 	},
+/obj/machinery/kitchen_machine/grill,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria";
 	dir = 2
@@ -3638,69 +3736,30 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	tag = ""
-	},
+/obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "gr" = (
-/obj/machinery/computer/crew,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer Requests Console";
-	pixel_x = 0;
-	pixel_y = 30
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen/multi,
+/obj/item/folder/white{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = 7
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
+	dir = 4;
 	icon_state = "darkblue"
 	},
 /area/medical/cmo)
 "gs" = (
 /obj/effect/spawner/window/reinforced,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/plating,
-/area/engine/engineering)
-"gt" = (
-/obj/machinery/door/airlock/command{
-	name = "Gateway Access";
-	req_access_txt = "62"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/hallway/primary/central/ne)
+/area/engine/controlroom)
 "gu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 4;
@@ -3709,17 +3768,11 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "gv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3733,39 +3786,17 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8";
-	tag = ""
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 8
 	},
-/area/engine/break_room)
-"gw" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
+/area/engine/engineering)
 "gx" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/structure/table,
+/obj/machinery/kitchen_machine/mixer,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -3787,19 +3818,20 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "gz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/chair/office/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "gA" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -3860,31 +3892,9 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
-"gO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "gP" = (
 /obj/structure/chair/office/light{
 	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Chief Medical Officer"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3921,6 +3931,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "ramptop";
@@ -4023,6 +4034,15 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
+"hs" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "hu" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plasteel{
@@ -4158,22 +4178,6 @@
 	icon_state = "white"
 	},
 /area/medical/medbay2)
-"hM" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "hN" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -4454,7 +4458,6 @@
 	},
 /area/toxins/xenobiology)
 "iy" = (
-/obj/structure/table/reinforced,
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
 	pixel_y = 6
@@ -4470,6 +4473,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/structure/table,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -4486,10 +4490,6 @@
 /area/toxins/lab)
 "iA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -4501,7 +4501,9 @@
 /area/crew_quarters/hor)
 "iH" = (
 /obj/machinery/smartfridge/secure/extract,
-/turf/simulated/wall,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
 /area/toxins/xenobiology)
 "iM" = (
 /obj/docking_port/stationary{
@@ -4526,6 +4528,11 @@
 /area/security/nuke_storage)
 "iQ" = (
 /obj/structure/closet/secure_closet/RD,
+/obj/machinery/vending/walldrobe/rd{
+	pixel_x = 28;
+	pixel_y = 0
+	},
+/obj/item/clothing/glasses/welding/superior,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -4662,6 +4669,9 @@
 /obj/item/storage/lockbox/medal,
 /obj/item/hand_tele,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/vending/walldrobe/cap{
+	pixel_x = 30
+	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "jg" = (
@@ -4711,14 +4721,13 @@
 /turf/simulated/wall,
 /area/crew_quarters/bar)
 "jk" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/machinery/plantgenes,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -4732,6 +4741,11 @@
 /area/hallway/primary/central/ne)
 "jm" = (
 /obj/machinery/mech_bay_recharge_port,
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "station intercom (General)";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
 "jn" = (
@@ -4832,8 +4846,13 @@
 	dir = 6;
 	level = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "green"
+	},
 /area/hydroponics)
 "jA" = (
 /obj/machinery/gateway{
@@ -4860,12 +4879,12 @@
 "jD" = (
 /obj/structure/rack,
 /obj/item/storage/box/tranquilizer{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/item/storage/box/tranquilizer{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/item/storage/box/buck{
 	pixel_x = 3;
@@ -4926,6 +4945,19 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
+"jJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/space,
+/area/solar/auxstarboard)
 "jO" = (
 /turf/simulated/wall/r_wall,
 /area/medical/genetics_cloning)
@@ -4964,6 +4996,13 @@
 /obj/effect/landmark/start{
 	name = "Civilian"
 	},
+/obj/machinery/vending/wallmed{
+	dir = 2;
+	name = "Emergency NanoMed";
+	pixel_x = -27;
+	pixel_y = 0;
+	req_access_txt = "0"
+	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "jT" = (
@@ -4989,15 +5028,22 @@
 	id_tag = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
-/turf/space,
-/area/hallway/primary/central/ne)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "jX" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
 /area/hydroponics)
 "jY" = (
 /obj/machinery/door/firedoor,
@@ -5041,6 +5087,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5105,7 +5156,11 @@
 	dir = 4;
 	level = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
 /area/hydroponics)
 "kg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -5115,7 +5170,10 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "green"
+	},
 /area/hydroponics)
 "kh" = (
 /obj/machinery/door/airlock/security/glass{
@@ -5198,7 +5256,7 @@
 "kq" = (
 /obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "kt" = (
 /obj/machinery/power/solar_control,
 /obj/structure/cable{
@@ -5209,21 +5267,24 @@
 	dir = 1;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "ku" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/atmos)
 "kv" = (
-/obj/effect/landmark/start{
-	name = "Life Support Specialist"
-	},
+/obj/structure/dispenser,
 /turf/simulated/floor/plasteel,
 /area/atmos)
-"kx" = (
-/obj/effect/spawner/window/reinforced,
+"kw" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
 /turf/simulated/floor/plating,
-/area/solar/port)
+/area/maintenance/auxsolarstarboard)
 "ky" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -5241,15 +5302,15 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/solar/port)
+/area/engine/engineering)
 "kC" = (
 /obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
 /obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
+	id = "aftportsolar";
+	name = "Aft Port Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -5296,7 +5357,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/solar/port)
+/area/engine/engineering)
 "kF" = (
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/plasteel,
@@ -5340,7 +5401,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/plating,
-/area/solar/port)
+/area/engine/engineering)
 "kL" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/simulated/floor/plasteel,
@@ -5406,6 +5467,24 @@
 	},
 /turf/space,
 /area/solar/port)
+"kX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "kY" = (
 /mob/living/carbon/human/monkey/punpun,
 /turf/simulated/floor/plasteel{
@@ -5434,6 +5513,19 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/solar/port)
+"lb" = (
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/hydroponics)
+"lc" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "le" = (
 /obj/effect/landmark/start{
 	name = "Geneticist"
@@ -5501,17 +5593,6 @@
 	icon_state = "dark"
 	},
 /area/medical/morgue)
-"lh" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/radio,
-/obj/item/radio,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/gateway)
 "li" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5685,7 +5766,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "green";
+	dir = 8
+	},
 /area/hydroponics)
 "lB" = (
 /obj/machinery/door/airlock/public/glass{
@@ -5803,6 +5887,10 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -5973,6 +6061,11 @@
 /obj/effect/landmark{
 	name = "revenantspawn"
 	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -6054,6 +6147,7 @@
 	dir = 4;
 	level = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "mz" = (
@@ -6173,26 +6267,13 @@
 /turf/simulated/floor/plasteel,
 /area/crew_quarters/kitchen)
 "mL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "cafeteria";
-	tag = "icon-cafeteria (NORTHEAST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10;
+	initialize_directions = 10
 	},
-/area/crew_quarters/kitchen)
-"mM" = (
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -6202,13 +6283,6 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 8;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
@@ -6351,6 +6425,10 @@
 "mY" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "mZ" = (
@@ -6392,6 +6470,7 @@
 "nf" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "nh" = (
@@ -6405,6 +6484,11 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25;
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet,
@@ -6571,6 +6655,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "station intercom (General)";
+	pixel_x = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -6612,6 +6701,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5;
+	level = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -6769,10 +6862,6 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "nF" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -6989,14 +7078,6 @@
 /turf/simulated/floor/bluegrid,
 /area/toxins/server)
 "nY" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 6
-	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -7011,6 +7092,16 @@
 	c_tag = "Research Robotics Lab";
 	dir = 2;
 	network = list("Research","SS13")
+	},
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
 /turf/simulated/floor/plasteel,
 /area/assembly/robotics)
@@ -7110,6 +7201,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/camera{
+	c_tag = "Research Server Room";
+	dir = 1;
+	network = list("Research","SS13");
+	pixel_x = 22
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/toxins/server)
 "oi" = (
@@ -7170,13 +7267,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/turretid/stun{
+	control_area = "\improper AI Chamber";
+	name = "AI Chamber Turret Control";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access = list(75)
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/server)
 "oo" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access";
+	name = "Messaging Server";
 	req_access_txt = "16"
 	},
 /obj/machinery/door/firedoor,
@@ -7225,6 +7329,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "ramptop";
@@ -7233,7 +7338,7 @@
 /area/hallway/primary/central/ne)
 "os" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access";
+	name = "Service Bay";
 	req_access_txt = "16"
 	},
 /obj/machinery/door/firedoor,
@@ -7285,6 +7390,7 @@
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "ramptop";
@@ -7366,23 +7472,20 @@
 /turf/simulated/floor/plasteel,
 /area/teleporter)
 "oB" = (
-/turf/simulated/wall/r_wall,
-/area/turret_protected/ai_upload)
-"oC" = (
-/obj/machinery/computer/aiupload,
-/obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 8;
-	name = "west bump Important Area";
-	pixel_x = -24;
-	shock_proof = 0
-	},
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai_upload)
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "oE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7476,7 +7579,7 @@
 /area/turret_protected/ai)
 "oK" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "AI Upload Access";
+	name = "AI Chamber";
 	req_access_txt = "16"
 	},
 /obj/machinery/door/firedoor,
@@ -7488,7 +7591,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/turret_protected/ai_upload)
+/area/turret_protected/ai)
 "oN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7513,6 +7616,7 @@
 /turf/simulated/wall/r_wall,
 /area/janitor)
 "oR" = (
+/obj/machinery/porta_turret,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7628,6 +7732,9 @@
 	dir = 4;
 	level = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7636,11 +7743,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/interrogation)
 "pc" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = 0
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4;
 	initialize_directions = 11;
@@ -7757,6 +7859,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/camera{
+	c_tag = "Brig Prisoner Processing West";
+	dir = 4;
+	network = list("SS13");
+	pixel_x = 0;
+	pixel_y = -22
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7819,6 +7928,10 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = 7;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "cafeteria";
@@ -7832,6 +7945,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7893,6 +8007,7 @@
 	dir = 4;
 	level = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "pr" = (
@@ -7947,6 +8062,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
@@ -8097,6 +8215,10 @@
 	dir = 4;
 	level = 1
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "pE" = (
@@ -8156,7 +8278,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8203,6 +8325,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/vending/walldrobe/hos{
+	pixel_x = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -8305,6 +8430,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "pX" = (
@@ -8322,7 +8448,7 @@
 	dir = 2;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "pY" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
@@ -8338,7 +8464,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "pZ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -8424,6 +8550,11 @@
 	pixel_x = -25;
 	pixel_y = 0
 	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plating,
 /area/teleporter)
 "qe" = (
@@ -8466,7 +8597,7 @@
 	dir = 8;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "qh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/alarm{
@@ -8629,6 +8760,9 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -8637,7 +8771,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 2";
-	name = "Cell 5";
+	name = "Cell 1";
 	req_access_txt = "2"
 	},
 /obj/machinery/door_timer/cell_1{
@@ -8699,7 +8833,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "qu" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8745,7 +8879,7 @@
 	icon_state = "darkyellow";
 	dir = 8
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "qx" = (
 /obj/effect/landmark/start{
 	name = "Security Officer"
@@ -8812,7 +8946,7 @@
 /area/security/armoury)
 "qA" = (
 /turf/simulated/wall/r_wall,
-/area/engine/engineering)
+/area/engine/controlroom)
 "qB" = (
 /obj/effect/landmark/start{
 	name = "Head of Personnel"
@@ -8880,6 +9014,10 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -24;
+	pixel_y = -6
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -9031,37 +9169,29 @@
 /area/quartermaster/office)
 "qT" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
+/obj/structure/cable,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellowcorners"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "qU" = (
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/power/terminal{
+	dir = 8
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 1
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "qV" = (
 /turf/simulated/wall/r_wall,
 /area/security/warden)
@@ -9125,6 +9255,31 @@
 "rd" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/grass,
+/area/hallway/primary/central/ne)
+"re" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/grass,
+/area/hallway/primary/central/ne)
+"rf" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
+/area/hallway/primary/central/ne)
+"rg" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "station intercom (General)";
@@ -9133,8 +9288,8 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
-"re" = (
-/obj/structure/flora/ausbushes/genericbush,
+"rh" = (
+/obj/structure/flora/ausbushes/grassybush,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "station intercom (General)";
@@ -9143,32 +9298,19 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
-"rf" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/vending/wallmed{
-	dir = 2;
-	name = "Emergency NanoMed";
-	pixel_x = -27;
-	pixel_y = 0;
-	req_access_txt = "0"
-	},
-/turf/simulated/floor/grass,
-/area/hallway/primary/central/ne)
-"rg" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/hallway/primary/central/ne)
-"rh" = (
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
-/area/hallway/primary/central/ne)
 "ri" = (
 /turf/space,
 /area/shuttle/gamma/station)
 "rj" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/sunnybush,
+/obj/machinery/vending/wallmed{
+	dir = 2;
+	name = "Emergency NanoMed";
+	pixel_x = 27;
+	pixel_y = 0;
+	req_access_txt = "0"
+	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "rk" = (
@@ -9243,14 +9385,6 @@
 	dir = 10
 	},
 /area/engine/chiefs_office)
-"rx" = (
-/obj/machinery/porta_turret,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
 "ry" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Warden's Office";
@@ -9315,7 +9449,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 1";
-	name = "Cell 5";
+	name = "Cell 2";
 	req_access_txt = "2"
 	},
 /obj/machinery/door_timer/cell_2{
@@ -9402,27 +9536,6 @@
 	icon_state = "dark"
 	},
 /area/engine/equipmentstorage)
-"rH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4;
-	level = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/hallway/primary/central/ne)
 "rI" = (
 /obj/machinery/computer/security{
 	network = list("SS13","Research Outpost","Mining Outpost")
@@ -9464,12 +9577,6 @@
 	initialize_directions = 11;
 	level = 1
 	},
-/obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = 32
-	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "rL" = (
@@ -9494,6 +9601,13 @@
 	icon_state = "yellow"
 	},
 /area/engine/equipmentstorage)
+"rM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/lootdrop/animals4maint,
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "rN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9571,7 +9685,7 @@
 	},
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "rS" = (
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
@@ -9626,6 +9740,11 @@
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/machinery/camera{
+	c_tag = "Brig Detective's Office";
+	dir = 1;
+	network = list("SS13")
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -9675,6 +9794,14 @@
 	icon_state = "dark"
 	},
 /area/security/warden)
+"rZ" = (
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/turf/simulated/floor/grass,
+/area/hallway/primary/central/ne)
 "sd" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -9686,7 +9813,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "sf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4;
@@ -9723,10 +9850,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "sj" = (
@@ -9747,6 +9878,9 @@
 	on = 1;
 	scrub_N2O = 1;
 	scrub_Toxins = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/bluegrid,
 /area/server)
@@ -9775,10 +9909,14 @@
 	icon_state = "1-2";
 	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
 	tag = "icon-whitebluefull"
@@ -9805,13 +9943,6 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber{
-	dir = 4;
-	name = "standard air scrubber";
-	on = 1;
-	scrub_N2O = 1;
-	scrub_Toxins = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/janitor)
 "sr" = (
@@ -9824,6 +9955,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/janitor)
+"ss" = (
+/obj/structure/closet/secure_closet/CMO,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer Requests Console";
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkblue"
+	},
+/area/medical/cmo)
 "st" = (
 /obj/effect/landmark{
 	name = "JoinLateCryo"
@@ -9836,6 +9982,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
+/obj/item/radio/beacon,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitegreenfull";
 	tag = "icon-whitebluefull"
@@ -9865,7 +10012,7 @@
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "sx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9879,6 +10026,7 @@
 	scrub_N2O = 1;
 	scrub_Toxins = 1
 	},
+/mob/living/simple_animal/pet/sloth/paperwork,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
 "sy" = (
@@ -9916,7 +10064,9 @@
 	dir = 4;
 	level = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/security/armoury)
 "sC" = (
 /obj/structure/cable{
@@ -9938,6 +10088,11 @@
 	icon_state = "dark"
 	},
 /area/security/armoury)
+"sG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/solar/auxstarboard)
 "sH" = (
 /obj/machinery/light{
 	icon_state = "tube1";
@@ -9957,11 +10112,17 @@
 	level = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "station intercom (General)";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 8
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "sJ" = (
 /obj/machinery/computer/brigcells,
 /obj/machinery/atmospherics/unary/vent_scrubber{
@@ -9984,13 +10145,16 @@
 	dir = 5
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
 	tag = ""
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "sL" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/light{
@@ -10040,7 +10204,6 @@
 	req_access_txt = "10";
 	req_one_access_txt = null
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
@@ -10048,17 +10211,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/engine/engineering)
+/area/engine/controlroom)
 "sQ" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;
 	level = 1
@@ -10066,12 +10230,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
 	level = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "sR" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -10107,6 +10280,9 @@
 /area/security/armoury)
 "sT" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/landmark/start{
+	name = "Life Support Specialist"
+	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
 "sU" = (
@@ -10269,16 +10445,14 @@
 	icon_state = "white"
 	},
 /area/assembly/robotics)
-"th" = (
+"ti" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid,
-/area/turret_protected/ai)
-"ti" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4;
-	level = 1
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /turf/simulated/floor/bluegrid,
 /area/turret_protected/ai)
@@ -10312,6 +10486,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
 /turf/simulated/floor/plasteel,
 /area/hallway/primary/central/ne)
 "tm" = (
@@ -10348,28 +10528,19 @@
 	},
 /area/security/warden)
 "ts" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow";
 	dir = 10
 	},
-/area/engine/break_room)
+/area/engine/engineering)
 "tv" = (
 /obj/structure/chair{
 	dir = 4
@@ -10434,15 +10605,16 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
+"us" = (
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "uE" = (
 /obj/structure/flora/ausbushes/genericbush,
-/obj/machinery/vending/wallmed{
-	dir = 2;
-	name = "Emergency NanoMed";
-	pixel_x = 27;
-	pixel_y = 0;
-	req_access_txt = "0"
-	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/central/ne)
 "uN" = (
@@ -10450,6 +10622,26 @@
 /obj/machinery/door/airlock/welded,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"uO" = (
+/obj/machinery/power/solar{
+	id = "auxsolareast";
+	name = "Port Auxiliary Solar Array"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
+/area/solar/auxstarboard)
+"uU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 2;
+	icon_state = "cafeteria";
+	tag = "icon-cafeteria (NORTHEAST)"
+	},
+/area/crew_quarters/kitchen)
 "vh" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -10515,10 +10707,48 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
+"wh" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/solar/auxstarboard)
 "wn" = (
 /obj/structure/sign/biohazard,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/tsf)
+"wD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
+"wN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/space,
+/area/solar/auxstarboard)
 "wU" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -10532,6 +10762,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"xc" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "xj" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
@@ -10540,6 +10774,32 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"xk" = (
+/obj/machinery/vending/walldrobe/cmo{
+	pixel_y = 28
+	},
+/obj/machinery/computer/card/minor/cmo,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkblue"
+	},
+/area/medical/cmo)
+"xm" = (
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 1;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/machinery/status_display{
+	density = 0;
+	layer = 4;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "xC" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -10588,6 +10848,19 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/chapel/main)
+"xT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4";
+	tag = "90Curve"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral2)
 "xV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10608,6 +10881,48 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"yp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
+"yu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "station intercom (General)";
+	pixel_x = -28
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
+"yz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "yC" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -10634,6 +10949,33 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"zS" = (
+/obj/structure/chair/e_chair{
+	dir = 2
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/item/assembly/signaler{
+	code = 6;
+	frequency = 1445
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24;
+	shock_proof = 0
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "Al" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -10667,6 +11009,17 @@
 	dir = 1
 	},
 /area/engine/gravitygenerator)
+"AM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "AO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10739,6 +11092,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"Ch" = (
+/obj/machinery/door/airlock/engineering{
+	icon_state = "door_closed";
+	locked = 0;
+	name = "Fore Starboard Solar Access";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "Cz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -10758,9 +11123,35 @@
 /obj/structure/sink/kitchen,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/tsf)
+"CH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/space,
+/area/solar/auxstarboard)
 "CK" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"CM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "CW" = (
 /turf/simulated/wall/r_wall,
 /area/hydroponics)
@@ -10895,6 +11286,35 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Fi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	level = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
+"Fu" = (
+/obj/machinery/power/solar{
+	id = "auxsolareast";
+	name = "Port Auxiliary Solar Array"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "solarpanel"
+	},
+/area/solar/auxstarboard)
 "FI" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/item/clothing/head/soft/solgov,
@@ -10924,13 +11344,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/quartermaster/miningdock)
-"Go" = (
-/turf/space,
-/area/quartermaster/qm)
 "Gu" = (
 /obj/structure/spawner/headcrab_old,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Gy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "GA" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
@@ -10947,6 +11373,35 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"HD" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
+"HH" = (
+/obj/machinery/power/solar_control,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
+"HK" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/grass,
+/area/hallway/primary/central/ne)
 "HL" = (
 /obj/machinery/vending/dinnerware,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -10984,13 +11439,13 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
 "Ia" = (
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	id = "aftportsolar";
+	name = "Aft Port Solar Array"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "solarpanel"
@@ -10998,6 +11453,12 @@
 /area/solar/port)
 "In" = (
 /obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "station intercom (General)";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -11034,6 +11495,19 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"IS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	dir = 0;
+	name = "station intercom (General)";
+	pixel_x = 28
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "IV" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human{
@@ -11056,6 +11530,35 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Kh" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/space,
+/area/solar/auxstarboard)
+"Kr" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral2)
 "Ky" = (
 /obj/structure/sign/directions/security,
 /obj/structure/sign/directions/evac{
@@ -11089,11 +11592,33 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
+"Lg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0;
+	tag = ""
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Execution";
+	req_access_txt = "3"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/security/execution)
 "Lv" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spawner/headcrab_old,
@@ -11134,6 +11659,27 @@
 /obj/machinery/optable,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Mp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "My" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -11145,6 +11691,21 @@
 	},
 /turf/space,
 /area/space)
+"MD" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral2)
 "MQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -11198,6 +11759,30 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"Nm" = (
+/obj/machinery/door/airlock/command{
+	name = "Gateway Access";
+	req_access_txt = "62"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4;
+	level = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "Nx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11226,6 +11811,14 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
+"NY" = (
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel,
+/area/hallway/primary/central/ne)
 "Oj" = (
 /turf/simulated/wall/r_wall,
 /area/toxins/lab)
@@ -11262,6 +11855,11 @@
 "OB" = (
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
+"OZ" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral2)
 "Pb" = (
 /obj/machinery/computer/pandemic,
 /turf/simulated/floor/plasteel{
@@ -11289,6 +11887,17 @@
 /obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel,
 /area/quartermaster/office)
+"Pz" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/blue{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/crew_quarters/bar)
 "PB" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -11314,6 +11923,16 @@
 	dir = 6
 	},
 /area/medical/virology)
+"PK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "PQ" = (
 /obj/structure/sign/directions/engineering,
 /turf/simulated/wall/mineral/plastitanium,
@@ -11331,6 +11950,16 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"QB" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/hydroponics)
+"QG" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "QH" = (
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
@@ -11360,7 +11989,18 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Ri" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/stamp/hop,
+/obj/item/eftpos,
+/obj/item/book/manual/sop_service,
+/obj/item/book/manual/sop_supply,
+/obj/item/book/manual/sop_command,
+/turf/simulated/floor/plasteel,
+/area/space)
 "Rk" = (
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	dir = 2;
 	icon_state = "ramptop";
@@ -11407,13 +12047,30 @@
 	icon_state = "barber"
 	},
 /area/medical/medbay2)
+"St" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/radio{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/radio{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "Su" = (
 /obj/machinery/computer/monitor{
 	name = "Grid Power Monitoring Computer"
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plasteel,
-/area/engine/engineering)
+/area/engine/controlroom)
 "Sx" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -11426,6 +12083,10 @@
 	},
 /turf/space,
 /area/space)
+"Sy" = (
+/obj/effect/spawner/window/reinforced,
+/turf/simulated/floor/plating,
+/area/security/execution)
 "SD" = (
 /obj/structure/showcase/horrific_experiment,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -11505,6 +12166,16 @@
 /obj/item/mounted/mirror,
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/tsf)
+"Ud" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "Um" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -11536,12 +12207,19 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"UO" = (
+/obj/machinery/smartfridge,
+/turf/simulated/floor/plasteel,
+/area/crew_quarters/kitchen)
 "Va" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/camera{
 	c_tag = "Atmospherics North-West";
 	dir = 2;
 	network = list("SS13")
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/plasteel,
 /area/atmos)
@@ -11578,6 +12256,26 @@
 /obj/effect/spawner/window/reinforced,
 /turf/simulated/floor/plating,
 /area/chapel/main)
+"VW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4;
+	level = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "VZ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/fans/tiny,
@@ -11605,6 +12303,27 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Wh" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber{
+	dir = 8;
+	name = "standard air scrubber";
+	on = 1;
+	scrub_N2O = 1;
+	scrub_Toxins = 1
+	},
+/obj/item/radio/intercom{
+	frequency = 1459;
+	name = "station intercom (General)";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/gateway)
 "WA" = (
 /obj/effect/decal/warning_stripes/south,
 /obj/machinery/driver_button{
@@ -11623,6 +12342,16 @@
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
 /area/shuttle/tsf)
+"WS" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	tag = ""
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/maintcentral)
 "WX" = (
 /obj/structure/shuttle/engine/propulsion{
 	tag = "icon-propulsion (NORTH)";
@@ -11638,6 +12367,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Xi" = (
+/obj/machinery/status_display/supply_display,
+/turf/simulated/wall,
+/area/quartermaster/office)
 "XS" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -11660,6 +12393,12 @@
 	},
 /obj/item/reagent_containers/food/drinks/flask/barflask,
 /obj/item/reagent_containers/food/drinks/flask/barflask,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "station intercom (General)";
+	pixel_x = 28;
+	pixel_y = 0
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -11684,6 +12423,12 @@
 /obj/effect/mob_spawn/human/sol_gov_dead_default,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Ys" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/auxsolarstarboard)
 "Yt" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/fans/tiny,
@@ -11698,6 +12443,10 @@
 /obj/machinery/suit_storage_unit/engine,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
+"Yz" = (
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/solar/auxstarboard)
 "YQ" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -11726,12 +12475,26 @@
 	icon_state = "blue"
 	},
 /area/hallway/primary/central/ne)
+"Ze" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "green";
+	dir = 4
+	},
+/area/hydroponics)
 "Zo" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
 /area/medical/chemistry)
+"Zz" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/space,
+/area/solar/auxstarboard)
 "ZG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/mech_bay_recharge_port,
@@ -41714,7 +42477,7 @@ cb
 me
 aa
 aa
-aa
+ac
 mF
 NC
 if
@@ -42522,7 +43285,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 aa
 aa
 aa
@@ -44050,7 +44813,7 @@ pH
 xC
 pV
 pV
-Go
+aa
 aa
 aa
 aa
@@ -44307,7 +45070,7 @@ pW
 qi
 KM
 pV
-Go
+aa
 aa
 aa
 aa
@@ -44564,7 +45327,7 @@ ek
 fu
 sL
 pV
-Go
+aa
 aa
 aa
 aa
@@ -44814,14 +45577,14 @@ aE
 dA
 eS
 dA
-ek
+Xi
 pq
 Pw
 pH
 pV
 pV
 pV
-Go
+aa
 aa
 aa
 aa
@@ -45045,9 +45808,9 @@ aa
 aa
 aa
 aa
-aa
 at
-fV
+jR
+ss
 cJ
 gP
 jR
@@ -45081,7 +45844,7 @@ pI
 qA
 qA
 qA
-jI
+gs
 Ia
 Ia
 Ia
@@ -45301,10 +46064,10 @@ aa
 ac
 aa
 aa
-aa
 at
 aa
 jR
+xk
 gr
 fD
 fV
@@ -45338,7 +46101,7 @@ hj
 rR
 gy
 sd
-jI
+gs
 aa
 aa
 aa
@@ -45570,8 +46333,8 @@ hp
 fZ
 mp
 mw
-nP
-aP
+kX
+HK
 mZ
 ep
 qB
@@ -45581,13 +46344,13 @@ sk
 ok
 nT
 jT
+WS
 jT
 jT
 jT
 jT
-jT
-rC
-id
+Dp
+kj
 pI
 em
 ql
@@ -45595,7 +46358,7 @@ hj
 gn
 gz
 kq
-jI
+gs
 kC
 kC
 kC
@@ -45838,13 +46601,13 @@ cs
 bT
 nT
 oB
-oI
-oI
-oI
+PK
+us
+jT
 fX
 gf
-rC
-jc
+Fi
+lc
 pI
 fB
 qm
@@ -45852,7 +46615,7 @@ hj
 gq
 sK
 Su
-jI
+gs
 kD
 kJ
 kJ
@@ -46082,7 +46845,7 @@ fg
 fh
 fm
 aC
-aa
+Ri
 jT
 TQ
 ed
@@ -46094,9 +46857,9 @@ nT
 nR
 on
 nT
-oC
-bp
-bx
+oI
+oI
+oI
 oI
 oI
 jT
@@ -46108,8 +46871,8 @@ qn
 hj
 gs
 sP
-jI
-jI
+gs
+gs
 Ia
 Ia
 Ia
@@ -46366,9 +47129,9 @@ sv
 gu
 sQ
 qT
-kx
-kx
-kx
+jI
+jI
+jI
 aa
 aa
 kV
@@ -46591,12 +47354,12 @@ bO
 cr
 eV
 fd
-gh
+hQ
 hQ
 fj
 iZ
 gh
-hQ
+yu
 cr
 lC
 is
@@ -46847,9 +47610,9 @@ aA
 iV
 eL
 jV
-jV
 gk
-jV
+IS
+AM
 fk
 jV
 gk
@@ -47104,9 +47867,9 @@ ax
 az
 eM
 jW
-jW
-gt
-jT
+Nm
+iU
+CM
 fl
 fl
 fr
@@ -47122,13 +47885,13 @@ nV
 sl
 oE
 nV
-dh
-th
-rx
+oI
+oI
+oI
 oI
 oI
 jT
-nP
+Mp
 jc
 pL
 fE
@@ -47362,8 +48125,8 @@ ad
 aU
 dj
 ej
-gw
 iU
+Ys
 fl
 fp
 fs
@@ -47379,14 +48142,14 @@ nV
 cv
 bW
 nV
-oB
-oI
-oI
-oI
+MD
+xT
+OZ
+jT
 ge
 gg
-nP
-id
+rK
+sg
 pL
 fF
 rA
@@ -47616,18 +48379,18 @@ ad
 ad
 ad
 ad
-iU
 jZ
-lh
+St
 gG
 iU
+yp
 fl
 fl
 fl
 fl
 fl
 Aw
-iq
+rZ
 na
 bE
 jf
@@ -47637,13 +48400,13 @@ cw
 rS
 nV
 jT
+Kr
 jT
 jT
 jT
 jT
-jT
-nP
-id
+kX
+kj
 pL
 fG
 rF
@@ -47870,14 +48633,14 @@ aa
 aa
 aa
 aa
-aa
 iU
 jd
 jA
 kb
 li
-gO
+VW
 iU
+wD
 CW
 eF
 fb
@@ -48127,7 +48890,6 @@ aa
 aa
 aa
 aa
-aa
 iU
 jh
 jC
@@ -48135,6 +48897,7 @@ kc
 lj
 hJ
 iU
+Ys
 CW
 jk
 jz
@@ -48384,14 +49147,14 @@ aa
 aa
 aa
 aa
-aa
 iU
 ji
 jE
 ke
 lk
-hM
+Wh
 iU
+rM
 CW
 aK
 jX
@@ -48641,7 +49404,6 @@ aa
 aa
 aa
 aa
-aa
 iU
 iU
 iU
@@ -48649,14 +49411,15 @@ jZ
 iU
 iU
 iU
+Ch
 CW
 aL
 kf
-aI
+QB
 aT
 mK
-aW
-aW
+be
+be
 aW
 aW
 Dp
@@ -48896,21 +49659,21 @@ aa
 aa
 aa
 aa
+Fu
+wN
+uO
 aa
-ac
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+wN
+uO
+QG
+hs
+Gy
 aG
 aM
 kg
-aQ
-aV
+aS
+aT
 mL
 nu
 nF
@@ -49153,26 +49916,26 @@ aa
 aa
 aa
 aa
+Fu
+CH
+uO
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+CH
+uO
+QG
+HD
+xc
 aG
-aN
-es
-aS
-aW
-mM
+aI
+lb
+Ze
+UO
 bb
+uU
 bb
 iA
-aW
+be
 DR
 jc
 oc
@@ -49410,28 +50173,28 @@ aa
 aa
 aa
 aa
-ac
+Fu
+CH
+uO
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+CH
+uO
+QG
+HH
+kw
 aG
-aG
-aG
-aG
+aN
+es
+aS
 aW
 go
 bj
 nN
 bZ
-aW
-rH
-id
+be
+rC
+NY
 oc
 jv
 jw
@@ -49667,28 +50430,28 @@ aa
 aa
 aa
 aa
+Fu
+CH
+uO
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+CH
+uO
+QG
+QG
+Ud
+aG
+aG
+aG
+aG
 mD
 gx
 bb
 bb
 bI
-aW
+be
 rK
-sg
+xm
 oc
 jw
 ju
@@ -49923,17 +50686,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+wh
+sG
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Zz
 aa
 aa
 aa
@@ -49944,7 +50707,7 @@ bk
 bb
 er
 aW
-rC
+yz
 id
 oc
 jx
@@ -50179,15 +50942,15 @@ aa
 aa
 aa
 aa
-ac
 aa
 aa
+Fu
+Kh
+uO
 aa
-ac
-aa
-aa
-aa
-aa
+Fu
+Kh
+uO
 aa
 aa
 VV
@@ -50209,7 +50972,7 @@ oc
 oc
 oc
 oT
-pb
+oT
 oZ
 ex
 ex
@@ -50438,13 +51201,13 @@ aa
 aa
 aa
 aa
+Fu
+Kh
+uO
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+Kh
+uO
 aa
 aa
 VV
@@ -50465,8 +51228,8 @@ sq
 cS
 eA
 oO
-aa
-pb
+zS
+Lg
 pa
 pi
 pb
@@ -50482,7 +51245,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 aa
 aa
 aa
@@ -50695,13 +51458,13 @@ aa
 aa
 aa
 aa
+Fu
+Kh
+uO
 aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fu
+Kh
+uO
 aa
 ac
 VV
@@ -50722,8 +51485,8 @@ si
 sr
 sU
 oO
-aa
-pb
+Sy
+Sy
 pd
 pn
 pb
@@ -50952,13 +51715,13 @@ aa
 aa
 aa
 aa
+Fu
+jJ
+uO
 aa
-ac
-aa
-aa
-aa
-aa
-aa
+Fu
+jJ
+uO
 aa
 aa
 VV
@@ -51210,7 +51973,7 @@ aa
 aa
 aa
 aa
-aa
+ac
 aa
 aa
 aa
@@ -51227,7 +51990,7 @@ mE
 vA
 bH
 bt
-bt
+Pz
 bV
 nP
 jc


### PR DESCRIPTION
## What Does This PR Do
-Agrega un solar norte, con maintenance
-Agrega varios Keycard Authenticators y Walldrobes a las oficinas de los heads
-Agrega una silla electrica
-Mejora el cableado lesgooo
-Sala de IA más chiquita para los maint de al lado. Ahora hay un Turret Control Switch en el Messaging Server Room
-Varios intercom y paper bins esparcidos por la estación
-Agrega el boton de los shutters de la Gate y tapa una brecha de ahí
-Agrega DNA Manipulator para Hydro y el Grill para la cocina
-Agrega una compu de genética en clonación
-2 tiles más para los CMO que padecen de claustrofobia
-Un P.A.C.M.A.N. en inge

## Why It's Good For The Game
-Faltaba algo más interesante en el norte de la estación
-Para poder subir la alerta
-Silla para freir a los nuevos lesgooo
-El resto se explica solo

## Images of changes
![image](https://user-images.githubusercontent.com/52227547/121483758-8ba72400-c99c-11eb-8f74-186563e0b683.png)
![image](https://user-images.githubusercontent.com/52227547/121483798-96fa4f80-c99c-11eb-9746-573155ad449f.png)
![image](https://user-images.githubusercontent.com/52227547/121483878-ab3e4c80-c99c-11eb-8c90-a14e3d61fbf1.png)
![image](https://user-images.githubusercontent.com/52227547/121484032-d88afa80-c99c-11eb-876c-7783bfc29992.png)
![image](https://user-images.githubusercontent.com/52227547/121484645-6c5cc680-c99d-11eb-8ac2-0c0cc4d8691e.png)

## Changelog
:cl: DanaDririon
tweak: Dababy maint
/:cl: