### PR TITLE
Cambia http a https en el manual de la ley

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -806,7 +806,7 @@
 		</head>
 
 		<body>
-		<iframe width='100%' height='97%' src="http://hispaniastation.net/ley/menu.html" frameborder="0" id="main_frame"></iframe>		</body>
+		<iframe width='100%' height='97%' src="https://hispaniastation.net/ley/menu.html" frameborder="0" id="main_frame"></iframe>		</body>
 
 		</html>
 


### PR DESCRIPTION
## What Does This PR Do
Canmbia HTTP a HTTPS en el link al manual de la ley espacial

## Why It's Good For The Game
Porque ya se puede ver la ley ingame

## Images of changes

## Changelog
:cl:
fix: Cambia HTTP a https en el manual de la ley espacial
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
