### PR TITLE
Fix map vote spam

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -234,6 +234,8 @@
 					return
 				mode = SHUTTLE_DOCKED
 				timer = world.time
+				spawn(5 SECONDS)
+					SSvote.initiate_vote("map", "the server", TRUE)
 				if(canRecall)
 					emergency_shuttle_docked.Announce("The emergency shuttle has docked with the station. You have [timeLeft(600)] minutes to board the emergency shuttle.")
 				else
@@ -248,8 +250,6 @@
 						G.dom_attempts = min(1,G.dom_attempts)
 */
 		if(SHUTTLE_DOCKED)
-
-			SSvote.initiate_vote("map", "the server", TRUE)
 			if(time_left <= 0 && SSshuttle.emergencyNoEscape)
 				GLOB.priority_announcement.Announce("Hostile environment detected. Departure has been postponed indefinitely pending conflict resolution.")
 				sound_played = 0


### PR DESCRIPTION
El map Vote al llegar la shuttle estaba en un if que se ejecutaba muchas veces porq se comprobaba cada segundo

Este fix hace q se ejecute 1 vez y agrega un delay de 5segundos para que no se pise con la bonita voz q deq la shuttle llego

![image](https://user-images.githubusercontent.com/24284918/139127599-1f7d32a8-47bb-44e5-8dd5-53b9ad94d374.png)


https://github.com/Helixis/Paradise/pull/975


:cl:
fix: map vote spam
/:cl:


