### PR TITLE
Modo de juego Extended Anarchy [MDB IGNORE] [IDB IGNORE]

### DIFF
--- a/code/hispania/game/gamemodes/extendedanarchy/anarchymode.dm
+++ b/code/hispania/game/gamemodes/extendedanarchy/anarchymode.dm
@@ -1,0 +1,15 @@
+/datum/game_mode/extended/anarchy
+	name = "Extended Anarchy"
+	config_tag = "extended-anarchy"
+	required_players = 0
+
+/datum/game_mode/announce()
+	to_chat(world, "<BR><B>El modo de juego es Extended Anarchy!</B>")
+	to_chat(world, "<B>En este modo de juego, <BIG>aplican menos reglas del server</BIG>, una experiencia menos intensiva de rol para más experimentación. Solo las reglas que están en el siguiente link aplican para esta partida <a href=\"https://hispaniastation.net/hispaniawiki/index.php/Anarchymode\">Reglas Anarchy</a></B>")
+	to_chat(world, "<B>Ten en cuenta que las leyes IC siguen aplicando, si haces algo ilegal, seguridad aún podrá arrestarte</B>")
+
+/datum/game_mode/extended/pre_setup()
+	return 1
+
+/datum/game_mode/extended/post_setup()
+	..()

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -239,7 +239,7 @@ gamemode_probabilities = [
 	{gamemode = "traitorvamp", probability = 3},
 	{gamemode = "vampire", probability = 3},
 	{gamemode = "wizard", probability = 2},
-    {gamemode = "extended-anarchy", probability = 2}
+    {gamemode = "extended-anarchy", probability = 0}
 ]
 # Maximum cycles (2s) before a shadowling starts to take damage if they dont hatch
 shadowling_max_age = 600 # 20 minutes

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -239,7 +239,7 @@ gamemode_probabilities = [
 	{gamemode = "traitorvamp", probability = 3},
 	{gamemode = "vampire", probability = 3},
 	{gamemode = "wizard", probability = 2},
-    {gamemode = "extended-anarchy", probability = 0}
+    {gamemode = "extended-anarchy"}
 ]
 # Maximum cycles (2s) before a shadowling starts to take damage if they dont hatch
 shadowling_max_age = 600 # 20 minutes

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -239,7 +239,7 @@ gamemode_probabilities = [
 	{gamemode = "traitorvamp", probability = 3},
 	{gamemode = "vampire", probability = 3},
 	{gamemode = "wizard", probability = 2},
-    {gamemode = "extended-anarchy"}
+    {gamemode = "extended-anarchy, probability = 0"},
 ]
 # Maximum cycles (2s) before a shadowling starts to take damage if they dont hatch
 shadowling_max_age = 600 # 20 minutes

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -239,6 +239,7 @@ gamemode_probabilities = [
 	{gamemode = "traitorvamp", probability = 3},
 	{gamemode = "vampire", probability = 3},
 	{gamemode = "wizard", probability = 2},
+    {gamemode = "extended-anarchy", probability = 2}
 ]
 # Maximum cycles (2s) before a shadowling starts to take damage if they dont hatch
 shadowling_max_age = 600 # 20 minutes


### PR DESCRIPTION
<!-- Escribe **ABAJO** de los encabezados y **ARRIBA** de los comentarios de otra manera, podria terminar sin verse correctamente el texto -->

## Que hace este PR
Agrega el modo de juego Extended Anarchy, el cual puede ser votado al inicio de la ronda junto con los demás modos de juego. Además de ser extended, no tiene ninguna otra funcionalidad especial más que avisarle a los jugadores que es un modo de juego con menos reglas.

## Por que es bueno este PR
Es un modo de juego nuevo que seguramente es más útil para rondas con pocas personas

## Imagenes de Cambios
![image](https://user-images.githubusercontent.com/28197551/144714286-ebb91f66-022e-464d-a3eb-bbfec4355116.png)
