### PR TITLE
Nerf Swarmers

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -376,6 +376,38 @@
 	to_chat(S, "<span class='warning'>Disrupting this energy field would overload us. Aborting.</span>")
 	return FALSE
 
+/obj/machinery/r_n_d/destructive_analyzer/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Esto parece muy peligroso, podria destruirme en el proceso.</span>")
+	return FALSE
+
+/obj/machinery/computer/rdconsole/core/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Esta consola contiene informacion valiosa para nuestro fin.</span>")
+	return FALSE
+
+/obj/machinery/r_n_d/protolathe/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Podria ser util en el futuro.</span>")
+	return FALSE
+
+/obj/machinery/r_n_d/circuit_imprinter/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Deberiamos preservar esta maquina.</span>")
+	return FALSE
+
+/obj/machinery/computer/communications/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>No parece una buena idea impedir una evacuacion.</span>")
+	return FALSE
+
+/obj/machinery/dna_scannernew/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Parece estar protegida.</span>")
+	return FALSE
+
+/obj/machinery/computer/cloning/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Esta consola es de vital importancia.</span>")
+	return FALSE
+
+/obj/machinery/clonepod/biomass/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	to_chat(S, "<span class='warning'>Los liquidos del interior podrian dañarnos.</span>")
+	return FALSE
+
 /turf/simulated/wall/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	var/isonshuttle = istype(loc, /area/shuttle)
 	for(var/turf/T in range(1, src))


### PR DESCRIPTION
Este PR intenta resolver una problematica recurrente desde tiempos inmemorables.  Sigue el mismo espiritu que mi PR:
https://github.com/Helixis/Paradise/pull/1087

Por un lado los swarmers se quejan de que las reglas no son claras en cuanto a lo que no deberian desarmar. Por otro lado los tripulantes se quejaran que su ronda fue arruinada y los swarmer merecen un castigo. Si ambas partes estan molestas quizas sea mejor que no puedan realizar estas destrucciones en primer lugar. **Evitamos baneos y  distintas interpretaciones de las reglas del servidor**

Los swarmers no pueden comer maquinaria vital de la estacion que demora mucho tiempo en conseguir o es muy importante en el desarrollo de la ronda

1. Consola de comunicaciones
2. Maquinaria RD (4, las de research)
3. Maquinas de clonacion

:cl:
tweak: mas restricciones a los swarmers a la hora de comer maquinarias importantes
/:cl:


