### PR TITLE
Cambia la dirección http en el manual de la ley espacial a https porq…

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -806,7 +806,7 @@
 		</head>
 
 		<body>
-		<iframe width='100%' height='97%' src="http://hispaniastation.net/ley/menu.html" frameborder="0" id="main_frame"></iframe>		</body>
+		<iframe width='100%' height='97%' src="https://hispaniastation.net/ley/menu.html" frameborder="0" id="main_frame"></iframe>		</body>
 
 		</html>
 


### PR DESCRIPTION
## What Does This PR Do
Cambia http a https en el link del libro de la ley espacial

## Why It's Good For The Game
Porque si no la ley espacial ingame no se puede leer

## Images of changes
No

## Changelog
:cl:
fix: Link de la ley espacial ingame apunta a https
/:cl:


