### PR TITLE
Tweak Plasmacutter Damage

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -206,7 +206,7 @@
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
-	damage = 5
+	damage = 10
 	range = 3
 	dismemberment = 20
 	sharp = TRUE
@@ -222,11 +222,11 @@
 		forcedodge = 0
 
 /obj/item/projectile/plasma/adv
-	damage = 7
+	damage = 15
 	range = 5
 
 /obj/item/projectile/plasma/adv/mech
-	damage = 10
+	damage = 25
 	range = 9
 
 /obj/item/projectile/energy/teleport

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -224,10 +224,12 @@
 /obj/item/projectile/plasma/adv
 	damage = 15
 	range = 5
+	dismemberment = 24
 
 /obj/item/projectile/plasma/adv/mech
 	damage = 25
 	range = 9
+	dismemberment = 30
 
 /obj/item/projectile/energy/teleport
 	name = "teleportation burst"


### PR DESCRIPTION
## What Does This PR Do
Sube el daño que hacen los plasmacutter y aumenta su probabilidad de desmembramiento en base a su escala de mejoras.

## Why It's Good For The Game
Actualmente si bien parecen ser una herramienta de minería peligrosa al atacar a un mob resultan hacer menos daño que incluso el lanzar una toolbox. Cuenta con una posibilidad de dar desmembramiento que tampoco escalaba.

## Changelog
:cl:
tweak: Plasmacutter Damage
/:cl:

