### PR TITLE
[Tweak] Goodbye F, Ahora la G sirve para dar objetos a las personas

### DIFF
--- a/code/hispania/modules/mob/living/carbon/give.dm
+++ b/code/hispania/modules/mob/living/carbon/give.dm
@@ -1,0 +1,72 @@
+/// Code by Danaleja2005
+
+/mob/proc/giveto(mob/user = usr)
+
+	var/list/validtargets = list()
+	var/mob/living/carbon/target
+
+	for(target in oview(1))
+		if(!iscarbon(target))
+			return
+		var/mob_name = target.name
+		validtargets[mob_name] = target
+
+	if(!length(validtargets))
+		to_chat(user, "<span class='warning'>There are no valid targets!</span>")
+		return
+
+	if(validtargets.len == 1)	
+		var/target_name = validtargets[1]
+		target = validtargets[target_name]
+	else
+		var/target_name = input("Choose the target to give to.", "Targeting") as null|anything in validtargets
+
+		if(!target_name || !(target = validtargets[target_name]))
+			return
+	
+		target = validtargets[target_name]
+
+	if(target.incapacitated() || usr.incapacitated() || target.client == null)
+		return
+
+	var/obj/item/I = get_active_hand()
+
+	if(!I)
+		to_chat(usr, "<span class='warning'> You don't have anything in your hand to give to [target.name]</span>")
+		return
+	if((I.flags & NODROP) || (I.flags & ABSTRACT))
+		to_chat(usr, "<span class='notice'>That's not exactly something you can give.</span>")
+		return
+	if(target.r_hand == null || target.l_hand == null)
+		var/ans = alert(target,"[usr] wants to give you \a [I]?",,"Yes","No")
+		if(!I || !target)
+			return
+		switch(ans)
+			if("Yes")
+				if(target.incapacitated() || usr.incapacitated())
+					return
+				if(!Adjacent(target))
+					to_chat(usr, "<span class='warning'> You need to stay in reaching distance while giving an object.</span>")
+					to_chat(target, "<span class='warning'> [usr.name] moved too far away.</span>")
+					return
+				if((I.flags & NODROP) || (I.flags & ABSTRACT))
+					to_chat(usr, "<span class='warning'>[I] stays stuck to your hand when you try to give it!</span>")
+					to_chat(target, "<span class='warning'>[I] stays stuck to [usr.name]'s hand when you try to take it!</span>")
+					return
+				if(I != get_active_hand())
+					to_chat(usr, "<span class='warning'> You need to keep the item in your active hand.</span>")
+					to_chat(target, "<span class='warning'> [usr.name] seem to have given up on giving [I] to you.</span>")
+					return
+				if(target.r_hand != null && target.l_hand != null)
+					to_chat(target, "<span class='warning'> Your hands are full.</span>")
+					to_chat(usr, "<span class='warning'> Their hands are full.</span>")
+					return
+				usr.unEquip(I)
+				target.put_in_hands(I)
+				I.add_fingerprint(target)
+				target.visible_message("<span class='notice'> [usr.name] handed [I] to [target.name].</span>")
+				I.on_give(usr, target)
+			if("No")
+				target.visible_message("<span class='warning'> [usr.name] tried to hand [I] to [target.name] but [target.name] didn't want it.</span>")
+	else
+		to_chat(usr, "<span class='warning'> [target.name]'s hands are full.</span>")

--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -45,10 +45,7 @@
 					stop_pulling()
 				return
 			if("Insert", "G")
-				a_intent_change(INTENT_HOTKEY_RIGHT)
-				return
-			if("F")
-				a_intent_change(INTENT_HOTKEY_LEFT)
+				giveto()
 				return
 			if("X", "Northeast") // Northeast is Page-up
 				swap_hand()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1357,6 +1357,7 @@
 #include "code\hispania\modules\mining\equipment\kinetic_crusher.dm"
 #include "code\hispania\modules\mob\language.dm"
 #include "code\hispania\modules\mob\living\status_procs.dm"
+#include "code\hispania\modules\mob\living\carbon\give.dm"
 #include "code\hispania\modules\mob\living\carbon\human\human.dm"
 #include "code\hispania\modules\mob\living\carbon\human\human_defense.dm"
 #include "code\hispania\modules\mob\living\carbon\human\species\monkey_combat.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Elimina la antigua función de la F y la G como cambiador del intent, ahora la G funciona para dar algun objeto a las personas, si hay mas de una persona adyacente a ti, te saldrá una lista para escoger a quien darle el objeto. Lo siento Kill :pensive: 

## Why It's Good For The Game
no mas tirar cosas en el suelo para darle cosas a la gente

## Images of changes

![image](https://user-images.githubusercontent.com/43283605/138383897-58a0a0f6-390e-411a-8893-74686100e8ed.png)


## Changelog
:cl:
del: Remueve la F como hotkey para cambiar el intent
tweak: La G ahora sirve para dar objetos a los demas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
