### PR TITLE
Fix default pref

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -272,7 +272,7 @@ CREATE TABLE `player` (
   `be_role` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `default_slot` smallint(4) DEFAULT '1',
   `toggles` int(11) DEFAULT NULL,
-  `toggles_2` int(11) DEFAULT '0',
+  `toggles_2` int(11) DEFAULT NULL,
   `sound` mediumint(8) DEFAULT '31',
   `volume_mixer` longtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `lastchangelog` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '0',


### PR DESCRIPTION
Enrealidad esto ya lo fixeo Affected pero no hemos actualizado aun 

Arregla las preferencias que varias opciones como el runechat venian por defecto desactivadas.
Queremos facilitarle a los jugadores nuevos que se sientan comodos desde un inicio y  no pierdan tiempo  buscando esa opcion q puede ser dificil de encontrar . O peor aun que no lleguen a conocer su existencia
