### PR TITLE
Fix double vote

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -131,8 +131,8 @@ SUBSYSTEM_DEF(ticker)
 			auto_toggle_ooc(TRUE) // Turn it on
 			declare_completion()
 			addtimer(CALLBACK(src, .proc/call_reboot), 5 SECONDS)
-			if(GLOB.configuration.vote.enable_map_voting)
-				SSvote.initiate_vote("map", "the server", TRUE) // Start a map vote. Timing is a little tight here but we should be good.
+			//if(GLOB.configuration.vote.enable_map_voting)
+			SSvote.initiate_vote("map", "the server", TRUE) // Start a map vote. Timing is a little tight here but we should be good.
 
 /datum/controller/subsystem/ticker/proc/call_reboot()
 	if(mode.station_was_nuked)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -16,6 +16,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/current_votes = list()
 	var/list/round_voters = list()
 	var/auto_muted = 0
+	var/no_more_vote = FALSE
 
 /datum/controller/subsystem/vote/fire()
 	if(mode)
@@ -209,6 +210,9 @@ SUBSYSTEM_DEF(vote)
 			return vote
 	return 0
 
+/datum/controller/subsystem/vote/proc/no_more_vote()
+	no_more_vote = !no_more_vote
+
 /datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, code_invoked = FALSE)
 	if(!mode)
 		if(usr && started_time != null && !check_rights(R_ADMIN)) // Allow the game to call votes whenever. But check other callers
@@ -236,6 +240,9 @@ SUBSYSTEM_DEF(vote)
 					question = "End the shift?"
 					choices.Add("Initiate Crew Transfer", "Continue The Round")
 			if("map")
+				if(no_more_vote == TRUE)
+					to_chat(world, "<span class='warning'> El mapa ya fue elegido </span>")
+					return FALSE
 				if(!(check_rights(R_SERVER) || code_invoked))
 					return FALSE
 				question = "Map for next round"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -236,6 +236,7 @@
 				timer = world.time
 				spawn(5 SECONDS)
 					SSvote.initiate_vote("map", "the server", TRUE)
+					SSvote.no_more_vote()
 				if(canRecall)
 					emergency_shuttle_docked.Announce("The emergency shuttle has docked with the station. You have [timeLeft(600)] minutes to board the emergency shuttle.")
 				else

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -234,9 +234,9 @@
 					return
 				mode = SHUTTLE_DOCKED
 				timer = world.time
-				spawn(5 SECONDS)
-					SSvote.initiate_vote("map", "the server", TRUE)
-					SSvote.no_more_vote()
+				// spawn(5 SECONDS)
+				// 	SSvote.initiate_vote("map", "the server", TRUE)
+				// 	SSvote.no_more_vote()
 				if(canRecall)
 					emergency_shuttle_docked.Announce("The emergency shuttle has docked with the station. You have [timeLeft(600)] minutes to board the emergency shuttle.")
 				else

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -234,9 +234,9 @@
 					return
 				mode = SHUTTLE_DOCKED
 				timer = world.time
-				// spawn(5 SECONDS)
-				// 	SSvote.initiate_vote("map", "the server", TRUE)
-				// 	SSvote.no_more_vote()
+				spawn(5 SECONDS)
+					SSvote.initiate_vote("map", "the server", TRUE)
+					SSvote.no_more_vote()
 				if(canRecall)
 					emergency_shuttle_docked.Announce("The emergency shuttle has docked with the station. You have [timeLeft(600)] minutes to board the emergency shuttle.")
 				else


### PR DESCRIPTION
## Que hace este PR
Arregla que se llamaba a votacion del mapa dos veces.

Se podria hacer que directamente solo llame a la votacion cuando sea GAME_STATE_FINISHED  pero ... Tambien me agrada la idea de votar el mapa cuando llega la shuttle y ya lo venimos arrastrando de esta manera por algun motivo...





