### PR TITLE
Fix Loadout Retro Suits

### DIFF
--- a/code/hispania/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/hispania/modules/client/preference/loadout/loadout_uniform.dm
@@ -4,7 +4,7 @@
 /datum/gear/uniform/retro/medical
 	display_name = "medical retro"
 	path = /obj/item/clothing/under/retro/medical
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Psychiatrist","Paramedic","Coroner")
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician" , "Coroner")
 
 /datum/gear/uniform/retro/sec
 	display_name = "security retro"
@@ -14,12 +14,12 @@
 /datum/gear/uniform/retro/engie
 	display_name = "engineer retro"
 	path = /obj/item/clothing/under/retro/engineering
-	allowed_roles = list("Chief Engineer","Station Engineer","Life Support Specialist")
+	allowed_roles = list("Chief Engineer","Station Engineer","Life Support Specialist", "Mechanic")
 
 /datum/gear/uniform/retro/sci
 	display_name = "scientist retro"
 	path = /obj/item/clothing/under/retro/science
-	allowed_roles = list("Research Director","Scientist")
+	allowed_roles = list("Research Director","Scientist", "Roboticist")
 
 /datum/gear/uniform/grean_heart_jump
 	display_name = "green heart jumpsuit"


### PR DESCRIPTION
## What Does This PR Do
Amplia el rango de cargos que pueden acceder a esta variante de sus jumpsuits la cual otorga igualmente las defensas bases de sus jumpsuits departamentales normales.

## Why It's Good For The Game
Evita instancias raras donde un virologo no era categorizado como medico.

## Changelog
:cl:
add: Retro Suits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
