### PR TITLE
Agrega chaqueta como loot raro en maint

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -135,6 +135,7 @@
 				/obj/item/stack/tape_roll = 10,
 				/obj/item/storage/bag/plasticbag = 20,
 				/obj/item/caution = 10,
+				/obj/item/fluff/kans_winter_coat_kit = 1,
 				////////////////CONTRABAND STUFF//////////////////
 				/obj/item/grenade/clown_grenade = 3,
 				/obj/item/seeds/ambrosia/cruciatus = 3,


### PR DESCRIPTION
La gente lo pidio. Bastantes votos positivos a la idea de Killer7luis. 
- Agrega la chaqueta como un loot raro, con igual de probabilidad de spawnear que una pistola

![image](https://user-images.githubusercontent.com/24284918/135701555-cd1fe876-a73e-4329-b2f2-aad06e2bfdcc.png)

## Changelog
:cl:
add: Chamqueta raro loot de maint
/:cl:

