### PR TITLE
Fix Autosurgeon TSF Discovery

### DIFF
--- a/_maps/map_files/Delta/delta_hispania.dmm
+++ b/_maps/map_files/Delta/delta_hispania.dmm
@@ -110446,7 +110446,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/autosurgeon,
+/obj/item/autosurgeon/organ,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
 "ifn" = (

--- a/_maps/map_files/MetaStation/MetaStation_hispania.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_hispania.dmm
@@ -79086,7 +79086,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/autosurgeon,
+/obj/item/autosurgeon/organ,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
 "doV" = (

--- a/_maps/map_files/hispania/hispania.dmm
+++ b/_maps/map_files/hispania/hispania.dmm
@@ -82532,7 +82532,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/autosurgeon,
+/obj/item/autosurgeon/organ,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/tsf)
 "dvn" = (


### PR DESCRIPTION
## What Does This PR Do
Un error de tipo de objeto lo hacia aparecer en cierta version padre incapaz de ser usada.

## Why It's Good For The Game
No se por que esta codeado asi pero con estos cambios ya podran usarlo como era esperado.

## Changelog
:cl:
fix: TSF Discovery Autosurgeon
/:cl:
