### PR TITLE
Bloquea especies no deseadas

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -145,10 +145,10 @@
 
 /mob/living/carbon/human/golem/Initialize(mapload)
 	. = ..(mapload, /datum/species/golem)
-
+/*
 /mob/living/carbon/human/wryn/Initialize(mapload)
 	. = ..(mapload, /datum/species/wryn)
-/*
+
 /mob/living/carbon/human/nucleation/Initialize(mapload)
 	. = ..(mapload, /datum/species/nucleation)
 */

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -93,10 +93,10 @@
 
 /mob/living/carbon/human/vox/Initialize(mapload)
 	. = ..(mapload, /datum/species/vox)
-
+/*
 /mob/living/carbon/human/voxarmalis/Initialize(mapload)
 	. = ..(mapload, /datum/species/vox/armalis)
-
+*/
 /mob/living/carbon/human/skeleton/Initialize(mapload)
 	. = ..(mapload, /datum/species/skeleton)
 
@@ -148,10 +148,10 @@
 
 /mob/living/carbon/human/wryn/Initialize(mapload)
 	. = ..(mapload, /datum/species/wryn)
-
+/*
 /mob/living/carbon/human/nucleation/Initialize(mapload)
 	. = ..(mapload, /datum/species/nucleation)
-
+*/
 /mob/living/carbon/human/drask/Initialize(mapload)
 	. = ..(mapload, /datum/species/drask)
 


### PR DESCRIPTION
## What Does This PR Do
Bloquea los Vox Armalis y Nucleation para que no sean razas jugables
Edit: Los Wryn también son bloqueados

## Why It's Good For The Game
Ya no mas players jugando con razas rotaS

## Changelog
:cl:
tweak: Vox Armalis, Wryn y Nucleations ya no son jugables
/:cl:

