### PR TITLE
Modos de Juego por votacion siempre seran jugables

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -172,13 +172,14 @@ SUBSYSTEM_DEF(ticker)
 		mode = GLOB.configuration.gamemode.pick_mode(GLOB.master_mode)
 
 	if(!mode.can_start())
-		to_chat(world, "<B>Unable to start [mode.name].</B> Not enough players, [mode.required_players] players needed. Reverting to pre-game lobby.")
-		mode = null
-		current_state = GAME_STATE_PREGAME
-		force_start = FALSE
-		SSjobs.ResetOccupations()
-		Master.SetRunLevel(RUNLEVEL_LOBBY)
-		return FALSE
+		if(!mode.can_start_solo_readys() && GLOB.configuration.gamemode.enable_gamemode_player_limit)
+			to_chat(world, "<B>Unable to start [mode.name].</B> Not enough players, [mode.required_players] players needed. Reverting to pre-game lobby.")
+			mode = null
+			current_state = GAME_STATE_PREGAME
+			force_start = FALSE
+			SSjobs.ResetOccupations()
+			Master.SetRunLevel(RUNLEVEL_LOBBY)
+			return FALSE
 
 	//Configure mode and assign player to special mode stuff
 	mode.pre_pre_setup()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -61,6 +61,14 @@ GLOBAL_LIST_EMPTY(all_cults)
 	to_chat(world, "<B>The current game mode is - Cult!</B>")
 	to_chat(world, "<B>Some crewmembers are attempting to start a cult!<BR>\nCultists - complete your objectives. Convert crewmembers to your cause by using the offer rune. Remember - there is no you, there is only the cult.<BR>\nPersonnel - Do not let the cult succeed in its mission. Brainwashing them with holy water reverts them to whatever CentComm-allowed faith they had.</B>")
 
+/datum/game_mode/cult/can_start()
+	if(!..())
+		required_enemies = required_enemies / 2
+		if(GLOB.player_list.len <= 10) //un caso extremo que haya muy pocos conectados solo habra 2 cultistas (el minimo)
+			required_enemies = 2
+		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
+
+
 /datum/game_mode/cult/pre_setup()
 	if(GLOB.configuration.gamemode.prevent_mindshield_antags)
 		restricted_jobs += protected_jobs

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -61,14 +61,6 @@ GLOBAL_LIST_EMPTY(all_cults)
 	to_chat(world, "<B>The current game mode is - Cult!</B>")
 	to_chat(world, "<B>Some crewmembers are attempting to start a cult!<BR>\nCultists - complete your objectives. Convert crewmembers to your cause by using the offer rune. Remember - there is no you, there is only the cult.<BR>\nPersonnel - Do not let the cult succeed in its mission. Brainwashing them with holy water reverts them to whatever CentComm-allowed faith they had.</B>")
 
-/datum/game_mode/cult/can_start()
-	if(!..())
-		required_enemies = required_enemies / 2
-		if(GLOB.player_list.len <= 10) //un caso extremo que haya muy pocos conectados solo habra 2 cultistas (el minimo)
-			required_enemies = 2
-		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
-
-
 /datum/game_mode/cult/pre_setup()
 	if(GLOB.configuration.gamemode.prevent_mindshield_antags)
 		restricted_jobs += protected_jobs

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -57,7 +57,18 @@
 		if((player.client)&&(player.ready))
 			playerC++
 
-	if(!GLOB.configuration.gamemode.enable_gamemode_player_limit || (playerC >= required_players))
+	if(playerC >= required_players)
+		return 1
+	return 0
+
+///can_start_solo_readys()
+///Chequea si no pudo comenzar unicamente porque no hubo readys
+/datum/game_mode/proc/can_start_solo_readys()
+	var/playerC = 0
+	for(var/mob/new_player/player in GLOB.player_list)
+		if((player.client)&&(player.ready))
+			playerC++
+	if(playerC >= required_players)
 		return 1
 	return 0
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 
 /datum/game_mode/heist/can_start()
 
-	if(!..())
+	if(!..() && GLOB.master_mode == "secret")
 		return 0
 
 	var/list/candidates = get_players_for_role(ROLE_RAIDER)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -29,8 +29,7 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 /datum/game_mode/heist/can_start()
 
 	if(!..())
-		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
-//		return 0
+		return 0
 
 	var/list/candidates = get_players_for_role(ROLE_RAIDER)
 	var/raider_num = 0

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -29,7 +29,8 @@ GLOBAL_LIST_EMPTY(cortical_stacks) //Stacks for 'leave nobody behind' objective.
 /datum/game_mode/heist/can_start()
 
 	if(!..())
-		return 0
+		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
+//		return 0
 
 	var/list/candidates = get_players_for_role(ROLE_RAIDER)
 	var/raider_num = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -26,9 +26,13 @@
 	to_chat(world, "A nuclear explosive was being transported by Nanotrasen to a military base. The transport ship mysteriously lost contact with Space Traffic Control (STC). About that time a strange disk was discovered around [station_name()]. It was identified by Nanotrasen as a nuclear authentication disk and now Syndicate Operatives have arrived to retake the disk and detonate SS13! There are most likely Syndicate starships are in the vicinity, so take care not to lose the disk!\n<B>Syndicate</B>: Reclaim the disk and detonate the nuclear bomb anywhere on SS13.\n<B>Personnel</B>: Hold the disk and <B>escape with the disk</B> on the shuttle!")
 
 /datum/game_mode/nuclear/can_start()//This could be better, will likely have to recode it later
-	if(!..())
+	if(!..() && GLOB.master_mode == "secret")
 		return 0
-
+	if(!..())
+		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
+		required_enemies = required_enemies / 2  //si no hubo readys suficientes se divide por 2 la cantidad de antags redondeando
+		if(GLOB.player_list.len <= 10) //un caso extremo que haya muy pocos conectados solo habra 1 nuke
+			required_enemies = 1
 	var/list/possible_syndicates = get_players_for_role(ROLE_OPERATIVE)
 	var/agent_number = 0
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -27,10 +27,7 @@
 
 /datum/game_mode/nuclear/can_start()//This could be better, will likely have to recode it later
 	if(!..())
-		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
-		required_enemies = required_enemies / 2  //si no hubo readys suficientes se divide por 2 la cantidad de antags redondeando
-		if(GLOB.player_list.len <= 10) //un caso extremo que haya muy pocos conectados solo habra 1 nuke
-			required_enemies = 1
+		return 0
 
 	var/list/possible_syndicates = get_players_for_role(ROLE_OPERATIVE)
 	var/agent_number = 0

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -27,7 +27,10 @@
 
 /datum/game_mode/nuclear/can_start()//This could be better, will likely have to recode it later
 	if(!..())
-		return 0
+		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
+		required_enemies = required_enemies / 2  //si no hubo readys suficientes se divide por 2 la cantidad de antags redondeando
+		if(GLOB.player_list.len <= 10) //un caso extremo que haya muy pocos conectados solo habra 1 nuke
+			required_enemies = 1
 
 	var/list/possible_syndicates = get_players_for_role(ROLE_OPERATIVE)
 	var/agent_number = 0

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -18,7 +18,7 @@
 	to_chat(world, "<B>There is a <font color='red'>SPACE WIZARD</font> on the station. You can't let him achieve his objective!</B>")
 
 /datum/game_mode/wizard/can_start()//This could be better, will likely have to recode it later
-	if(!..())
+	if(!..() && GLOB.master_mode == "secret")
 		return 0
 	var/list/datum/mind/possible_wizards = get_players_for_role(ROLE_WIZARD)
 	if(possible_wizards.len==0)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -19,7 +19,8 @@
 
 /datum/game_mode/wizard/can_start()//This could be better, will likely have to recode it later
 	if(!..())
-		return 0
+		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
+//		return 0
 	var/list/datum/mind/possible_wizards = get_players_for_role(ROLE_WIZARD)
 	if(possible_wizards.len==0)
 		return 0

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -19,8 +19,7 @@
 
 /datum/game_mode/wizard/can_start()//This could be better, will likely have to recode it later
 	if(!..())
-		message_admins("(<font color='#ffcc00'><b>No se alcanzaron los readys Minimos.Se recomienda revisar que la ronda no este desbalanceada</b></font>)\n")
-//		return 0
+		return 0
 	var/list/datum/mind/possible_wizards = get_players_for_role(ROLE_WIZARD)
 	if(possible_wizards.len==0)
 		return 0

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+secret


### PR DESCRIPTION
Le da otro propósito a la variable global de config  **"enable_gamemode_player_limit ".**
Esta variable anteriormente se usaba para poder jugar todos los modos de juego sin restriccion de readys. Lo cual es util para una votacion de game-mode.  En caso de que hubiera 15 jugadores por ejemplo se podia jugar Nuke aun sin cumplir el minimo

**El unico problema que tenia es que estaba atado a los modos q podian salir de  secret.**  Entonces cada vez que se jugaba secret salian TODOS los modos de juego.

Este PR los vuelve dos cosas independientes. Si se pone la variable en **FALSE** Los modos de secret siguen saliendo acorde a la cantidad de readys puesta por la configuracion pero si elige un modo de juego ( por votacion o por admin) este va funcionar independiente de la cantidad de readys.    A menos que no  cumpla las condiciones minimas minimas. Por ejemplo si no hay suficiente gente con ese rol de antag activado. (esto rara vez pasaria)

He estado testeando y parece funcionar bien

:cl:
fix: Los gamemode votados siempre funcionaran
/:cl:
