### PR TITLE
wood cabinet construible con madera

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -199,7 +199,8 @@ GLOBAL_LIST_INIT(wood_recipes, list(
 	new /datum/stack_recipe("baseball bat", /obj/item/melee/baseball_bat, 5, time = 15),
 	new /datum/stack_recipe("loom", /obj/structure/loom, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new /datum/stack_recipe("fermenting barrel", /obj/structure/fermenting_barrel, 30, time = 50),
-	new /datum/stack_recipe("firebrand", /obj/item/match/firebrand, 2, time = 100)
+	new /datum/stack_recipe("firebrand", /obj/item/match/firebrand, 2, time = 100),
+	new /datum/stack_recipe("wood cabinet", /obj/structure/closet/cabinet, 10, time = 15)
 ))
 
 /obj/item/stack/sheet/wood


### PR DESCRIPTION
desconozco porque no era crafteable esta bonita pieza de carpinteria

requisitos: 10 de madera

![image](https://user-images.githubusercontent.com/24284918/136719399-258c0e51-5c7e-48dd-94a4-84bb869b0751.png)

:cl:
add:  ahora se puede construir el wood cabinet
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
