### PR TITLE
[BOUNTY] Mobs con caracteristicas random

### DIFF
--- a/code/HISPANIA/modules/mob/living/simple_animal/hostile/randmonster.dm
+++ b/code/HISPANIA/modules/mob/living/simple_animal/hostile/randmonster.dm
@@ -1,4 +1,4 @@
-+/mob/living/simple_animal/hostile/randomstats
+/mob/living/simple_animal/hostile/randomstats
 	name = "alien fighter"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "alienh_running"

--- a/code/HISPANIA/modules/mob/living/simple_animal/hostile/randmonster.dm
+++ b/code/HISPANIA/modules/mob/living/simple_animal/hostile/randmonster.dm
@@ -1,0 +1,47 @@
++/mob/living/simple_animal/hostile/randomstats
+	name = "alien fighter"
+	icon = 'icons/mob/alien.dmi'
+	icon_state = "alienh_running"
+	icon_living = "alienh_running"
+	icon_dead = "alienh_dead"
+	icon_gib = "syndicate_gib"
+	gender = FEMALE
+	response_help = "pokes"
+	response_harm = "hits"
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/monstermeat/xenomeat= 3, /obj/item/stack/sheet/animalhide/xeno = 1)
+	attacktext = "slashes"
+	speak_emote = list("hisses")
+	bubble_icon = "alien"
+	maxHealth = 125
+	health = 125
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	faction = list("alien")
+	var/attack_minimum = 8
+	var/attack_maximum = 25
+	var/health_minimum = 100
+	var/health_maximum = 200
+	var/randomize_aggro = TRUE // falso para no randomizar la agresividad, solo los stats
+	var/mad_length = 30 SECONDS // duración en segundos que un mob neutral se hace hostil cuando le pegan
+
+/mob/living/simple_animal/hostile/randomstats/Initialize()
+	. = ..()
+	var/attack_result = rand(attack_minimum,attack_maximum)
+	var/health_result = rand(health_minimum,health_maximum)
+	melee_damage_lower = attack_result
+	melee_damage_upper = attack_result
+	maxHealth = health_result
+	health = health_result
+	if(randomize_aggro == TRUE)
+		faction += pick("hostile","neutral")
+
+/mob/living/simple_animal/hostile/randomstats/proc/stop_malding()
+	faction -= "hostile"
+	faction += "neutral"
+
+/mob/living/simple_animal/hostile/randomstats/attacked_by(obj/item/I, mob/living/user)
+	if("neutral" in faction)
+		faction -= "neutral"
+		faction += "hostile"
+		addtimer(CALLBACK(src, /mob/living/simple_animal/hostile/randomstats/.proc/stop_malding), mad_length)
+	. = ..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1408,7 +1408,7 @@
 #include "code\hispania\modules\mob\living\simple_animal\hostile\fleas.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\headcrabs.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\netherworld.dm"
-#include "code\HISPANIA\modules\mob\living\simple_animal\hostile\randmonster.dm"
+#include "code\hispania\modules\mob\living\simple_animal\hostile\randmonster.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\venus_human_trap.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\megafauna\wendigo.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\mining\goliath.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1408,6 +1408,7 @@
 #include "code\hispania\modules\mob\living\simple_animal\hostile\fleas.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\headcrabs.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\netherworld.dm"
+#include "code\HISPANIA\modules\mob\living\simple_animal\hostile\randmonster.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\venus_human_trap.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\megafauna\wendigo.dm"
 #include "code\hispania\modules\mob\living\simple_animal\hostile\mining\goliath.dm"


### PR DESCRIPTION
rehice PR porque los checks de github me robaron la billetera en un callejon oscuro

## Que hace este PR
Añade un nuevo tipo de mob que randomiza su ataque, salud y agresividad cuando spawnea, haciendo cada uno diferente al otro.

Por ahora, el mob randomiza sus stats de ataque entre 8 - 25, su vida entre 100 - 200, y su agresividad entre hostil y neutral.

Si unos de estos mobs randoms es neutral, al ser golpeados, cambiaran su estado neutral a hostil y harán mierda a todo por un periodo de tiempo, luego del cual seran neutrales otra vez. (Por default, este momento dura 30 segundos.) 

(los sprites utilizados son los del xeno-hunter, no hay sprites custom)

## Por que es bueno este PR
dinero dinero dinero pogfish
añade una forma diferente de hacer el mismo tipo de mob unico.
