### PR TITLE
[FIXES] Remueve todas las razas excepto IPC y Humano del Codigo, siendo estas ahora injugables totalmente

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,7 +11,7 @@
 	name = "traitor"
 	config_tag = "traitor"
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Internal Affairs Agent", "Brig Physician", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Internal Affairs Agent", "Brig Physician", "Nanotrasen Navy Officer", "Special Operations Officer", "Syndicate Officer", "Solar Federation General")
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
## What Does This PR Do
Human Supremacy, los humanos son y siempre seran la raza mas poderosa, y estos nunca permitirían que sucios zorros, slimes, perros, que cojones es un drask?, voxes, trabajasen en una estación de tanto nivel como lo es la NSS Hispania, con esto arreglamos eso, un cambio totalmente aprobado por el Code Prefectus Saga

## Imagenes del Cambio

![image](https://user-images.githubusercontent.com/43283605/140433093-87c842c0-bf13-4057-942a-84585bc6e770.png)


## Changelog
:cl:
fix: Los Heads no pueden ser Traidores
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
