### PR TITLE
Tweak Hand Held Body Scanner

### DIFF
--- a/code/hispania/modules/research/designs/medical_designs.dm
+++ b/code/hispania/modules/research/designs/medical_designs.dm
@@ -47,3 +47,13 @@
 	materials = list(MAT_METAL=6000, MAT_GLASS=800, MAT_TITANIUM = 850)
 	build_path = /obj/item/reagent_containers/moa
 	category = list("Medical")
+
+/datum/design/moa
+	name = "Handheld Body Scanner"
+	desc = "A handheld scanner capable of deep-scanning an entire body."
+	id = "handbodyscanner"
+	req_tech = list("materials" = 7, "biotech" = 7, "engineering" = 7)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=6000, MAT_GLASS=800, MAT_TITANIUM = 850, MAT_DIAMOND = 250,  MAT_URANIUM = 1500)
+	build_path = /obj/item/bodyanalyzer
+	category = list("Medical")

--- a/code/hispania/modules/research/designs/medical_designs.dm
+++ b/code/hispania/modules/research/designs/medical_designs.dm
@@ -48,7 +48,7 @@
 	build_path = /obj/item/reagent_containers/moa
 	category = list("Medical")
 
-/datum/design/moa
+/datum/design/handheldbody
 	name = "Handheld Body Scanner"
 	desc = "A handheld scanner capable of deep-scanning an entire body."
 	id = "handbodyscanner"


### PR DESCRIPTION
## What Does This PR Do
Añade la posibilidad de imprimir un handheld body scanner cuando alcanzan los niveles de: Materials-7 / Bio-7 / Eng-7

## Why It's Good For The Game
Actualmente la herramienta no da una ventana considerable y es poco usada por su limitación para conseguirla. Esto da mas versatilidad al equipo de medbay una vez logre avanzar RnD.

## Changelog
:cl:
tweak: Handheld body scanner
/:cl:

