### PR TITLE
Port CIV 13 Fullscreen

### DIFF
--- a/code/hispania/controllers/fullscreen.dm
+++ b/code/hispania/controllers/fullscreen.dm
@@ -1,0 +1,20 @@
+/client/New()
+	..()
+	winset(src, "mainwindow", "can-resize=true;titlebar=true;menu=menu")
+	winset(src, "mainwindow.mainvsplit", "splitter=75")
+
+/client/verb/updatefullscreen()
+	set name = "updateFullscreen"
+	set category = "Preferences"
+	set desc = "Toggle Fullscreen"
+	if (!fullscreen)
+		winset(src, "mainwindow", "is-maximized=false;can-resize=false;titlebar=false;menu=")
+		winset(src, "mainwindow.mainvsplit", "splitter=78")
+		winset(src, "mainwindow", "is-maximized=true")
+		fullscreen = TRUE
+		return
+	else
+		winset(src, "mainwindow", "can-resize=true;titlebar=true;menu=menu")
+		winset(src, "mainwindow.mainvsplit", "splitter=75")
+		fullscreen = FALSE
+		return

--- a/code/hispania/controllers/fullscreen.dm
+++ b/code/hispania/controllers/fullscreen.dm
@@ -4,7 +4,7 @@
 	winset(src, "mainwindow.mainvsplit", "splitter=75")
 
 /client/verb/updatefullscreen()
-	set name = "updateFullscreen"
+	set name = "Fullscreen"
 	set category = "Preferences"
 	set desc = "Toggle Fullscreen"
 	if (!fullscreen)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -118,6 +118,8 @@
 	var/datum/click_handler/CH
 	///////////////////////////
 	var/list/recent_examines // HISPANIA EYE CONTACT
+	var/fullscreen = FALSE // HISPANIA FULLSCREEN
+
 
 /client/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1141,6 +1141,7 @@
 #include "code\hispania\__HELPERS\cmp.dm"
 #include "code\hispania\__HELPERS\names.dm"
 #include "code\hispania\__HELPERS\unsorted.dm"
+#include "code\hispania\controllers\fullscreen.dm"
 #include "code\hispania\controllers\subsystem\processing\quirks.dm"
 #include "code\hispania\datums\autofiresystem.dm"
 #include "code\hispania\datums\discord.dm"


### PR DESCRIPTION
## What Does This PR Do
Portea el modo de Fullscreen de CIV 13 lo cual oculta la barra de tareas.

## Why It's Good For The Game
Proporciona mas espacio para los jugadores, tengo aun varias pruebas respecto a otras UIs con las cuales probarlo pero me serviría si lo prueban igual. 

## Images of changes
![image](https://user-images.githubusercontent.com/46639834/125614184-b8e752bd-2d7b-40a0-8607-0382181d1f82.png)


## Changelog
:cl:
add: Fullscreen CIV13
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
