### PR TITLE
Tweak Quirks a la DB

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -195,7 +195,8 @@
 					socks,
 					body_accessory,
 					gear,
-					autohiss
+					autohiss,
+					quirks
 				 	FROM [format_table_name("characters")] WHERE ckey=:ckey AND slot=:slot"}, list(
 						 "ckey" = C.ckey,
 						 "slot" = slot
@@ -275,6 +276,7 @@
 		body_accessory = query.item[50]
 		loadout_gear = params2list(query.item[51])
 		autohiss_mode = text2num(query.item[52])
+		all_quirks = params2list(query.item[53])
 
 		saved = TRUE
 
@@ -336,6 +338,7 @@
 	if(!organ_data) src.organ_data = list()
 	if(!rlimb_data) src.rlimb_data = list()
 	if(!loadout_gear) loadout_gear = list()
+	if(!all_quirks) all_quirks = list()
 
 	// Check if the current body accessory exists
 	if(!GLOB.body_accessory_by_name[body_accessory])
@@ -348,6 +351,7 @@
 	var/rlimblist
 	var/playertitlelist
 	var/gearlist
+	var/quirklist
 
 	var/markingcolourslist = list2params(m_colours)
 	var/markingstyleslist = list2params(m_styles)
@@ -359,6 +363,8 @@
 		playertitlelist = list2params(player_alt_titles)
 	if(!isemptylist(loadout_gear))
 		gearlist = list2params(loadout_gear)
+	if(!isemptylist(all_quirks))
+		quirklist = list2params(all_quirks)
 
 	var/datum/db_query/firstquery = SSdbcore.NewQuery("SELECT slot FROM [format_table_name("characters")] WHERE ckey=:ckey ORDER BY slot", list(
 		"ckey" = C.ckey
@@ -421,7 +427,8 @@
 												socks=:socks,
 												body_accessory=:body_accessory,
 												gear=:gearlist,
-												autohiss=:autohiss_mode
+												autohiss=:autohiss_mode,
+												quirks=:quirklist
 												WHERE ckey=:ckey
 												AND slot=:slot"}, list(
 													// OH GOD SO MANY PARAMETERS
@@ -477,6 +484,7 @@
 													"body_accessory" = (body_accessory ? body_accessory : ""),
 													"gearlist" = (gearlist ? gearlist : ""),
 													"autohiss_mode" = autohiss_mode,
+													"quirklist" = (quirklist ? quirklist : ""),
 													"ckey" = C.ckey,
 													"slot" = default_slot
 												)
@@ -518,7 +526,7 @@
 											gen_record,
 											player_alt_titles,
 											disabilities, organ_data, rlimb_data, nanotrasen_relation, speciesprefs,
-											socks, body_accessory, gear, autohiss)
+											socks, body_accessory, gear, autohiss, quirks)
 
 					VALUES
 											(:ckey, :slot, :metadata, :name, :be_random_name, :gender,
@@ -546,7 +554,7 @@
 											:gen_record,
 											:playertitlelist,
 											:disabilities, :organlist, :rlimblist, :nanotrasen_relation, :speciesprefs,
-											:socks, :body_accessory, :gearlist, :autohiss_mode)
+											:socks, :body_accessory, :gearlist, :autohiss_mode, :quirklist)
 
 	"}, list(
 		// This has too many params for anyone to look at this without going insae
@@ -603,7 +611,8 @@
 		"socks" = socks,
 		"body_accessory" = (body_accessory ? body_accessory : ""),
 		"gearlist" = (gearlist ? gearlist : ""),
-		"autohiss_mode" = autohiss_mode
+		"autohiss_mode" = autohiss_mode,
+		"quirklist" = (quirklist ? quirklist : "")
 	))
 
 	if(!query.warn_execute())


### PR DESCRIPTION
## What Does This PR Do
Ahora con estos los quirks se guardan en la fila 53 de la tabla characters, la fila debe llamarse quirks y tiene que ser un longtext.

## Why It's Good For The Game
Ayuda a poder guardar tus quirks y no tener que configurarlos cada que reinicia partida.

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/121606281-77523e00-ca13-11eb-8c70-7bb8acfb3d1e.png)
![image](https://user-images.githubusercontent.com/46639834/121606316-876a1d80-ca13-11eb-81c8-7787e044e6d1.png)


## Changelog
:cl:
Tweak: Quirks a la DB
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
