### PR TITLE
Airlocks Tile Update

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -105,6 +105,9 @@
 		return
 
 	face_atom(A)
+	if(istype(A,/turf))
+		var/turf/AA = A
+		AA.Airlock(src)
 
 	if(next_move > world.time) // in the year 2000...
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -195,6 +195,12 @@
 /turf/proc/TerraformTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
 	return ChangeTurf(path, defer_change, keep_icon, ignore_air)
 
+/turf/proc/Airlock(mob/user)
+	for(var/i in contents)
+		if(istype(i,/obj/machinery/door))
+			var/obj/machinery/door/A = i
+			A.try_to_activate_door(user)
+
 //Creates a new turf
 /turf/proc/ChangeTurf(path, defer_change = FALSE, keep_icon = TRUE, ignore_air = FALSE)
 	if(!path)


### PR DESCRIPTION
## Que hace este PR
Al presionar el turf con un airlock arriba de este se abrira o cerrara la puerta.

## Por que es bueno este PR
No necesitas tener precision de cirujano para cerrar una puerta rapidamente, especialmente positivo para jugadores de comando y seguridad que no quieren que se cuele gente a brig o bridge.

## Imagenes de Cambios
![cJ5SXGaVT0](https://user-images.githubusercontent.com/55407528/141691794-867140f1-d278-4361-bfff-e550cd7446f2.gif)

